### PR TITLE
add HTTP port in bootloader configuration for ironic

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -24,7 +24,7 @@ api_workers = $NUMWORKERS
 
 [conductor]
 api_url = http://${IRONIC_URL_HOST}:6385
-bootloader = http://${IRONIC_URL_HOST}/uefi_esp.img
+bootloader = http://${IRONIC_URL_HOST}:${HTTP_PORT}/uefi_esp.img
 
 [database]
 connection = mysql+pymysql://ironic:${MARIADB_PASSWORD}@localhost/ironic?charset=utf8


### PR DESCRIPTION
It was missing the port, always going to port 80 when httpd
listens on 6180 in BMO deployments