### PR TITLE
Disabling mdns for ipv6 testing

### DIFF
--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -4,6 +4,6 @@
 echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in ironic-inspector-image
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=mdns systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -21,7 +21,6 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 
 [conductor]
 automated_clean = true
-enable_mdns = True
 send_sensor_data = true
 # NOTE(TheJulia): Do not lower this value below 120 seconds.
 # Power state is checked every 60 seconds and BMC activity should


### PR DESCRIPTION
The mdns feature is not compatible with ipv6 yet.