### PR TITLE
Switch from "current" to "current-tripleo-rdo"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos7
 
 RUN yum install -y python-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/5609d2e3aee35578e914bcbfac92a46c759c0a31/tripleo_repos/main.py | python - current && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/5609d2e3aee35578e914bcbfac92a46c759c0a31/tripleo_repos/main.py | python - current-tripleo && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini iproute dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools mariadb-server python-PyMySQL python2-chardet && \
     yum clean all
 


### PR DESCRIPTION
Moving to use a repository that has passed the RDO
ci should protect us a bit better from regressions.