### PR TITLE
Remove explicit install of python-PyMySQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install -y python-requests && \
     yum update -y && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
-        mariadb-server python-PyMySQL python2-chardet && \
+        mariadb-server python2-chardet && \
     yum clean all
 
 RUN mkdir /tftpboot && \


### PR DESCRIPTION
This is a dependency of the ironic packages (via the python2-oslo-db
package) already, and copying this dependency to the downstream el8
based dockerfile has caused issues since[1] made some of the image
building checks stricter, I assume this is because the package name
is different but I don't have a specfile reference atm.

This has led to [2] failing CI, and rather than just fix that downstream
we should probably make things consistent and remove this spuruious
install, then let RPM dependencies defined by the package maintainers
do the right thing on each platform?

[1] https://github.com/openshift/images/pull/11
[2] https://github.com/openshift/ironic-image/pull/15