### PR TITLE
Enable fast_track deployments

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -15,6 +15,9 @@ enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake
 rpc_transport = json-rpc
 use_stderr = true
 
+[conductor]
+send_sensor_data_interval = 160
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy


### PR DESCRIPTION
Set the [deploy]fast_track option to true such
that already heartbeating ramdisks can can be
recorded and moved through fast_track and explicitly
set inspection to use mdns to identify the ironic
api endpoint such that heartbeating can occur.