### PR TITLE
Enable fast_track deployments

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -29,6 +29,7 @@ default_boot_option = local
 erase_devices_metadata_priority = 10
 erase_devices_priority = 0
 http_root = /shared/html/
+fast_track = true
 
 [dhcp]
 dhcp_provider = none


### PR DESCRIPTION
Set the [deploy]fast_track option to true such
that already heartbeating ramdisks can can be
recorded and moved through fast_track and explicitly
set inspection to use mdns to identify the ironic
api endpoint such that heartbeating can occur.