### PR TITLE
Support an explicit allowlist for MAC's

### DIFF
--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -7,6 +7,23 @@ DNSMASQ_EXCEPT_INTERFACE=${DNSMASQ_EXCEPT_INTERFACE:-"lo"}
 
 wait_for_interface_or_ip
 
+# If $DHCP_ALLOWLIST is set, filter out any mac's other
+# than those specified. Works better than dnsmasq's
+# dhcp-host feature, which expects to use the DUID instead
+# of MAC's for DHCPv6 clients.
+if [[ -n "$DHCP_ALLOWLIST" ]]; then
+  iptables -t raw -N DHCP
+  iptables -t raw -A PREROUTING -p udp --dport 67 -j DHCP
+  iptables -t raw -A PREROUTING -p udp --dport 546 -j DHCP
+
+  for mac in $(echo $DHCP_ALLOWLIST | sed 's/,/ /g')
+  do
+    iptables -t raw -A DHCP -m mac --mac-source "$mac" -j ACCEPT
+  done
+
+  iptables -t raw -A DHCP -j DROP
+fi
+
 mkdir -p /shared/tftpboot
 mkdir -p /shared/html/images
 mkdir -p /shared/html/pxelinux.cfg


### PR DESCRIPTION
In OpenShift, we have a pivot from a "bootstrap" VM to the cluster
Metal3 pod, but there's a short time where both could exist. The
bootstrap knows which mac's it needs to respond to, which is only the
k8s control plane hosts. This adds an optional feature to our dnsmasq
configuration that allows permitting an explicit list of mac's.