### PR TITLE
Change ironic-prometheus-exporter port

### DIFF
--- a/runexporterapp.sh
+++ b/runexporterapp.sh
@@ -2,5 +2,5 @@
 
 export IRONIC_CONFIG=/etc/ironic/ironic.conf
 export FLASK_RUN_HOST=0.0.0.0
-export FLASK_RUN_PORT=5001
+export FLASK_RUN_PORT=9608
 uwsgi --plugin python --http-socket ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} --module ironic_prometheus_exporter.app.wsgi:application


### PR DESCRIPTION
Prometheus has a default port for the ironic-prometheus-exporter[1]

[1] https://github.com/prometheus/prometheus/wiki/Default-port-allocations