### PR TITLE
Use snponly.efi instead of ipxe.efi for IPv4

### DIFF
--- a/dnsmasq.conf.j2
+++ b/dnsmasq.conf.j2
@@ -25,7 +25,7 @@ dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9
 dhcp-match=set:efi,option:client-arch,11
 # Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
-dhcp-boot=tag:efi,tag:!ipxe,ipxe.efi
+dhcp-boot=tag:efi,tag:!ipxe,snponly.efi
 
 # Client is running PXE over BIOS; send BIOS version of iPXE chainloader
 dhcp-boot=/undionly.kpxe,{{ env["IRONIC_IP"] }}


### PR DESCRIPTION
As part of the UEFI stack, a network stack is available. The iPXE
binary that implements this stack, and only this stack support is
snponly.efi, where as ipxe.efi instead tries to load network driers
that have been authored and incorporated into the ipxe.efi binary
itself.

These drivers are redundant in UEFI mode, and we should not need
them. As such, we should realistically only be using snponly.efi.

If not used, we get an error about no networks having been found
upon loading ipxe.efi.

rhbz# 1830161