### PR TITLE
Do not install python-chardet explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y python-requests && \
     yum install -y python-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils \
         parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
-        mariadb-server python-chardet genisoimage && \
+        mariadb-server genisoimage && \
     yum install -y python-ironic-prometheus-exporter && \
     yum clean all && \
     rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
The python-chardet package is a dependency of python-requests so no
need to install it explicitly.