### PR TITLE
Decrease the sensor data collection interval timer

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -15,6 +15,9 @@ enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake
 rpc_transport = json-rpc
 use_stderr = true
 
+[conductor]
+send_sensor_data_interval = 160
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy


### PR DESCRIPTION
Default is 600 seconds, to get it below 5 minutes and not hit
some BMCs on the sixty second interval, make the interval
slightly more than two and a half minutes