### PR TITLE
Stop defining inspection kernel params in ironic-image

### DIFF
--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -4,7 +4,7 @@
 :retry_boot
 echo In inspector.ipxe
 imgfree
-# NOTE(dtantsur): keep kernel params in sync with [mdns]params in ironic-inspector-image
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=mdns ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+# NOTE(dtantsur): keep inspection kernel params in [mdns]params in ironic-inspector-image
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=mdns systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot


### PR DESCRIPTION
After https://github.com/metal3-io/ironic-inspector-image/pull/25
these parameters are distributed via mDNS. Duplicating them here is
confusing, since this image is supposed to be for ironic.