### PR TITLE
Changes needed for IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
+## Build iPXE w/ IPv6 Support
+## Note: we are pinning to a specific commit for reproducible builds.
+## Updated as needed.
+FROM docker.io/centos:centos7 AS builder
+RUN yum install -y gcc git make genisoimage xz-devel
+WORKDIR /tmp
+COPY . .
+RUN git clone http://git.ipxe.org/ipxe.git && \
+      cd ipxe && \
+      git checkout 3fe683ebab29afacf224e6b0921f6329bebcdca7 && \
+      cd src && \
+      sed -i -e "s/#undef.*NET_PROTO_IPV6/#define NET_PROTO_IPV6/g" config/general.h && \
+      make bin/undionly.kpxe bin-x86_64-efi/ipxe.efi bin-x86_64-efi/snponly.efi
+
 FROM docker.io/centos:centos7
 
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - -b train current-tripleo && \
     yum update -y && \
     yum install -y python-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
-        iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils \
-        parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
-        mariadb-server genisoimage && \
-    yum install -y python-ironic-prometheus-exporter && \
+        iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk psmisc \
+        sysvinit-tools mariadb-server genisoimage python-ironic-prometheus-exporter && \
     yum clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
-RUN mkdir /tftpboot && \
-    cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/
+RUN mkdir -p /tftpboot
+COPY --from=builder /tmp/ipxe/src/bin/undionly.kpxe /tftpboot
+COPY --from=builder /tmp/ipxe/src/bin-x86_64-efi/snponly.efi /tftpboot
+COPY --from=builder /tmp/ipxe/src/bin-x86_64-efi/ipxe.efi /tftpboot
 
 COPY ./ironic.conf /tmp/ironic.conf
 RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
@@ -25,13 +39,15 @@ COPY ./rundnsmasq.sh /bin/rundnsmasq
 COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
 COPY ./configure-ironic.sh /bin/configure-ironic.sh
+COPY ./ironic-common.sh /bin/ironic-common.sh
 
 # TODO(dtantsur): remove these 2 scripts if we decide to
 # stop supporting running all 2 processes via one entry point.
 COPY ./runhealthcheck.sh /bin/runhealthcheck
 COPY ./runironic.sh /bin/runironic
 
-COPY ./dnsmasq.conf /etc/dnsmasq.conf
+COPY ./dnsmasq.conf.ipv4 /etc/dnsmasq.conf.ipv4
+COPY ./dnsmasq.conf.ipv6 /etc/dnsmasq.conf.ipv6
 COPY ./inspector.ipxe /tmp/inspector.ipxe
 COPY ./dualboot.ipxe /tmp/dualboot.ipxe
 

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -1,13 +1,7 @@
 #!/usr/bin/bash
 
-# Get environment settings and update ironic.conf
-PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
-IRONIC_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
-until [ ! -z "${IRONIC_IP}" ]; do
-  echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-  sleep 1
-  IRONIC_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
-done
+. /bin/ironic-common.sh
+
 HTTP_PORT=${HTTP_PORT:-"80"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
@@ -16,6 +10,8 @@ NUMWORKERS=$(( NUMPROC < 12 ? NUMPROC : 12 ))
 # Whether to enable fast_track provisioning or not
 IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
 
+wait_for_interface_or_ip
+
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 
 crudini --merge /etc/ironic/ironic.conf <<EOF
@@ -23,21 +19,21 @@ crudini --merge /etc/ironic/ironic.conf <<EOF
 my_ip = $IRONIC_IP
 
 [api]
+host_ip = ::
 api_workers = $NUMWORKERS
 
 [conductor]
-api_url = http://${IRONIC_IP}:6385
+api_url = http://${IRONIC_URL_HOST}:6385
 
 [database]
 connection = mysql+pymysql://ironic:${MARIADB_PASSWORD}@localhost/ironic?charset=utf8
 
 [deploy]
-http_url = http://${IRONIC_IP}:${HTTP_PORT}
+http_url = http://${IRONIC_URL_HOST}:${HTTP_PORT}
 fast_track = ${IRONIC_FAST_TRACK}
 
 [inspector]
-endpoint_override = http://${IRONIC_IP}:5050
-
+endpoint_override = http://${IRONIC_URL_HOST}:5050
 EOF
 
 mkdir -p /shared/html

--- a/dnsmasq.conf.ipv4
+++ b/dnsmasq.conf.ipv4
@@ -6,7 +6,7 @@ tftp-root=/shared/tftpboot
 
 dhcp-match=ipxe,175
 # Client is already running iPXE; move to next stage of chainloading
-dhcp-boot=tag:ipxe,http://IRONIC_IP:HTTP_PORT/dualboot.ipxe
+dhcp-boot=tag:ipxe,http://IRONIC_URL_HOST:HTTP_PORT/dualboot.ipxe
 
 # Note: Need to test EFI booting
 dhcp-match=set:efi,option:client-arch,7

--- a/dnsmasq.conf.ipv6
+++ b/dnsmasq.conf.ipv6
@@ -1,0 +1,21 @@
+interface=PROVISIONING_INTERFACE
+bind-dynamic
+enable-tftp
+tftp-root=/shared/tftpboot
+log-dhcp
+
+enable-ra
+ra-param=PROVISIONING_INTERFACE,10
+
+dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
+dhcp-range=DHCP_RANGE
+dhcp-userclass=set:ipxe6,iPXE
+dhcp-option=tag:pxe6,option6:bootfile-url,tftp://IRONIC_URL_HOST/snponly.efi
+dhcp-option=tag:ipxe6,option6:bootfile-url,http://IRONIC_URL_HOST:HTTP_PORT/dualboot.ipxe
+
+# Disable listening for DNS
+port=0
+
+# Disable default router(s) and DNS over provisioning network
+dhcp-option=3
+dhcp-option=6

--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -1,0 +1,32 @@
+PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
+
+# Wait for the interface or IP to be up, sets $IRONIC_IP
+function wait_for_interface_or_ip() {
+  # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
+  if [ ! -z "${PROVISIONING_IP}" ];
+  then
+    IRONIC_IP=""
+    until [ ! -z "${IRONIC_IP}" ]; do
+      echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
+      IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
+      sleep 1
+    done
+  else
+    until [ ! -z "${IRONIC_IP}" ]; do
+      echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+      IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
+      sleep 1
+    done
+  fi
+
+  # If the IP contains a colon, then it's an IPv6 address, and the HTTP
+  # host needs surrounding with brackets
+  if [[ "$IRONIC_IP" =~ .*:.* ]]
+  then
+    IPV=6
+    IRONIC_URL_HOST="[$IRONIC_IP]"
+  else
+    IPV=4
+    IRONIC_URL_HOST=$IRONIC_IP
+  fi
+}

--- a/runhealthcheck.sh
+++ b/runhealthcheck.sh
@@ -15,7 +15,7 @@ while true ; do
 
     elif [ $1 = "dnsmasq" ] ; then
        DNSMASQPID=$(pidof dnsmasq)
-       fuser 67/udp |& grep -w "$DNSMASQPID"
+       fuser 67/udp 547/udp |& grep -w "$DNSMASQPID"
 
     elif [ $1 = "ironic" ] ; then
        curl -s http://localhost:6385 > /dev/null || ( echo "Can't contact ironic-api" && exit 1 )


### PR DESCRIPTION
This commit adds support for IPv6. When $PROVISIONING_IP is specified,
which may be an IPv6 address, the various containers will wait for that
IP to become available on an interface.

If the IP is IPv6, then we use an IPv6-specific configurations. Note,
IPv6 hosts are expected to be using UEFI boot, as we use snponly.efi.
snponly.efi uses the UEFI network stack instead of the iPXE drivers.
When using EDK2 OVMF + iPXE + ipxe.efi, we have seen lock-ups in
initialization of the hardware devices.

As neither CentOS nor RHEL distribute iPXE builds with IPv6 support, we
build them from source as part of the container build.