### PR TITLE
Fix python version in rundnsmasq

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -15,7 +15,7 @@ mkdir -p /shared/html/pxelinux.cfg
 cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftpboot
 
 # Template and write dnsmasq.conf
-python -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
 
 for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf


### PR DESCRIPTION
After the move to centos8, python3 is the only python installation.
changing the python version to 3 in the dnsmasq script.