### PR TITLE
Convert httpd and ironic config to be rendered by jinja

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY ./ironic.conf /tmp/ironic.conf
 RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
     rm /tmp/ironic.conf
 
+COPY ./jinjarender.py /bin/jinjarender
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor
 COPY ./runironic-exporter.sh /bin/runironic-exporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,7 @@ COPY --from=builder /tmp/ipxe/src/bin-x86_64-efi/ipxe.efi /tftpboot
 
 COPY --from=builder /tmp/esp.img /tmp/uefi_esp.img
 
-COPY ./ironic.conf /tmp/ironic.conf
-RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
-    rm /tmp/ironic.conf
-
+COPY ./ironic.conf.j2 /etc/ironic/ironic.conf.j2
 COPY ./jinjarender.py /bin/jinjarender
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,7 @@ COPY ./runironic.sh /bin/runironic
 COPY ./dnsmasq.conf.j2 /etc/dnsmasq.conf.j2
 COPY ./inspector.ipxe /tmp/inspector.ipxe
 COPY ./dualboot.ipxe /tmp/dualboot.ipxe
+COPY ./httpd.conf /etc/httpd/conf/httpd.conf
+COPY ./httpd-ironic-image.conf.j2 /etc/httpd/conf.d/ironic-image.conf.j2
 
 ENTRYPOINT ["/bin/runironic"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ All of the containers must share a common mount point or data store.  Ironic req
 
 The following environment variables can be passed in to customize run-time functionality:
 - PROVISIONING_INTERFACE - interface to use for ironic, dnsmasq(dhcpd) and httpd (default provisioning)
-- DNSMASQ_EXCEPT_INTERFACE - interfaces to exclude when providing DHCP address (default "lo")
 - HTTP_PORT - port used by http server (default 80)
 - DHCP_RANGE - dhcp range to use for provisioning (default 172.22.0.10-172.22.0.100)
 - MARIADB_PASSWORD - The database password

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -15,37 +15,7 @@ IRONIC_AUTOMATED_CLEAN=${IRONIC_AUTOMATED_CLEAN:-true}
 
 wait_for_interface_or_ip
 
-cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
-
-crudini --merge /etc/ironic/ironic.conf <<EOF
-[DEFAULT]
-my_ip = $IRONIC_IP
-
-[api]
-host_ip = ::
-api_workers = $NUMWORKERS
-
-[conductor]
-bootloader = http://${IRONIC_URL_HOST}:${HTTP_PORT}/uefi_esp.img
-automated_clean = ${IRONIC_AUTOMATED_CLEAN}
-
-[database]
-connection = mysql+pymysql://ironic:${MARIADB_PASSWORD}@localhost/ironic?charset=utf8
-
-[deploy]
-http_url = http://${IRONIC_URL_HOST}:${HTTP_PORT}
-fast_track = ${IRONIC_FAST_TRACK}
-
-[inspector]
-endpoint_override = http://${IRONIC_URL_HOST}:5050
-# TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
-# not, so working around here.
-# NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
-extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ipa-api-url=http://${IRONIC_URL_HOST}:6385
-
-[service_catalog]
-endpoint_override = http://${IRONIC_URL_HOST}:6385
-EOF
+jinjarender </etc/ironic/ironic.conf.j2 | crudini --merge /etc/ironic/ironic.conf
 
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter

--- a/httpd-ironic-image.conf.j2
+++ b/httpd-ironic-image.conf.j2
@@ -1,0 +1,20 @@
+Listen [::]:{{ env["HTTP_PORT"] }}
+
+<VirtualHost *:{{ env["HTTP_PORT"] }}>
+
+    ErrorLog "/dev/stderr"
+    CustomLog "/dev/stderr" combined
+
+    DocumentRoot "/shared/html"
+    <Directory "/shared">
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+    <Directory "/shared/html">
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+</VirtualHost>

--- a/httpd.conf
+++ b/httpd.conf
@@ -1,0 +1,25 @@
+ServerRoot "/etc/httpd"
+Include conf.modules.d/*.conf
+User apache
+Group apache
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+ErrorLog "/dev/stderr"
+
+LogLevel warn
+
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+CustomLog "/dev/stderr" combined
+TypesConfig /etc/mime.types
+
+AddDefaultCharset UTF-8
+
+MIMEMagicFile conf/magic
+
+EnableSendfile on
+
+IncludeOptional conf.d/*.conf

--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -13,8 +13,13 @@ enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,i
 enabled_power_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ibmc
 enabled_raid_interfaces = no-raid,irmc,agent,fake
 enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake,ibmc
+my_ip = {{ env["IRONIC_IP"] }}
 rpc_transport = json-rpc
 use_stderr = true
+
+[api]
+host_ip = ::
+api_workers = {{ env["NUMWORKERS"] }}
 
 [agent]
 deploy_logs_collect = always
@@ -26,7 +31,8 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 max_command_attempts = 30
 
 [conductor]
-automated_clean = true
+automated_clean = {{ env["IRONIC_AUTOMATED_CLEAN"] }}
+bootloader = http://{{ env["IRONIC_URL_HOST"] }}:{{ env["HTTP_PORT"] }}/uefi_esp.img
 # NOTE(dtantsur): keep aligned with [pxe]boot_retry_timeout below.
 deploy_callback_timeout = 4800
 send_sensor_data = true
@@ -39,13 +45,12 @@ send_sensor_data_interval = 160
 default_boot_option = local
 erase_devices_metadata_priority = 10
 erase_devices_priority = 0
+fast_track = {{ env["IRONIC_FAST_TRACK"] }}
 http_root = /shared/html/
+http_url = http://{{ env["IRONIC_URL_HOST"] }}:{{ env["HTTP_PORT"] }}
 
 [dhcp]
 dhcp_provider = none
-
-[inspector]
-power_off = false
 
 [oslo_messaging_notifications]
 driver = prometheus_exporter
@@ -67,3 +72,9 @@ uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
 
 [redfish]
 use_swift = false
+
+[database]
+connection = mysql+pymysql://ironic:{{ env["MARIADB_PASSWORD"] }}@localhost/ironic?charset=utf8
+
+[service_catalog]
+endpoint_override = http://{{ env["IRONIC_URL_HOST"] }}:6385

--- a/jinjarender.py
+++ b/jinjarender.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import jinja2
+
+rendered = jinja2.Template(sys.stdin.read()).render(env=os.environ)
+sys.stdout.write(rendered)

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -3,7 +3,6 @@
 . /bin/ironic-common.sh
 
 export HTTP_PORT=${HTTP_PORT:-"80"}
-DNSMASQ_EXCEPT_INTERFACE=${DNSMASQ_EXCEPT_INTERFACE:-"lo"}
 
 wait_for_interface_or_ip
 
@@ -16,9 +15,5 @@ cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftp
 
 # Template and write dnsmasq.conf
 jinjarender </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
-
-for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
-    sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf
-done
 
 exec /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -15,7 +15,7 @@ mkdir -p /shared/html/pxelinux.cfg
 cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftpboot
 
 # Template and write dnsmasq.conf
-python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
+jinjarender </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
 
 for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -17,13 +17,6 @@ cp /tmp/uefi_esp.img /shared/html/uefi_esp.img
 # Use configured values
 sed -i -e s/IRONIC_IP/${IRONIC_URL_HOST}/g -e s/HTTP_PORT/${HTTP_PORT}/g /shared/html/inspector.ipxe
 
-sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
-sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
-    -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
-    -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf
-
-# Log to std out/err
-sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
-sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
+jinjarender </etc/httpd/conf.d/ironic-image.conf.j2 >/etc/httpd/conf.d/ironic-image.conf
 
 exec /usr/sbin/httpd -DFOREGROUND


### PR DESCRIPTION
Contains the following changes:
- Make jinja render one-liner a real script
- Remove DNSMASQ_EXCEPT_INTERFACE
- Convert httpd config to static conf + jinja
- Make ironic.conf jinja template driven 