### PR TITLE
Install iptables explicitly and correct the iptables lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM docker.io/centos:centos7
 # TODO(iurygregory): remove epel-release and  other packages necessary for the ironic_prometheus_exporter when we have a package for it
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
-    yum install -y epel-release python-pip python-devel gcc openstack-ironic-api openstack-ironic-conductor crudini iproute dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools mariadb-server python-PyMySQL python2-chardet && \
+    yum install -y epel-release python-pip python-devel gcc openstack-ironic-api openstack-ironic-conductor crudini \
+        iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
+        mariadb-server python-PyMySQL python2-chardet && \
     yum install -y python-configparser python2-prometheus_client && \
     yum clean all
 

--- a/runironic.sh
+++ b/runironic.sh
@@ -15,8 +15,11 @@ if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -
 fi
 
 # Allow access to mDNS
-if ! iptables -i $INTERFACE -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
-    iptables -i $INTERFACE -p udp --dport 5353 -j ACCEPT
+if ! iptables -C INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
+    iptables -I INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT
+fi
+if ! iptables -C OUTPUT -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
+    iptables -I OUTPUT -p udp --dport 5353 -j ACCEPT
 fi
 
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig


### PR DESCRIPTION
Apparently, iptables are not installed by default. This is hidden
by the fact that the script doesn't fail on errors. And it hides
the fact the the mdns iptables commands are not correct.