### PR TITLE
Limit mDNS to the provisioning interface

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -28,6 +28,9 @@ http_url = http://${IRONIC_IP}:${HTTP_PORT}
 
 [inspector]
 endpoint_override = http://${IRONIC_IP}:5050
+
+[mdns]
+interfaces = $IRONIC_IP
 EOF
 
 mkdir -p /shared/html


### PR DESCRIPTION
This still causes mdns queries responded on the interface the bridge is attached to.
I'm not sure if it's a problem or an implementation detail.