### PR TITLE
Fix the IP address parsing in ironic-common.sh

### DIFF
--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -14,7 +14,7 @@ function wait_for_interface_or_ip() {
   else
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-      export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3; exit}')
+      export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
   fi


### PR DESCRIPTION
The prefix was captured with the IP address. This change strips it

Fixes #155 