### PR TITLE
Stop logging to file

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -11,7 +11,6 @@ wait_for_interface_or_ip
 mkdir -p /shared/tftpboot
 mkdir -p /shared/html/images
 mkdir -p /shared/html/pxelinux.cfg
-mkdir -p /shared/log/dnsmasq
 
 # Copy files to shared mount
 cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftpboot
@@ -27,6 +26,5 @@ for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf
 done
 
-/usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf 2>&1 | tee /shared/log/dnsmasq/dnsmasq.log &
 /bin/runhealthcheck "dnsmasq" &>/dev/null &
-sleep infinity
+exec /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -21,18 +21,9 @@ sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
     -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
     -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf
 
-# Remove log files from last deployment
-rm -rf /shared/log/httpd
-
-mkdir -p /shared/log/httpd
-
-# Make logs available in shared mount
-touch /shared/log/httpd/access_log
-ln -s /shared/log/httpd/access_log /var/log/httpd/access_log
-touch /shared/log/httpd/error_log
-ln -s /shared/log/httpd/error_log /var/log/httpd/error_log
-
-/usr/sbin/httpd &
+# Log to std out/err
+sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
+sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
 
 /bin/runhealthcheck "httpd" "$HTTP_PORT" &>/dev/null &
-sleep infinity
+exec /usr/sbin/httpd -DFOREGROUND

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,5 +2,4 @@
 
 . /bin/configure-ironic.sh
 
-exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf \
-    --log-file /shared/log/ironic/ironic-api.log
+exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -12,5 +12,4 @@ until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
   sleep 1
 done
 
-exec /usr/bin/ironic-conductor --config-file /etc/ironic/ironic.conf \
-    --log-file /shared/log/ironic/ironic-conductor.log
+exec /usr/bin/ironic-conductor --config-file /etc/ironic/ironic.conf

--- a/runironic.sh
+++ b/runironic.sh
@@ -9,8 +9,8 @@ rm -rf /shared/log/ironic
 
 mkdir -p /shared/log/ironic
 
-/usr/bin/ironic-conductor --log-file /shared/log/ironic/ironic-conductor.log &
-/usr/bin/ironic-api --log-file  /shared/log/ironic/ironic-api.log &
+/usr/bin/ironic-conductor &
+/usr/bin/ironic-api &
 
 /bin/runhealthcheck "ironic" &>/dev/null &
 

--- a/runmariadb.sh
+++ b/runmariadb.sh
@@ -4,22 +4,15 @@ DATADIR="/var/lib/mysql"
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 MARIADB_CONF_FILE="/etc/my.cnf.d/mariadb-server.cnf"
 
+ln -sf /proc/self/fd/1 /var/log/mariadb/mariadb.log
+
 if [ ! -d "${DATADIR}/mysql" ]; then
     crudini --set "$MARIADB_CONF_FILE" mysqld max_connections 64
     crudini --set "$MARIADB_CONF_FILE" mysqld max_heap_table_size 1M
     crudini --set "$MARIADB_CONF_FILE" mysqld innodb_buffer_pool_size 5M
     crudini --set "$MARIADB_CONF_FILE" mysqld innodb_log_buffer_size 512K
-    crudini --set "$MARIADB_CONF_FILE" mysqld general_log_file /shared/log/mariadb/mariadb.log
 
     mysql_install_db --datadir="$DATADIR"
-
-    mkdir -p /shared/log/mariadb
-    touch /shared/log/mariadb/mariadb.log
-    chmod 664 /shared/log/mariadb/mariadb.log
-    chown -R mysql /shared/log/mariadb
-
-    sed -i 's/var\/log\/mariadb\/mariadb\.log/shared\/log\/mariadb\/mariadb\.log/g' \
-          /etc/my.cnf.d/mariadb-server.cnf
 
     chown -R mysql "$DATADIR"
 
@@ -32,8 +25,9 @@ CREATE DATABASE IF NOT EXISTS  ironic ;
 FLUSH PRIVILEGES ;
 EOSQL
 
-    exec mysqld_safe --init-file /tmp/configure-mysql.sql
+    # mysqld_safe closes stdout/stderr if no bash options are set ($- == '')
+    # turn on tracing to prevent this
+    exec bash -x /usr/bin/mysqld_safe --init-file /tmp/configure-mysql.sql
 else
-    exec mysqld_safe
+    exec bash -x /usr/bin/mysqld_safe
 fi
-


### PR DESCRIPTION
Rely instead on the logs to std out/err for each container

Fixes: #46