### PR TITLE
Start using ironic-prometheus-exporter package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
 FROM docker.io/centos:centos7
 
-# TODO(iurygregory): remove epel-release and  other packages necessary for the ironic_prometheus_exporter when we have a package for it
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
     yum update -y && \
-    yum install -y epel-release python-pip python-devel gcc openstack-ironic-api openstack-ironic-conductor crudini \
+    yum install -y uwsgi uwsgi-plugin-python openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
         mariadb-server python-PyMySQL python2-chardet && \
-    yum install -y python-configparser python2-prometheus_client && \
+    yum install -y python-ironic-prometheus-exporter && \
     yum clean all
 
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/
 
-COPY ./installexporter.sh /bin/installexporter
-RUN /bin/installexporter
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor
 COPY ./runironic-exporter.sh /bin/runironic-exporter

--- a/installexporter.sh
+++ b/installexporter.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/bash
-
-git clone https://github.com/metal3-io/ironic-prometheus-exporter.git
-cd ironic-prometheus-exporter/
-python setup.py install

--- a/runexporterapp.sh
+++ b/runexporterapp.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/bash
 
-cd /ironic-prometheus-exporter
 export IRONIC_CONFIG=/etc/ironic/ironic.conf
 export FLASK_RUN_HOST=0.0.0.0
 export FLASK_RUN_PORT=5001
-uwsgi --socket ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} --protocol=http -w ironic_prometheus_exporter.app.wsgi
+uwsgi --plugin python --http-socket ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} --module ironic_prometheus_exporter.app.wsgi:application


### PR DESCRIPTION
This commit changes the ironic-image to use the
ironic-prometheus-exporter Package that is now available
in RDO.

- Updated Dockerfile
- Removed installexporter.sh
- Updated runexporterapp.sh