### PR TITLE
Use env in shebang for bash scripts

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . /bin/ironic-common.sh
 

--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 
 # Wait for the interface or IP to be up, sets $IRONIC_IP

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . /bin/ironic-common.sh
 

--- a/runhealthcheck.sh
+++ b/runhealthcheck.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -ex
 
 trap killcontainer ERR

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . /bin/ironic-common.sh
 

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . /bin/configure-ironic.sh
 

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . /bin/configure-ironic.sh
 

--- a/runironic-exporter.sh
+++ b/runironic-exporter.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . /bin/configure-ironic.sh
 

--- a/runironic.sh
+++ b/runironic.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 . /bin/configure-ironic.sh
 

--- a/runmariadb.sh
+++ b/runmariadb.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
+
 PATH=$PATH:/usr/sbin/
 DATADIR="/var/lib/mysql"
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}


### PR DESCRIPTION
Standardize bash command location relying on env to detect the
default system binary instead of giving its path as assumed.