### PR TITLE
Add set -e to all the entrypoint scripts

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -e
+
 PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 
 HTTP_PORT=${HTTP_PORT:-"80"}

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -e
+
 PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 HTTP_PORT=${HTTP_PORT:-"80"}
 HTTP_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -e
+
 . /bin/configure-ironic.sh
 
 # Allow access to Ironic

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -e
+
 . /bin/configure-ironic.sh
 
 # Allow access to mDNS

--- a/runmariadb.sh
+++ b/runmariadb.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/bash
+
+set -e
+
 PATH=$PATH:/usr/sbin/
 DATADIR="/var/lib/mysql"
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}


### PR DESCRIPTION
I noticed that it's possible for the dbsync in the conductor script
to fail (if mariadb is not yet up), which is silently ignored and
results in a broken Ironic.

It's probably one of many possible failures, so lets set -e so containers
exit when an error happens, which allows for automated restart e.g
via k8s or systemd.