### PR TITLE
enable idrac-wsman BIOS interface

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -5,6 +5,7 @@ default_boot_interface = ipxe
 default_deploy_interface = direct
 default_inspect_interface = inspector
 default_network_interface = noop
+enabled_bios_interfaces = idrac-wsman
 enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media,idrac-redfish-virtual-media
 enabled_deploy_interfaces = direct,fake
 enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish


### PR DESCRIPTION
I'm working on BIOS configuration with the `idrac-wsman` driver. Since this requires enabling the interface, I've edited the `ironic.conf` to do so.