### PR TITLE
WIP: Reload httpd on certificate change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,14 @@ RUN dd bs=1024 count=2880 if=/dev/zero of=esp.img && \
 
 FROM docker.io/centos:centos8
 
-RUN dnf install -y python3 python3-requests && \
+RUN dnf install -y python3 python3-requests epel-release && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo && \
     dnf update -y && \
     dnf install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk psmisc \
         mariadb-server genisoimage python3-ironic-prometheus-exporter \
-        python3-jinja2 python3-sushy-oem-idrac python3-ibmcclient mod_ssl python3-mod_wsgi && \
+        python3-jinja2 python3-sushy-oem-idrac python3-ibmcclient mod_ssl python3-mod_wsgi \
+        inotify-tools && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN dnf install -y python3 python3-requests && \
     dnf install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk psmisc \
         mariadb-server genisoimage python3-ironic-prometheus-exporter \
-        python3-jinja2 python3-sushy-oem-idrac python3-ibmcclient && \
+        python3-jinja2 python3-sushy-oem-idrac python3-ibmcclient mod_ssl python3-mod_wsgi && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
@@ -49,7 +49,8 @@ COPY --from=builder /tmp/esp.img /tmp/uefi_esp.img
 
 COPY ./ironic.conf /tmp/ironic.conf
 RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
-    rm /tmp/ironic.conf
+    rm /tmp/ironic.conf && chown ironic:ironic /var/log/ironic && \
+    rm /etc/httpd/conf.d/ssl.conf
 
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor
@@ -59,6 +60,7 @@ COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb
 COPY ./configure-ironic.sh /bin/configure-ironic.sh
 COPY ./ironic-common.sh /bin/ironic-common.sh
+COPY ./apache2-ironic.conf.j2 /etc/httpd-ironic.conf.j2
 
 # TODO(dtantsur): remove this script when we stop supporting running both
 # API and conductor processes via one entry point.

--- a/apache2-ironic.conf.j2
+++ b/apache2-ironic.conf.j2
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Listen 6385
+
+<VirtualHost *:6385>
+    WSGIDaemonProcess ironic user=ironic group=ironic threads=10 display-name=%{GROUP}
+    WSGIScriptAlias / /usr/bin/ironic-api-wsgi
+
+    SetEnv APACHE_RUN_USER ironic
+    SetEnv APACHE_RUN_GROUP ironic
+    WSGIProcessGroup ironic
+
+    ErrorLog /dev/stdout
+    LogLevel debug
+    CustomLog /dev/stdout combined
+
+{% if "CERT_FILE" in env and "KEY_FILE" in env %}
+    ServerName {{ env["DOMAIN_NAME"]}}
+    SSLEngine on
+    SSLCertificateFile {{ env["CERT_FILE"] }}
+    SSLCertificateKeyFile {{ env["KEY_FILE"] }}
+
+{% if "CACERT_FILE" in env %}
+    SSLVerifyClient none
+    SSLCACertificateFile {{ env["CACERT_FILE"] }}
+
+    <Location "/">
+    <If "! -R '{{ env["IRONIC_IP"] }}/32'">
+        SSLVerifyClient require
+        SSLVerifyDepth 1
+    </If>
+    </Location>
+
+    <LocationMatch "(^/?$)|(^/v1/?$)|(^/v1/lookup)|(^/v1/heartbeat)">
+    <If "! -R '{{ env["IRONIC_IP"] }}/32'">
+        SSLVerifyClient none
+    </If>
+    </LocationMatch>
+
+{% endif %}
+{% endif %}
+
+    <Directory /usr/bin >
+        WSGIProcessGroup ironic
+        WSGIApplicationGroup %{GLOBAL}
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -4,6 +4,6 @@
 echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in ironic-inspector-image
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-insecure=True ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -15,6 +15,7 @@ enabled_raid_interfaces = no-raid,irmc,agent,fake
 enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake,ibmc
 rpc_transport = json-rpc
 use_stderr = true
+host = localhost
 
 [agent]
 deploy_logs_collect = always
@@ -64,3 +65,8 @@ uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
 
 [redfish]
 use_swift = false
+
+[json_rpc]
+auth_strategy = noauth
+host_ip = ::
+port = 8089

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,4 +2,7 @@
 
 . /bin/configure-ironic.sh
 
-exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf
+# Template and write httpd ironic.conf
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic.conf.j2 > /etc/httpd/conf.d/ironic.conf
+
+exec /usr/sbin/httpd -DFOREGROUND

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -6,4 +6,10 @@
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic.conf.j2 > /etc/httpd/conf.d/ironic.conf
 sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
 
+if [ -n "${CERT_FILE}" ]; then
+    inotifywait -m -e delete_self "${CERT_FILE}" | while read file event; do
+        /usr/sbin/httpd -k graceful
+    done &
+fi
+
 exec /usr/sbin/httpd -DFOREGROUND

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -4,5 +4,6 @@
 
 # Template and write httpd ironic.conf
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic.conf.j2 > /etc/httpd/conf.d/ironic.conf
+sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
 
 exec /usr/sbin/httpd -DFOREGROUND

--- a/runironic.sh
+++ b/runironic.sh
@@ -10,7 +10,7 @@ rm -rf /shared/log/ironic
 mkdir -p /shared/log/ironic
 
 /usr/bin/ironic-conductor &
-/usr/bin/ironic-api &
+/bin/runironic-api.sh &
 
 sleep infinity
 

--- a/runironic.sh
+++ b/runironic.sh
@@ -10,7 +10,7 @@ rm -rf /shared/log/ironic
 mkdir -p /shared/log/ironic
 
 /usr/bin/ironic-conductor &
-/bin/runironic-api.sh &
+/bin/runironic-api &
 
 sleep infinity
 


### PR DESCRIPTION
When the certificates used by httpd change (e.g., due to automatic
certificate renewal by cert-manager). We want to reload httpd so it uses
the new certificates. This is achieved by using inotify to get informed
about changes of the files.

As the secrets in k8s are just symlinks to the real files, the event we
see when the certificates are renewed is DELETE_SELF.

**WIP:** This only reloads the httpd for ironic-api. The changes from @maelk need to be integrated first.
