### PR TITLE
export HTTP_PORT

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -2,7 +2,7 @@
 
 . /bin/ironic-common.sh
 
-HTTP_PORT=${HTTP_PORT:-"80"}
+export HTTP_PORT=${HTTP_PORT:-"80"}
 DNSMASQ_EXCEPT_INTERFACE=${DNSMASQ_EXCEPT_INTERFACE:-"lo"}
 
 wait_for_interface_or_ip


### PR DESCRIPTION
Its required when rendering /etc/dnsmasq.conf.j2