### PR TITLE
Support ironic_prometheus_exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
 FROM docker.io/centos:centos7
 
+# TODO(iurygregory): remove epel-release and  other packages necessary for the ironic_prometheus_exporter when we have a package for it
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
-    yum install -y openstack-ironic-api openstack-ironic-conductor crudini iproute dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools mariadb-server python-PyMySQL python2-chardet && \
+    yum install -y epel-release python-pip python-devel gcc openstack-ironic-api openstack-ironic-conductor crudini iproute dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools mariadb-server python-PyMySQL python2-chardet && \
+    yum install -y python-configparser python2-prometheus_client && \
     yum clean all
 
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/
 
+COPY ./installexporter.sh /bin/installexporter
+RUN /bin/installexporter
 COPY ./runironic.sh /bin/runironic
 COPY ./rundnsmasq.sh /bin/rundnsmasq
 COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
 COPY ./runhealthcheck.sh /bin/runhealthcheck
+COPY ./runexporterapp.sh /bin/runexporterapp
 
 COPY ./dnsmasq.conf /etc/dnsmasq.conf
 COPY ./inspector.ipxe /tmp/inspector.ipxe

--- a/installexporter.sh
+++ b/installexporter.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+git clone https://github.com/metal3-io/ironic-prometheus-exporter.git
+cd ironic-prometheus-exporter/
+python setup.py install

--- a/runexporterapp.sh
+++ b/runexporterapp.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+cd /ironic-prometheus-exporter
+export IRONIC_CONFIG=/etc/ironic/ironic.conf
+export FLASK_RUN_HOST=0.0.0.0
+export FLASK_RUN_PORT=5001
+uwsgi --socket ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} --protocol=http -w ironic_prometheus_exporter.app.wsgi

--- a/runironic.sh
+++ b/runironic.sh
@@ -31,6 +31,10 @@ crudini --set /etc/ironic/ironic.conf DEFAULT default_deploy_interface direct
 crudini --set /etc/ironic/ironic.conf DEFAULT enabled_inspect_interfaces inspector,idrac,fake
 crudini --set /etc/ironic/ironic.conf DEFAULT default_inspect_interface inspector
 crudini --set /etc/ironic/ironic.conf DEFAULT rpc_transport json-rpc
+crudini --set /etc/ironic/ironic.conf conductor send_sensor_data true
+crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications driver prometheus_exporter
+crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications transport_url fake://
+crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications location /tmp/ironic_prometheus_exporter
 crudini --set /etc/ironic/ironic.conf dhcp dhcp_provider none
 crudini --set /etc/ironic/ironic.conf conductor automated_clean true
 crudini --set /etc/ironic/ironic.conf conductor api_url http://${IP}:6385
@@ -65,6 +69,7 @@ mkdir -p /shared/log/ironic
 /usr/bin/python2 /usr/bin/ironic-api --log-file  /shared/log/ironic/ironic-api.log & 
 
 /bin/runhealthcheck "ironic" &>/dev/null &
+/bin/runexporterapp &
 
 sleep infinity
 


### PR DESCRIPTION
- Install the oslo messaging notifier Driver
- Configures ironic to use the new Driver
- Run a Flask Application under uWSGI to expose the metrics to Prometheus (by default it will run on port 5001 and this port need to be accessible for the Prometheus Container)

