### PR TITLE
Install ironic clients for test/debug usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf install -y python3 python3-requests && \
     dnf install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk psmisc \
         mariadb-server genisoimage python3-ironic-prometheus-exporter \
+        python3-ironicclient python3-ironic-inspector-client python3-openstackclient \
         python3-jinja2 python3-sushy-oem-idrac && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
In https://github.com/metal3-io/metal3-dev-env/pull/187
we discuss the current usage of the RDO repos, and since
virtualbmc is now containerized, the only things we
install from the RDO repos are the python ironic clients.

For development and debugging, it's helpful to have these
available, and also in real production environments for
collecting debug information (and in this latter case it's
often not possible to e.g pip install some clients, so
having them available in an image already accessible to the
cluster is useful).

This can be used interactively e.g:

podman run -ti --entrypoint='["/usr/bin/openstack", "baremetal", "node", "list"]' \
  -v /home/shardy/dev-scripts/etc_openstack:/etc/openstack \
  -e OS_CLOUD=$OS_CLOUD localhost/ironic_client

Clearly we could add a shell alias or wrapper function to make this
transparent and act like the current installed client.