### PR TITLE
Set uefi_pxe_config_template to use the ipxe template

### DIFF
--- a/runironic.sh
+++ b/runironic.sh
@@ -47,6 +47,7 @@ crudini --set /etc/ironic/ironic.conf pxe tftp_master_path /shared/tftpboot
 crudini --set /etc/ironic/ironic.conf pxe instance_master_path /shared/html/master_images
 crudini --set /etc/ironic/ironic.conf pxe images_path /shared/html/tmp
 crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
+crudini --set /etc/ironic/ironic.conf pxe uefi_pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
 crudini --set /etc/ironic/ironic.conf agent deploy_logs_collect always
 crudini --set /etc/ironic/ironic.conf agent deploy_logs_local_path /shared/log/ironic/deploy
 crudini --set /etc/ironic/ironic.conf api api_workers ${NUMWORKERS}


### PR DESCRIPTION
Our dnsmasq config is setup to send "ipxe.efi" incases
where the host is UEFI booting. But by default ironic
sends a grub2 config when using UEFI boot. Switch
Ironic to use ipxe so they both match up and booting
UEFI works.