### PR TITLE
Set the hash ring algorithm to SHA256

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -18,6 +18,8 @@ enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake,ibmc
 rpc_transport = json-rpc
 use_stderr = true
 require_agent_token = true
+# NOTE(dtantsur): the default md5 is not compatible with FIPS mode
+hash_ring_algorithm = sha256
 
 [agent]
 deploy_logs_collect = always


### PR DESCRIPTION
The default MD5 is not compatible with FIPS mode. See
https://bugzilla.redhat.com/show_bug.cgi?id=1853302