### PR TITLE
Publish ironic endpoint via mDNS

### DIFF
--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -5,6 +5,6 @@
 echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep kernel params in sync with [mdns]params in ironic-inspector-image
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=mdns ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -4,6 +4,7 @@
 :retry_boot
 echo In inspector.ipxe
 imgfree
+# NOTE(dtantsur): keep kernel params in sync with [mdns]params in ironic-inspector-image
 kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/runironic.sh
+++ b/runironic.sh
@@ -14,6 +14,11 @@ if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -
     iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT
 fi
 
+# Allow access to mDNS
+if ! iptables -i $INTERFACE -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
+    iptables -i $INTERFACE -p udp --dport 5353 -j ACCEPT
+fi
+
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 
 crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy noauth
@@ -31,6 +36,7 @@ crudini --set /etc/ironic/ironic.conf DEFAULT default_deploy_interface direct
 crudini --set /etc/ironic/ironic.conf DEFAULT enabled_inspect_interfaces inspector,idrac,fake
 crudini --set /etc/ironic/ironic.conf DEFAULT default_inspect_interface inspector
 crudini --set /etc/ironic/ironic.conf DEFAULT rpc_transport json-rpc
+crudini --set /etc/ironic/ironic.conf conductor enable_mdns True
 crudini --set /etc/ironic/ironic.conf conductor send_sensor_data true
 crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications driver prometheus_exporter
 crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications transport_url fake://


### PR DESCRIPTION
Requires https://github.com/metal3-io/ironic-inspector-image/pull/21 and a recent IPA image.