### PR TITLE
Adds initial redfish UEFI virtual media boot

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -5,7 +5,7 @@ default_boot_interface = ipxe
 default_deploy_interface = direct
 default_inspect_interface = inspector
 default_network_interface = noop
-enabled_boot_interfaces = pxe,ipxe,fake
+enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media
 enabled_deploy_interfaces = direct,fake
 enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish
 enabled_inspect_interfaces = inspector,idrac,irmc,fake,redfish
@@ -22,6 +22,7 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 
 [conductor]
 automated_clean = true
+bootloader = /httpboot/uefi_esp.img
 send_sensor_data = true
 # NOTE(TheJulia): Do not lower this value below 120 seconds.
 # Power state is checked every 60 seconds and BMC activity should


### PR DESCRIPTION
In order to boot instances via virtual media in UEFI,
we need to be able to master an EFI image which contains
the bootloader and related files.

In this case, we're collecting the shim and grubx64.efi
into the image which will be used by the EFI firmware to
load the bootloader.