### PR TITLE
Allow any IPv6 address to be configured for provisioning, but link local scope

### DIFF
--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -14,7 +14,7 @@ function wait_for_interface_or_ip() {
   else
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-      export IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
+      export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3; exit}')
       sleep 1
     done
   fi


### PR DESCRIPTION
This PR fixes an issue when using routable IPv6 addresses for the provisioning network. The previous grep command only matched local unicast addresses, this new grep will match any IPv6 address, but the link local scope.

The httpd container keeps waiting for "PROV_IFACE" to be configured otherwise.

