### PR TITLE
WIP: Run ironic-api as WSGI when standalone with TLS capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN dnf install -y python3 python3-requests && \
     dnf install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk psmisc \
         mariadb-server genisoimage python3-ironic-prometheus-exporter \
-        python3-jinja2 python3-sushy-oem-idrac python3-ibmcclient && \
+        python3-jinja2 python3-sushy-oem-idrac python3-ibmcclient mod_ssl python3-mod_wsgi && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
@@ -49,7 +49,8 @@ COPY --from=builder /tmp/esp.img /tmp/uefi_esp.img
 
 COPY ./ironic.conf /tmp/ironic.conf
 RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
-    rm /tmp/ironic.conf
+    rm /tmp/ironic.conf && chown ironic:ironic /var/log/ironic && \
+    rm /etc/httpd/conf.d/ssl.conf
 
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor
@@ -59,6 +60,7 @@ COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
 COPY ./configure-ironic.sh /bin/configure-ironic.sh
 COPY ./ironic-common.sh /bin/ironic-common.sh
+COPY ./apache2-ironic.conf.j2 /etc/httpd-ironic.conf.j2
 
 # TODO(dtantsur): remove this script when we stop supporting running both
 # API and conductor processes via one entry point.

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
 COPY ./configure-ironic.sh /bin/configure-ironic.sh
 COPY ./ironic-common.sh /bin/ironic-common.sh
-COPY ./apache2-ironic.conf.j2 /etc/httpd-ironic.conf.j2
+COPY ./apache2-ironic-api.conf.j2 /etc/httpd-ironic-api.conf.j2
+COPY ./apache2-ironic-conductor.conf.j2 /etc/httpd-ironic-conductor.conf.j2
 
 # TODO(dtantsur): remove this script when we stop supporting running both
 # API and conductor processes via one entry point.

--- a/apache2-ironic-api.conf.j2
+++ b/apache2-ironic-api.conf.j2
@@ -35,16 +35,12 @@ Listen 6385
     SSLCACertificateFile {{ env["CACERT_FILE"] }}
 
     <Location "/">
-    <If "! -R '{{ env["IRONIC_IP"] }}/32'">
         SSLVerifyClient require
         SSLVerifyDepth 1
-    </If>
     </Location>
 
     <LocationMatch "(^/?$)|(^/v1/?$)|(^/v1/lookup)|(^/v1/heartbeat)">
-    <If "! -R '{{ env["IRONIC_IP"] }}/32'">
         SSLVerifyClient none
-    </If>
     </LocationMatch>
 
 {% endif %}

--- a/apache2-ironic-api.conf.j2
+++ b/apache2-ironic-api.conf.j2
@@ -30,9 +30,9 @@ Listen 6385
     SSLCertificateFile {{ env["CERT_FILE"] }}
     SSLCertificateKeyFile {{ env["KEY_FILE"] }}
 
-{% if "CACERT_FILE" in env %}
+{% if "CLIENT_AUTH_CACERT_FILE" in env %}
     SSLVerifyClient none
-    SSLCACertificateFile {{ env["CACERT_FILE"] }}
+    SSLCACertificateFile {{ env["CLIENT_AUTH_CACERT_FILE"] }}
 
     <Location "/">
         SSLVerifyClient require

--- a/apache2-ironic-conductor.conf.j2
+++ b/apache2-ironic-conductor.conf.j2
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Listen 8089
+<VirtualHost *:8089>
+    ProxyPass "/"  "http://127.0.0.1:8090/"
+    ProxyPassReverse "/"  "http://127.0.0.1:8090/"
+
+    SetEnv APACHE_RUN_USER ironic
+    SetEnv APACHE_RUN_GROUP ironic
+
+    ErrorLog /dev/stdout
+    LogLevel debug
+    CustomLog /dev/stdout combined
+
+{% if "CERT_FILE" in env and "KEY_FILE" in env %}
+    ServerName {{ env["DOMAIN_NAME"]}}
+    SSLEngine on
+    SSLCertificateFile {{ env["CERT_FILE"] }}
+    SSLCertificateKeyFile {{ env["KEY_FILE"] }}
+
+{% if "CACERT_FILE" in env %}
+    SSLCACertificateFile {{ env["CACERT_FILE"] }}
+    SSLVerifyClient require
+    SSLVerifyDepth 1
+{% endif %}
+{% endif %}
+</VirtualHost>

--- a/apache2-ironic-conductor.conf.j2
+++ b/apache2-ironic-conductor.conf.j2
@@ -28,8 +28,8 @@ Listen 8089
     SSLCertificateFile {{ env["CERT_FILE"] }}
     SSLCertificateKeyFile {{ env["KEY_FILE"] }}
 
-{% if "CACERT_FILE" in env %}
-    SSLCACertificateFile {{ env["CACERT_FILE"] }}
+{% if "CLIENT_AUTH_CACERT_FILE" in env %}
+    SSLCACertificateFile {{ env["CLIENT_AUTH_CACERT_FILE"] }}
     SSLVerifyClient require
     SSLVerifyDepth 1
 {% endif %}

--- a/apache2-ironic.conf.j2
+++ b/apache2-ironic.conf.j2
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Listen 6385
+
+<VirtualHost *:6385>
+    WSGIDaemonProcess ironic user=ironic group=ironic threads=10 display-name=%{GROUP}
+    WSGIScriptAlias / /usr/bin/ironic-api-wsgi
+
+    SetEnv APACHE_RUN_USER ironic
+    SetEnv APACHE_RUN_GROUP ironic
+    WSGIProcessGroup ironic
+
+    ErrorLog /dev/stdout
+    LogLevel debug
+    CustomLog /dev/stdout combined
+
+{% if "CERT_FILE" in env and "KEY_FILE" in env %}
+    ServerName {{ env["DOMAIN_NAME"]}}
+    SSLEngine on
+    SSLCertificateFile {{ env["CERT_FILE"] }}
+    SSLCertificateKeyFile {{ env["KEY_FILE"] }}
+
+{% if "CACERT_FILE" in env %}
+    SSLVerifyClient none
+    SSLCACertificateFile {{ env["CACERT_FILE"] }}
+
+    <Location "/">
+    <If "! -R '{{ env["IRONIC_IP"] }}/32'">
+        SSLVerifyClient require
+        SSLVerifyDepth 1
+    </If>
+    </Location>
+
+    <LocationMatch "(^/?$)|(^/v1/?$)|(^/v1/lookup)|(^/v1/heartbeat)">
+    <If "! -R '{{ env["IRONIC_IP"] }}/32'">
+        SSLVerifyClient none
+    </If>
+    </LocationMatch>
+
+{% endif %}
+{% endif %}
+
+    <Directory /usr/bin >
+        WSGIProcessGroup ironic
+        WSGIApplicationGroup %{GLOBAL}
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -39,14 +39,15 @@ fast_track = ${IRONIC_FAST_TRACK}
 
 EOF
 
-if [ ! -z "$CERT_FILE" ] && [ ! -z "$KEY_FILE" ]; then
+if [ ! -z "$CLIENT_CERT_FILE" ] || [ ! -z "$CLIENT_KEY_FILE" ] || [ ! -z "$CACERT_FILE" ] || [ ! -z "$INSECURE" ]; then
     crudini --merge /etc/ironic/ironic.conf <<EOF
 [inspector]
 endpoint_override = https://${IRONIC_URL_HOST}:5050
-certfile = $CERT_FILE
-keyfile = $KEY_FILE
-insecure = false
+$([ ! -z "$CLIENT_CERT_FILE" ] && echo "certfile = $CLIENT_CERT_FILE")
+$([ ! -z "$CLIENT_KEY_FILE" ] && echo "keyfile = $CLIENT_KEY_FILE")
 $([ ! -z "$CACERT_FILE" ] && echo "cafile = $CACERT_FILE")
+$([ ! -z "$INSECURE" ] && echo "insecure = $INSECURE" || echo "insecure = false")
+
 # TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
 # not, so working around here.
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
@@ -54,15 +55,16 @@ extra_kernel_params = ipa-insecure=True ipa-inspector-collectors=default,extra-h
 
 [service_catalog]
 endpoint_override = https://${IRONIC_URL_HOST}:6385
-certfile = $CERT_FILE
-keyfile = $KEY_FILE
-insecure = false
+$([ ! -z "$CLIENT_CERT_FILE" ] && echo "certfile = $CLIENT_CERT_FILE")
+$([ ! -z "$CLIENT_KEY_FILE" ] && echo "keyfile = $CLIENT_KEY_FILE")
 $([ ! -z "$CACERT_FILE" ] && echo "cafile = $CACERT_FILE")
+$([ ! -z "$INSECURE" ] && echo "insecure = $INSECURE" || echo "insecure = false")
 EOF
 else
     crudini --merge /etc/ironic/ironic.conf <<EOF
 [inspector]
 endpoint_override = http://${IRONIC_URL_HOST}:5050
+
 # TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
 # not, so working around here.
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -13,6 +13,20 @@ IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
 # Whether cleaning disks before and after deployment
 IRONIC_AUTOMATED_CLEAN=${IRONIC_AUTOMATED_CLEAN:-true}
 
+RPC_SSL_CONF=""
+
+if [ ! -z "$CERT_FILE" ] && [ ! -z "$KEY_FILE" ]; then
+    read -r -d '' RPC_SSL_CONF << EOM
+[json_rpc]
+use_ssl = true
+certfile = $CERT_FILE
+keyfile = $KEY_FILE
+insecure = false
+$([ ! -z "$CACERT_FILE" ] && echo "cafile = $CACERT_FILE")
+EOM
+fi
+
+
 wait_for_interface_or_ip
 
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
@@ -20,6 +34,7 @@ cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 crudini --merge /etc/ironic/ironic.conf <<EOF
 [DEFAULT]
 my_ip = $IRONIC_IP
+host = $IRONIC_IP
 
 [api]
 host_ip = ::
@@ -45,6 +60,9 @@ extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-i
 
 [service_catalog]
 endpoint_override = http://${IRONIC_URL_HOST}:6385
+
+$RPC_SSL_CONF
+
 EOF
 
 mkdir -p /shared/html

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -51,7 +51,10 @@ $([ ! -z "$INSECURE" ] && echo "insecure = $INSECURE" || echo "insecure = false"
 # TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
 # not, so working around here.
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
-extra_kernel_params = ipa-insecure=True ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ipa-api-url=https://${IRONIC_URL_HOST}:6385
+extra_kernel_params = ipa-insecure=1 ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ipa-api-url=https://${IRONIC_URL_HOST}:6385
+
+[pxe]
+pxe_append_params = nofb nomodeset vga=normal ipa-insecure=1
 
 [service_catalog]
 endpoint_override = https://${IRONIC_URL_HOST}:6385

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -5,6 +5,6 @@ echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in
 # ironic-inspector-image and configuration in configure-ironic.sh
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-api-url=http://IRONIC_IP:6385 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-insecure=True ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-api-url=http://IRONIC_IP:6385 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -5,6 +5,6 @@ echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in
 # ironic-inspector-image and configuration in configure-ironic.sh
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-insecure=True ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-api-url=http://IRONIC_IP:6385 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-insecure=1 ipa-inspection-callback-url=https://IRONIC_IP:5050/v1/continue ipa-api-url=https://IRONIC_IP:6385 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -15,6 +15,7 @@ enabled_raid_interfaces = no-raid,irmc,agent,fake
 enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake,ibmc
 rpc_transport = json-rpc
 use_stderr = true
+host = localhost
 
 [agent]
 deploy_logs_collect = always
@@ -67,3 +68,8 @@ uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
 
 [redfish]
 use_swift = false
+
+[json_rpc]
+auth_strategy = noauth
+host_ip = ::
+port = 8089

--- a/ironic.conf
+++ b/ironic.conf
@@ -71,5 +71,3 @@ use_swift = false
 
 [json_rpc]
 auth_strategy = noauth
-host_ip = ::
-port = 8089

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,4 +2,7 @@
 
 . /bin/configure-ironic.sh
 
-exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf
+# Template and write httpd ironic.conf
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic.conf.j2 > /etc/httpd/conf.d/ironic.conf
+
+exec /usr/sbin/httpd -DFOREGROUND

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -6,14 +6,14 @@
 rm -rf /shared/log/ironic
 mkdir -p /shared/log/ironic
 
-if [ ! -z "$CERT_FILE" ] && [ ! -z "$KEY_FILE" ]; then
+if [ ! -z "$CLIENT_CERT_FILE" ] || [ ! -z "$CLIENT_KEY_FILE" ] || [ ! -z "$CACERT_FILE" ] || [ ! -z "$INSECURE" ]; then
     crudini --merge /etc/ironic/ironic.conf <<EOF
 [json_rpc]
 use_ssl = true
-certfile = $CERT_FILE
-keyfile = $KEY_FILE
-insecure = false
+$([ ! -z "$CLIENT_CERT_FILE" ] && echo "certfile = $CLIENT_CERT_FILE")
+$([ ! -z "$CLIENT_KEY_FILE" ] && echo "keyfile = $CLIENT_KEY_FILE")
 $([ ! -z "$CACERT_FILE" ] && echo "cafile = $CACERT_FILE")
+$([ ! -z "$INSECURE" ] && echo "insecure = $INSECURE" || echo "insecure = false")
 port = 8089
 EOF
 else

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,8 +2,30 @@
 
 . /bin/configure-ironic.sh
 
+# Remove log files from last deployment
+rm -rf /shared/log/ironic
+mkdir -p /shared/log/ironic
+
+if [ ! -z "$CERT_FILE" ] && [ ! -z "$KEY_FILE" ]; then
+    crudini --merge /etc/ironic/ironic.conf <<EOF
+[json_rpc]
+use_ssl = true
+certfile = $CERT_FILE
+keyfile = $KEY_FILE
+insecure = false
+$([ ! -z "$CACERT_FILE" ] && echo "cafile = $CACERT_FILE")
+port = 8089
+EOF
+else
+    crudini --merge /etc/ironic/ironic.conf <<EOF
+[json_rpc]
+port = 8089
+use_ssl = false
+EOF
+fi
+
 # Template and write httpd ironic.conf
-python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic.conf.j2 > /etc/httpd/conf.d/ironic.conf
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic-api.conf
 sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
 
 exec /usr/sbin/httpd -DFOREGROUND

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -4,5 +4,6 @@
 
 # Template and write httpd ironic.conf
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic.conf.j2 > /etc/httpd/conf.d/ironic.conf
+sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
 
 exec /usr/sbin/httpd -DFOREGROUND

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -2,6 +2,16 @@
 
 . /bin/configure-ironic.sh
 
+crudini --merge /etc/ironic/ironic.conf <<EOF
+[json_rpc]
+port = 8090
+host_ip = 127.0.0.1
+EOF
+
+# Remove log files from last deployment
+rm -rf /shared/log/ironic
+mkdir -p /shared/log/ironic
+
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
@@ -11,5 +21,12 @@ until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
   echo "WARNING: ironic-dbsync failed, retrying"
   sleep 1
 done
+
+# Template and write httpd ironic.conf
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-conductor.conf.j2 > /etc/httpd/conf.d/ironic-conductor.conf
+sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
+
+
+/usr/sbin/httpd
 
 exec /usr/bin/ironic-conductor --config-file /etc/ironic/ironic.conf

--- a/runironic.sh
+++ b/runironic.sh
@@ -10,7 +10,7 @@ rm -rf /shared/log/ironic
 mkdir -p /shared/log/ironic
 
 /usr/bin/ironic-conductor &
-/usr/bin/ironic-api &
+/bin/runironic-api.sh &
 
 sleep infinity
 

--- a/runironic.sh
+++ b/runironic.sh
@@ -2,14 +2,7 @@
 
 . /bin/configure-ironic.sh
 
-ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
-
-# Remove log files from last deployment
-rm -rf /shared/log/ironic
-
-mkdir -p /shared/log/ironic
-
-/usr/bin/ironic-conductor &
+/bin/runironic-conductor &
 /bin/runironic-api &
 
 sleep infinity

--- a/runironic.sh
+++ b/runironic.sh
@@ -10,7 +10,7 @@ rm -rf /shared/log/ironic
 mkdir -p /shared/log/ironic
 
 /usr/bin/ironic-conductor &
-/bin/runironic-api.sh &
+/bin/runironic-api &
 
 sleep infinity
 


### PR DESCRIPTION
This commit adds support for mTLS when running ironic-api
standalone. It runs ironic behind an Apache server, using
mod_wsgi