### PR TITLE
Configure ironic to use Ipmitool retries

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -50,7 +50,7 @@ fast_track = ${IRONIC_FAST_TRACK}
 endpoint_override = http://${IRONIC_URL_HOST}:5050
 power_off = ${INSPECTOR_POWER_OFF}
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
-extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ${INSPECTOR_EXTRA_ARGS}
+extra_kernel_params = console=ttyS0 ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ${INSPECTOR_EXTRA_ARGS}
 
 [service_catalog]
 endpoint_override = http://${IRONIC_URL_HOST}:6385

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -5,6 +5,6 @@ echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in
 # ironic-inspector-image and configuration in configure-ironic.sh
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 EXTRA_ARGS initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel console=ttyS0 ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 EXTRA_ARGS initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -15,6 +15,7 @@ enabled_raid_interfaces = no-raid,irmc,agent,fake
 enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake,ibmc
 rpc_transport = json-rpc
 use_stderr = true
+require_agent_token = true
 
 [agent]
 deploy_logs_collect = always

--- a/ironic.conf
+++ b/ironic.conf
@@ -64,3 +64,20 @@ uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
 
 [redfish]
 use_swift = false
+
+[ipmi]
+# use_ipmitool_retries transfers the responsibility of retrying to ipmitool
+# when supported. If set to false, then ipmitool is called as follows :
+#    $ipmitool -R 1 -N 1 ...
+# and Ironic handles the retry loop.
+use_ipmitool_retries = true
+# The following parameters are the defaults in Ironic. They are used in the
+# following way if use_ipmitool_retries is set to true:
+#    $ipmitool -R <X> -N <Y> ...
+# where :
+#    X = command_retry_timeout / min_command_interval
+#    Y = min_command_interval
+# If use_ipmitool_retries is false, then ironic retries X times, with an
+# interval of Y in between each tries.
+min_command_interval = 5
+command_retry_timeout = 60


### PR DESCRIPTION
Without this configuration, the ipmitool timeout is 1 second. This is too short
for vbmc. This commit uses the ipmitool retry feature and extends the
timeout.

This PR also set console=ttyS0 in the IPA kernel parameter to gather IPA logs
in Metal3-dev-env