### PR TITLE
Allows users to configure any non-link-local IPV6 address for the provisioning interface

### DIFF
--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -14,7 +14,7 @@ function wait_for_interface_or_ip() {
   else
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-      export IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
+      export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
   fi


### PR DESCRIPTION
This fix introduces the fix created for metal3-io ironic-image https://github.com/metal3-io/ironic-image/pull/156/

Thank @maelk for fixing our previous fix! 

