### PR TITLE
Switch to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/centos:centos7
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
     yum update -y && \
-    yum install -y uwsgi uwsgi-plugin-python openstack-ironic-api openstack-ironic-conductor crudini \
+    yum install -y python-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
         mariadb-server python-PyMySQL python2-chardet && \
     yum install -y python-ironic-prometheus-exporter && \

--- a/runexporterapp.sh
+++ b/runexporterapp.sh
@@ -3,4 +3,4 @@
 export IRONIC_CONFIG=/etc/ironic/ironic.conf
 export FLASK_RUN_HOST=0.0.0.0
 export FLASK_RUN_PORT=9608
-uwsgi --plugin python --http-socket ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} --module ironic_prometheus_exporter.app.wsgi:application
+gunicorn -b ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} -w 4 ironic_prometheus_exporter.app.wsgi:application


### PR DESCRIPTION
Switching to gunicorn, since uwsgi is not available in the OSP packages.