### PR TITLE
Enable RAID interfaces for Ironic container

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -11,6 +11,7 @@ enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish
 enabled_inspect_interfaces = inspector,idrac,irmc,fake,redfish
 enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish
 enabled_power_interfaces = ipmitool,idrac,irmc,fake,redfish
+enabled_raid_interfaces = no-raid,irmc,agent,fake
 enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake
 rpc_transport = json-rpc
 use_stderr = true


### PR DESCRIPTION
Currently, Ironic container does not enable RAID interfaces. This PR aims to add supported RAID interfaces into `ironic.conf` in order to support RAID configuration in Ironic provisioner.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>
Co-Authored-By: Dao Cong Tien <tiendc@vn.fujitsu.com>