### PR TITLE
Retry dbsync until success

### DIFF
--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -13,7 +13,12 @@ fi
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
-ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
+# It's possible for the dbsync to fail if mariadb is not up yet, so
+# retry until success
+until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
+  echo "WARNING: ironic-dbsync failed, retrying"
+  sleep 1
+done
 
 exec /usr/bin/ironic-conductor --config-file /etc/ironic/ironic.conf \
     --log-file /shared/log/ironic/ironic-conductor.log


### PR DESCRIPTION
I've seen some situations where mariadb is not up soon enough for the
dbsync, despite the 10 retries done inside ironic-dbsync.

In this situation we start the ironic services anyway and since #80 got reverted,
we can't rely on pod/container restart to handle this, so lets retry inside
the script logging a warning instead.