### PR TITLE
Revert "Add set -e to all the entrypoint scripts"

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/bash
 
-set -e
-
 PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 
 HTTP_PORT=${HTTP_PORT:-"80"}

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/bash
 
-set -e
-
 PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 HTTP_PORT=${HTTP_PORT:-"80"}
 HTTP_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/bash
 
-set -e
-
 . /bin/configure-ironic.sh
 
 # Allow access to Ironic

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/bash
 
-set -e
-
 . /bin/configure-ironic.sh
 
 # Allow access to mDNS

--- a/runmariadb.sh
+++ b/runmariadb.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/bash
-
-set -e
-
 PATH=$PATH:/usr/sbin/
 DATADIR="/var/lib/mysql"
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}


### PR DESCRIPTION
(updated to revert)
We have always been ignoring errors from the iptables
commands(on master nodes). Revert this while we figure
out a way to eliminate them altogether.

This reverts commit 7e7eb9a.