### PR TITLE
Increase the sensor data collection interval

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -15,6 +15,12 @@ enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake
 rpc_transport = json-rpc
 use_stderr = true
 
+[conductor]
+# NOTE(TheJulia): Do not lower this value below 120 seconds.
+# Power state is checked every 60 seconds and BMC activity should
+# be avoided more often than once every sixty seconds.
+send_sensor_data_interval = 160
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy


### PR DESCRIPTION
Default is 600 seconds, to get it below 5 minutes and not to hit
some BMCs on the sixty second interval, make the interval
slightly more than two and a half minutes