### PR TITLE
Changes to use Ironic Stein

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM docker.io/centos:centos7
 
 RUN yum install -y python-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current-tripleo && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - -b stein current-tripleo && \
     yum update -y && \
-    yum install -y python-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
+    yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
         mariadb-server python-PyMySQL python2-chardet && \
-    yum install -y python-ironic-prometheus-exporter && \
     yum clean all
 
 RUN mkdir /tftpboot && \
@@ -18,16 +17,13 @@ RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
 
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor
-COPY ./runironic-exporter.sh /bin/runironic-exporter
 COPY ./rundnsmasq.sh /bin/rundnsmasq
 COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
 COPY ./configure-ironic.sh /bin/configure-ironic.sh
 
-# TODO(dtantsur): remove these 3 scripts and squash runexporterapp into
-# runironic-exporter if we decide to stop supporting running all 3 processes
-# via one entry point.
-COPY ./runexporterapp.sh /bin/runexporterapp
+# TODO(dtantsur): remove these 2 scripts if we decide to
+# stop supporting running all 2 processes via one entry point.
 COPY ./runhealthcheck.sh /bin/runhealthcheck
 COPY ./runironic.sh /bin/runironic
 

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -34,4 +34,3 @@ interfaces = $IRONIC_IP
 EOF
 
 mkdir -p /shared/html
-mkdir -p /shared/ironic_prometheus_exporter

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -4,7 +4,6 @@
 :retry_boot
 echo In inspector.ipxe
 imgfree
-# NOTE(dtantsur): keep inspection kernel params in [mdns]params in ironic-inspector-image
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=mdns systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -15,20 +15,12 @@ enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake
 rpc_transport = json-rpc
 use_stderr = true
 
-[conductor]
-# NOTE(TheJulia): Do not lower this value below 120 seconds.
-# Power state is checked every 60 seconds and BMC activity should
-# be avoided more often than once every sixty seconds.
-send_sensor_data_interval = 160
-
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy
 
 [conductor]
 automated_clean = true
-enable_mdns = True
-send_sensor_data = true
 
 [deploy]
 default_boot_option = local
@@ -38,11 +30,6 @@ http_root = /shared/html/
 
 [dhcp]
 dhcp_provider = none
-
-[oslo_messaging_notifications]
-driver = prometheus_exporter
-location = /shared/ironic_prometheus_exporter
-transport_url = fake://
 
 [pxe]
 images_path = /shared/html/tmp

--- a/runexporterapp.sh
+++ b/runexporterapp.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/bash
-
-export IRONIC_CONFIG=/etc/ironic/ironic.conf
-export FLASK_RUN_HOST=0.0.0.0
-export FLASK_RUN_PORT=9608
-gunicorn -b ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} -w 4 ironic_prometheus_exporter.app.wsgi:application

--- a/runironic-exporter.sh
+++ b/runironic-exporter.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/bash
-
-. /bin/configure-ironic.sh
-
-# TODO(dtantsur): merge these two scripts when/if we no longer support
-# all-in-one container
-/bin/runexporterapp

--- a/runironic.sh
+++ b/runironic.sh
@@ -26,7 +26,6 @@ mkdir -p /shared/log/ironic
 /usr/bin/ironic-api --log-file  /shared/log/ironic/ironic-api.log &
 
 /bin/runhealthcheck "ironic" &>/dev/null &
-/bin/runexporterapp &
 
 sleep infinity
 


### PR DESCRIPTION
This patch contains changes needed to be able to use Ironic Stein.

It has dependencies from other patches in other related repos
and they should all be merged at the same time, following the order below,
to guarantee a correct behavior.

Full patch set:
https://github.com/openshift-metal3/dev-scripts/pull/680
https://github.com/metal3-io/ironic-image/pull/79
https://github.com/metal3-io/ironic-inspector-image/pull/30
https://github.com/metal3-io/ironic-ipa-downloader/pull/3
