### PR TITLE
Allow running ironic API, conductor and exporter separately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
 COPY ./configure-ironic.sh /bin/configure-ironic.sh
 
-# TODO(dtantsur): remove this if/when we stop supporting all-in-one container
+# TODO(dtantsur): remove these 3 scripts and squash runexporterapp into
+# runironic-exporter if we decide to stop supporting running all 3 processes
+# via one entry point.
 COPY ./runexporterapp.sh /bin/runexporterapp
 COPY ./runhealthcheck.sh /bin/runhealthcheck
 COPY ./runironic.sh /bin/runironic

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,18 @@ RUN mkdir /tftpboot && \
 
 COPY ./installexporter.sh /bin/installexporter
 RUN /bin/installexporter
-COPY ./runironic.sh /bin/runironic
+COPY ./runironic-api.sh /bin/runironic-api
+COPY ./runironic-conductor.sh /bin/runironic-conductor
+COPY ./runironic-exporter.sh /bin/runironic-exporter
 COPY ./rundnsmasq.sh /bin/rundnsmasq
 COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
-COPY ./runhealthcheck.sh /bin/runhealthcheck
+COPY ./configure-ironic.sh /bin/configure-ironic.sh
+
+# TODO(dtantsur): remove this if/when we stop supporting all-in-one container
 COPY ./runexporterapp.sh /bin/runexporterapp
+COPY ./runhealthcheck.sh /bin/runhealthcheck
+COPY ./runironic.sh /bin/runironic
 
 COPY ./dnsmasq.conf /etc/dnsmasq.conf
 COPY ./inspector.ipxe /tmp/inspector.ipxe

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/bash
+
+# Get environment settings and update ironic.conf
+PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
+IRONIC_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+HTTP_PORT=${HTTP_PORT:-"80"}
+MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
+NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
+NUMWORKERS=$(( NUMPROC < 12 ? NUMPROC : 12 ))
+
+cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
+
+crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy noauth
+crudini --set /etc/ironic/ironic.conf DEFAULT my_ip "$IRONIC_IP"
+crudini --set /etc/ironic/ironic.conf DEFAULT debug true
+crudini --set /etc/ironic/ironic.conf DEFAULT default_network_interface noop
+crudini --set /etc/ironic/ironic.conf DEFAULT enabled_boot_interfaces pxe,ipxe,fake
+crudini --set /etc/ironic/ironic.conf DEFAULT enabled_power_interfaces ipmitool,idrac,fake
+crudini --set /etc/ironic/ironic.conf DEFAULT enabled_management_interfaces ipmitool,idrac,fake
+crudini --set /etc/ironic/ironic.conf DEFAULT enabled_hardware_types ipmi,idrac,fake-hardware
+crudini --set /etc/ironic/ironic.conf DEFAULT enabled_vendor_interfaces ipmitool,no-vendor,idrac,fake
+crudini --set /etc/ironic/ironic.conf DEFAULT enabled_deploy_interfaces direct,fake
+crudini --set /etc/ironic/ironic.conf DEFAULT default_boot_interface ipxe
+crudini --set /etc/ironic/ironic.conf DEFAULT default_deploy_interface direct
+crudini --set /etc/ironic/ironic.conf DEFAULT enabled_inspect_interfaces inspector,idrac,fake
+crudini --set /etc/ironic/ironic.conf DEFAULT default_inspect_interface inspector
+crudini --set /etc/ironic/ironic.conf DEFAULT rpc_transport json-rpc
+crudini --set /etc/ironic/ironic.conf conductor enable_mdns True
+crudini --set /etc/ironic/ironic.conf conductor send_sensor_data true
+crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications driver prometheus_exporter
+crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications transport_url fake://
+crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications location /shared/ironic_prometheus_exporter
+crudini --set /etc/ironic/ironic.conf dhcp dhcp_provider none
+crudini --set /etc/ironic/ironic.conf conductor automated_clean true
+crudini --set /etc/ironic/ironic.conf conductor api_url http://${IRONIC_IP}:6385
+crudini --set /etc/ironic/ironic.conf database connection mysql+pymysql://ironic:${MARIADB_PASSWORD}@localhost/ironic?charset=utf8
+crudini --set /etc/ironic/ironic.conf deploy http_url http://${IRONIC_IP}:${HTTP_PORT}
+crudini --set /etc/ironic/ironic.conf deploy http_root /shared/html/
+crudini --set /etc/ironic/ironic.conf deploy default_boot_option local
+crudini --set /etc/ironic/ironic.conf deploy erase_devices_priority 0
+crudini --set /etc/ironic/ironic.conf deploy erase_devices_metadata_priority 10
+crudini --set /etc/ironic/ironic.conf inspector endpoint_override http://${IRONIC_IP}:5050
+crudini --set /etc/ironic/ironic.conf pxe ipxe_enabled true
+crudini --set /etc/ironic/ironic.conf pxe tftp_root /shared/tftpboot
+crudini --set /etc/ironic/ironic.conf pxe tftp_master_path /shared/tftpboot
+crudini --set /etc/ironic/ironic.conf pxe instance_master_path /shared/html/master_images
+crudini --set /etc/ironic/ironic.conf pxe images_path /shared/html/tmp
+crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
+crudini --set /etc/ironic/ironic.conf pxe uefi_pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
+crudini --set /etc/ironic/ironic.conf agent deploy_logs_collect always
+crudini --set /etc/ironic/ironic.conf agent deploy_logs_local_path /shared/log/ironic/deploy
+crudini --set /etc/ironic/ironic.conf api api_workers "$NUMWORKERS"
+
+mkdir -p /shared/html
+mkdir -p /shared/ironic_prometheus_exporter

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+. /bin/configure-ironic.sh
+
+# Allow access to Ironic
+if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT > /dev/null 2>&1; then
+    iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT
+fi
+
+ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
+
+exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+. /bin/configure-ironic.sh
+
+# Allow access to mDNS
+if ! iptables -C INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
+    iptables -I INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT
+fi
+if ! iptables -C OUTPUT -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
+    iptables -I OUTPUT -p udp --dport 5353 -j ACCEPT
+fi
+
+# Ramdisk logs
+mkdir -p /shared/log/ironic/deploy
+
+ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
+
+exec /usr/bin/ironic-conductor --config-file /etc/ironic/ironic.conf

--- a/runironic-exporter.sh
+++ b/runironic-exporter.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+. /bin/configure-ironic.sh
+
+# TODO(dtantsur): merge these two scripts when/if we no longer support
+# all-in-one container
+/bin/runexporterapp

--- a/runironic.sh
+++ b/runironic.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/bash
 
-# Get environment settings and update ironic.conf
-PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
-IRONIC_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
-HTTP_PORT=${HTTP_PORT:-"80"}
-MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
-NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
-NUMWORKERS=$(( NUMPROC < 12 ? NUMPROC : 12 ))
-
+. /bin/configure-ironic.sh
 
 # Allow access to Ironic
 if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT > /dev/null 2>&1; then
@@ -22,52 +15,7 @@ if ! iptables -C OUTPUT -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
     iptables -I OUTPUT -p udp --dport 5353 -j ACCEPT
 fi
 
-cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
-
-crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy noauth
-crudini --set /etc/ironic/ironic.conf DEFAULT my_ip "$IRONIC_IP"
-crudini --set /etc/ironic/ironic.conf DEFAULT debug true
-crudini --set /etc/ironic/ironic.conf DEFAULT default_network_interface noop
-crudini --set /etc/ironic/ironic.conf DEFAULT enabled_boot_interfaces pxe,ipxe,fake
-crudini --set /etc/ironic/ironic.conf DEFAULT enabled_power_interfaces ipmitool,idrac,fake
-crudini --set /etc/ironic/ironic.conf DEFAULT enabled_management_interfaces ipmitool,idrac,fake
-crudini --set /etc/ironic/ironic.conf DEFAULT enabled_hardware_types ipmi,idrac,fake-hardware
-crudini --set /etc/ironic/ironic.conf DEFAULT enabled_vendor_interfaces ipmitool,no-vendor,idrac,fake
-crudini --set /etc/ironic/ironic.conf DEFAULT enabled_deploy_interfaces direct,fake
-crudini --set /etc/ironic/ironic.conf DEFAULT default_boot_interface ipxe
-crudini --set /etc/ironic/ironic.conf DEFAULT default_deploy_interface direct
-crudini --set /etc/ironic/ironic.conf DEFAULT enabled_inspect_interfaces inspector,idrac,fake
-crudini --set /etc/ironic/ironic.conf DEFAULT default_inspect_interface inspector
-crudini --set /etc/ironic/ironic.conf DEFAULT rpc_transport json-rpc
-crudini --set /etc/ironic/ironic.conf conductor enable_mdns True
-crudini --set /etc/ironic/ironic.conf conductor send_sensor_data true
-crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications driver prometheus_exporter
-crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications transport_url fake://
-crudini --set /etc/ironic/ironic.conf oslo_messaging_notifications location /tmp/ironic_prometheus_exporter
-crudini --set /etc/ironic/ironic.conf dhcp dhcp_provider none
-crudini --set /etc/ironic/ironic.conf conductor automated_clean true
-crudini --set /etc/ironic/ironic.conf conductor api_url http://${IRONIC_IP}:6385
-crudini --set /etc/ironic/ironic.conf database connection mysql+pymysql://ironic:${MARIADB_PASSWORD}@localhost/ironic?charset=utf8
-crudini --set /etc/ironic/ironic.conf deploy http_url http://${IRONIC_IP}:${HTTP_PORT}
-crudini --set /etc/ironic/ironic.conf deploy http_root /shared/html/
-crudini --set /etc/ironic/ironic.conf deploy default_boot_option local
-crudini --set /etc/ironic/ironic.conf deploy erase_devices_priority 0
-crudini --set /etc/ironic/ironic.conf deploy erase_devices_metadata_priority 10
-crudini --set /etc/ironic/ironic.conf inspector endpoint_override http://${IRONIC_IP}:5050
-crudini --set /etc/ironic/ironic.conf pxe ipxe_enabled true
-crudini --set /etc/ironic/ironic.conf pxe tftp_root /shared/tftpboot
-crudini --set /etc/ironic/ironic.conf pxe tftp_master_path /shared/tftpboot
-crudini --set /etc/ironic/ironic.conf pxe instance_master_path /shared/html/master_images
-crudini --set /etc/ironic/ironic.conf pxe images_path /shared/html/tmp
-crudini --set /etc/ironic/ironic.conf pxe pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
-crudini --set /etc/ironic/ironic.conf pxe uefi_pxe_config_template \$pybasedir/drivers/modules/ipxe_config.template
-crudini --set /etc/ironic/ironic.conf agent deploy_logs_collect always
-crudini --set /etc/ironic/ironic.conf agent deploy_logs_local_path /shared/log/ironic/deploy
-crudini --set /etc/ironic/ironic.conf api api_workers "$NUMWORKERS"
-
 ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
-
-mkdir -p /shared/html
 
 # Remove log files from last deployment
 rm -rf /shared/log/ironic


### PR DESCRIPTION
We want to stop running several processes in one container, since it
violates container good practices and makes collecting logs and
health checking much harder.