### PR TITLE
Add a managed introspection IPA url

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -38,6 +38,7 @@ fast_track = ${IRONIC_FAST_TRACK}
 
 [inspector]
 endpoint_override = http://${IRONIC_URL_HOST}:5050
+extra_kernel_params = ipa-api-url=http://${IRONIC_URL_HOST}:6385
 
 [service_catalog]
 endpoint_override = http://${IRONIC_URL_HOST}:6385


### PR DESCRIPTION
Managed introspection is modeled around powering on the machine
updating the inspection data, and powering it off.

However when features like fast track are used, inspection does not
know how to check-in with ironic. As such, we should supply it.