### PR TITLE
Remove yum cache from image file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y python-requests && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
         mariadb-server python2-chardet && \
-    yum clean all
+    yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/


### PR DESCRIPTION
There's no need to keep it around, and we tend to do this in other
images ([see OpenShift's baremetal installer Dockerfile](https://github.com/openshift/installer/blob/fac6d0ae60d15568faf118e5c0463ddec621a530/images/baremetal/Dockerfile.ci#L17)). The reduction is probably less than 100kB, but every byte counts.