### PR TITLE
Limit unauthenticated json-rpc to localhost interface

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -71,7 +71,9 @@ if [ "$USE_HTTP_BASIC" = "true" ]; then
 
 	crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy http_basic
 	crudini --set /etc/ironic/ironic.conf DEFAULT http_basic_auth_user_file /shared/htpasswd-ironic
+
 	crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy http_basic
+	crudini --del /etc/ironic/ironic.conf json_rpc host_ip
 	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_auth_user_file /shared/htpasswd-ironic
 	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_username $IRONIC_HTTP_BASIC_USERNAME
 	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_password $IRONIC_HTTP_BASIC_PASSWORD

--- a/ironic.conf
+++ b/ironic.conf
@@ -38,6 +38,10 @@ send_sensor_data = true
 # be avoided more often than once every sixty seconds.
 send_sensor_data_interval = 160
 
+[json_rpc]
+auth_strategy = noauth
+host_ip = localhost
+
 [deploy]
 default_boot_option = local
 erase_devices_metadata_priority = 10

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -5,6 +5,12 @@
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
+# If the config file has the json-rpc server bound to a specific address
+# (rather than the default ::), use that address as the host name
+if bind_addr="$(crudini --get /etc/ironic/ironic.conf json_rpc host_ip 2>/dev/null)"; then
+  crudini --set /etc/ironic/ironic.conf DEFAULT host ${bind_addr}
+fi
+
 # It's possible for the dbsync to fail if mariadb is not up yet, so
 # retry until success
 until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do

--- a/runironic.sh
+++ b/runironic.sh
@@ -2,6 +2,8 @@
 
 . /bin/configure-ironic.sh
 
+crudini --set /etc/ironic/ironic.conf DEFAULT host localhost
+
 ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
 
 # Remove log files from last deployment


### PR DESCRIPTION
By default, ironic-conductor currently binds to any IP address, so it is
accessible outside of the pod. When no authentication method is used for
json-rpc, bind only to localhost so that only other containers in the
same pod can connect to the json-rpc server.

This will break any deployments that put ironic-conductor and ironic-api
in separate pods but do not specify basic_auth. This is probably a good
thing.