### PR TITLE
Add http_basic auth support

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -2,6 +2,10 @@
 
 . /bin/ironic-common.sh
 
+USE_HTTP_BASIC=${USE_HTTP_BASIC:-false}
+IRONIC_HTTP_BASIC_USERNAME=${IRONIC_HTTP_BASIC_USERNAME:-"change_me"}
+IRONIC_HTTP_BASIC_PASSWORD=${IRONIC_HTTP_BASIC_PASSWORD:-"change_me"}
+
 HTTP_PORT=${HTTP_PORT:-"80"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
@@ -45,3 +49,16 @@ EOF
 
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter
+
+if [ "$USE_HTTP_BASIC" = "true" ]; then
+
+	crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy http_basic
+	crudini --set /etc/ironic/ironic.conf DEFAULT http_basic_auth_user_file /shared/htpasswd-ironic
+	crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy http_basic
+	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_auth_user_file /shared/htpasswd-ironic
+	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_username $IRONIC_HTTP_BASIC_USERNAME
+	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_password $IRONIC_HTTP_BASIC_PASSWORD
+
+	## NOTE(iurygregory): reusing the ironic credentials so we don't end up with wrong client credentials
+	htpasswd -nbB $IRONIC_HTTP_BASIC_USERNAME $IRONIC_HTTP_BASIC_PASSWORD > /shared/htpasswd-ironic
+fi


### PR DESCRIPTION
This commit adds the support to run ironic using `http_basic`.
To enable that is necessary to set USE_HTTP_BASIC to true, and also
specify values for the following enviroment variables:
-IRONIC_HTTP_BASIC_USERNAME
-IRONIC_HTTP_BASIC_PASSWORD