### PR TITLE
Update inspection configuration to enable fast-track

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -38,6 +38,10 @@ fast_track = ${IRONIC_FAST_TRACK}
 
 [inspector]
 endpoint_override = http://${IRONIC_URL_HOST}:5050
+# TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
+# not, so working around here.
+# NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
+extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ipa-api-url=http://${IRONIC_URL_HOST}:6385
 
 [service_catalog]
 endpoint_override = http://${IRONIC_URL_HOST}:6385

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -3,7 +3,8 @@
 :retry_boot
 echo In inspector.ipxe
 imgfree
-# NOTE(dtantsur): keep inspection kernel params in [mdns]params in ironic-inspector-image
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+# NOTE(dtantsur): keep inspection kernel params in [mdns]params in
+# ironic-inspector-image and configuration in configure-ironic.sh
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-api-url=http://IRONIC_IP:6385 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -44,6 +44,9 @@ http_root = /shared/html/
 [dhcp]
 dhcp_provider = none
 
+[inspector]
+power_off = false
+
 [oslo_messaging_notifications]
 driver = prometheus_exporter
 location = /shared/ironic_prometheus_exporter


### PR DESCRIPTION
Without it ironic will never learn that the ramdisk has been booted
for inspection, requiring a reboot despite fast-track enabled.