### PR TITLE
Enable serial console by default for pxe

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -58,6 +58,7 @@ images_path = /shared/html/tmp
 instance_master_path = /shared/html/master_images
 ipxe_enabled = true
 pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
+pxe_append_params = nofb nomodeset vga=normal console=ttyS0 console=tty0
 tftp_master_path = /shared/tftpboot
 tftp_root = /shared/tftpboot
 uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template


### PR DESCRIPTION
If a problem happens in IPA, it can help to use the serial console to
debug. We can also use the serial console to log the output in CI
systems.

We specify 2 console options, one for the serial console, and one for
the graphical display. According to the kernel docs, the last devices
will be used for /dev/console, but output will appear on all of them[1].
`tty0` is last so if there's an emegency prompt needed it'll be put
on the graphical console by default.

[1] kernel.org/doc/html/v5.5-rc2/admin-guide/serial-console.html