### PR TITLE
Add ability to set arbitrary ironic configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ The following environment variables can be passed in to customize run-time funct
 - HTTP_PORT - port used by http server (default 80)
 - DHCP_RANGE - dhcp range to use for provisioning (default 172.22.0.10-172.22.0.100)
 - MARIADB_PASSWORD - The database password
+- OS_<section>_\_<name>=<value> - This format can be used to set arbitary ironic config options

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -43,5 +43,9 @@ endpoint_override = http://${IRONIC_URL_HOST}:5050
 endpoint_override = http://${IRONIC_URL_HOST}:6385
 EOF
 
+# oslo.config also supports Config Opts From Environment, log them
+echo '# Options set from Environment variables' | tee /etc/ironic/ironic.extra
+env | grep "^OS_" | tee -a /etc/ironic/ironic.extra
+
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter


### PR DESCRIPTION
As more use cases are using this image and may need to tweak
various config options. Add the method to set arbitary options
rather then having to add a new option for each case.

Potential solution (the ironic part) to https://github.com/metal3-io/ironic-image/issues/143

Another alternative method might be to mount a partial ironic.conf to be merged into /etc/ironic/ironic.conf , I've leaned in the direction of the env variable as its more consistent
with that we currently have

Marking as WIP until we discuss whats best.
