### PR TITLE
Fix bootloader copy

### DIFF
--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -12,6 +12,7 @@ chmod 0777 /shared/html
 # Copy files to shared mount
 cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
 cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
+cp /tmp/uefi_esp.img /shared/html/uefi_esp.img
 
 # Use configured values
 sed -i -e s/IRONIC_IP/${IRONIC_URL_HOST}/g -e s/HTTP_PORT/${HTTP_PORT}/g /shared/html/inspector.ipxe

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -5,8 +5,6 @@
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
-cp -f /tmp/uefi_esp.img /shared/html/uefi_esp.img
-
 # It's possible for the dbsync to fail if mariadb is not up yet, so
 # retry until success
 until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do


### PR DESCRIPTION
The bootloader was copied to the html folder in runironic-conductor
while some other scripts are used to start ironic. Moving the copy
to runhttpd as the file is served by httpd.