### PR TITLE
Limit dbsync to only the Conductor entry point

### DIFF
--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -7,7 +7,5 @@ if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -
     iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT
 fi
 
-ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
-
 exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf \
     --log-file /shared/log/ironic/ironic-api.log


### PR DESCRIPTION
Ironic API will happily start without database connection, while
Conductor requires database on start-up. Running dbsync in two
places is potentially racy, so limit it to Conductor only.