### PR TITLE
Re-adding Train features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ FROM docker.io/centos:centos7
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - -b train current-tripleo && \
     yum update -y && \
-    yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
-        iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
+    yum install -y python-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
+        iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils \
+        parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
         mariadb-server python2-chardet genisoimage && \
-    yum clean all && rm -rf /var/cache/{yum,dnf}/*
+    yum install -y python-ironic-prometheus-exporter && \
+    yum clean all && \
+    rm -rf /var/cache/{yum,dnf}/*
 
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/
@@ -17,6 +20,7 @@ RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
 
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor
+COPY ./runironic-exporter.sh /bin/runironic-exporter
 COPY ./rundnsmasq.sh /bin/rundnsmasq
 COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -39,3 +39,4 @@ interfaces = $IRONIC_IP
 EOF
 
 mkdir -p /shared/html
+mkdir -p /shared/ironic_prometheus_exporter

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -1,9 +1,9 @@
 #!ipxe
 
-
 :retry_boot
 echo In inspector.ipxe
 imgfree
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+# NOTE(dtantsur): keep inspection kernel params in [mdns]params in ironic-inspector-image
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=mdns systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -21,6 +21,12 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 
 [conductor]
 automated_clean = true
+enable_mdns = True
+send_sensor_data = true
+# NOTE(TheJulia): Do not lower this value below 120 seconds.
+# Power state is checked every 60 seconds and BMC activity should
+# be avoided more often than once every sixty seconds.
+send_sensor_data_interval = 160
 
 [deploy]
 default_boot_option = local
@@ -30,6 +36,11 @@ http_root = /shared/html/
 
 [dhcp]
 dhcp_provider = none
+
+[oslo_messaging_notifications]
+driver = prometheus_exporter
+location = /shared/ironic_prometheus_exporter
+transport_url = fake://
 
 [pxe]
 images_path = /shared/html/tmp

--- a/runironic-exporter.sh
+++ b/runironic-exporter.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+. /bin/configure-ironic.sh
+
+FLASK_RUN_HOST=${FLASK_RUN_HOST:-"0.0.0.0"}
+FLASK_RUN_PORT=${FLASK_RUN_PORT:-"9608"}
+
+export IRONIC_CONFIG="/etc/ironic/ironic.conf"
+
+exec gunicorn -b ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} -w 4 \
+    ironic_prometheus_exporter.app.wsgi:application


### PR DESCRIPTION
This patch adds back the features that were removed because we
were on Stain branch:
- continuous introspection
- ironic-prometheus-exporter
- mdns support

Also fixes #102 

Please merge this and https://github.com/metal3-io/ironic-inspector-image/pull/38 at the same time!