### PR TITLE
Removing forgotten mdns conf param

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -34,8 +34,6 @@ http_url = http://${IRONIC_IP}:${HTTP_PORT}
 [inspector]
 endpoint_override = http://${IRONIC_IP}:5050
 
-[mdns]
-interfaces = $IRONIC_IP
 EOF
 
 mkdir -p /shared/html


### PR DESCRIPTION
Removing a forgotten mdns configuration parameter that
might interfere if mdns is disabled.