### PR TITLE
Wait for PROVISIONING_INTERFACE to be up

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -3,6 +3,11 @@
 # Get environment settings and update ironic.conf
 PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 IRONIC_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+until [ ! -z "${IRONIC_IP}" ]; do
+  echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+  sleep 1
+  IRONIC_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+done
 HTTP_PORT=${HTTP_PORT:-"80"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -7,6 +7,11 @@ DHCP_RANGE=${DHCP_RANGE:-"172.22.0.10,172.22.0.100"}
 DNSMASQ_EXCEPT_INTERFACE=${DNSMASQ_EXCEPT_INTERFACE:-"lo"}
 
 PROVISIONING_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+until [ ! -z "${PROVISIONING_IP}" ]; do
+  echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+  sleep 1
+  PROVISIONING_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+done
 
 mkdir -p /shared/tftpboot
 mkdir -p /shared/html/images

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -3,6 +3,11 @@
 PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 HTTP_PORT=${HTTP_PORT:-"80"}
 HTTP_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+until [ ! -z "${HTTP_IP}" ]; do
+  echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+  sleep 1
+  HTTP_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+done
 
 mkdir -p /shared/html
 chmod 0777 /shared/html


### PR DESCRIPTION
We've seen some issues where the static-ip-refresh doesn't happen quickly
enough, and/or static-ip-set from initContainers expires before we start
the ironic containers.

To ensure we don't fail in that case, wait for the provisioning IP to be
assigned, then the exact order of container start is not important, and
we'll wait until static-ip-refresh has configured the nic.