### PR TITLE
Disable listening for DNS

### DIFF
--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -18,6 +18,9 @@ dhcp-boot=tag:efi,tag:!ipxe,ipxe.efi
 # Client is running PXE over BIOS; send BIOS version of iPXE chainloader
 dhcp-boot=/undionly.kpxe,IRONIC_IP
 
+# Disable listening for DNS
+port=0
+
 # Disable DHCP and DNS over provisioning network
 dhcp-option=3
 dhcp-option=6


### PR DESCRIPTION
Having DNS enabled causes issues when using this image on the bootstrap
node in openshift. If the dnsmasq container starts before coredns,
coredns refuses to start as dnsmasq has taken port 53.