### PR TITLE
Add a note about setting env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ The following environment variables can be passed in to customize run-time funct
 - HTTP_PORT - port used by http server (default 80)
 - DHCP_RANGE - dhcp range to use for provisioning (default 172.22.0.10-172.22.0.100)
 - MARIADB_PASSWORD - The database password
+
+Each of these variables is needed by multiple containers and any that are set should be passed into all of the ironic containers.
+
+The ironic configuration can be overridden by various environment variables.
 - OS_<section>_\_<name>=<value> - This format can be used to set arbitary ironic config options
 
-The ironic configuration can be overridden by various environment variables. The following can serve as an example:
+The following can serve as an example:
 - OS_CONDUCTOR__DEPLOY_CALLBACK_TIMEOUT=4800 - timeout (seconds) to wait for a callback from a deploy ramdisk
 - OS_CONDUCTOR__INSPECT_TIMEOUT=1800 - timeout (seconds) for waiting for node inspection
 - OS_CONDUCTOR__CLEAN_CALLBACK_TIMEOUT=1800 - timeout (seconds) to wait for a callback from the ramdisk doing the cleaning


### PR DESCRIPTION
These should be set on all containers if set on any as some of them
are needed in multiple containers.

Fixes: #68 