### PR TITLE
Remove iptables filters from ironic containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - -b train current-tripleo && \
     yum update -y && \
     yum install -y python-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
-        iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk psmisc \
+        iproute dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk psmisc \
         sysvinit-tools mariadb-server genisoimage python-ironic-prometheus-exporter && \
     yum clean all && \
     rm -rf /var/cache/{yum,dnf}/*

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -27,13 +27,6 @@ for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf
 done
 
-# Allow access to dhcp and tftp server for pxeboot
-for port in 67 69 ; do
-    if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p udp --dport "$port" -j ACCEPT 2>/dev/null ; then
-        iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p udp --dport "$port" -j ACCEPT
-    fi
-done
-
 /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf 2>&1 | tee /shared/log/dnsmasq/dnsmasq.log &
 /bin/runhealthcheck "dnsmasq" &>/dev/null &
 sleep infinity

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -32,11 +32,6 @@ ln -s /shared/log/httpd/access_log /var/log/httpd/access_log
 touch /shared/log/httpd/error_log
 ln -s /shared/log/httpd/error_log /var/log/httpd/error_log
 
-# Allow external access
-if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp --dport "$HTTP_PORT" -j ACCEPT 2>/dev/null ; then
-    iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp --dport "$HTTP_PORT" -j ACCEPT
-fi
-
 /usr/sbin/httpd &
 
 /bin/runhealthcheck "httpd" "$HTTP_PORT" &>/dev/null &

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,10 +2,5 @@
 
 . /bin/configure-ironic.sh
 
-# Allow access to Ironic
-if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT
-fi
-
 exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf \
     --log-file /shared/log/ironic/ironic-api.log

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -2,14 +2,6 @@
 
 . /bin/configure-ironic.sh
 
-# Allow access to mDNS
-if ! iptables -C INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT
-fi
-if ! iptables -C OUTPUT -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I OUTPUT -p udp --dport 5353 -j ACCEPT
-fi
-
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 

--- a/runironic.sh
+++ b/runironic.sh
@@ -2,19 +2,6 @@
 
 . /bin/configure-ironic.sh
 
-# Allow access to Ironic
-if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 6385 -j ACCEPT
-fi
-
-# Allow access to mDNS
-if ! iptables -C INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I INPUT -i $PROVISIONING_INTERFACE -p udp --dport 5353 -j ACCEPT
-fi
-if ! iptables -C OUTPUT -p udp --dport 5353 -j ACCEPT > /dev/null 2>&1; then
-    iptables -I OUTPUT -p udp --dport 5353 -j ACCEPT
-fi
-
 ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
 
 # Remove log files from last deployment


### PR DESCRIPTION
We don't appear to need these, infact they output
errors on container startup...