### PR TITLE
Exit if ironic-api or ironic-conductor exits

### DIFF
--- a/runironic.sh
+++ b/runironic.sh
@@ -12,5 +12,4 @@ mkdir -p /shared/log/ironic
 /usr/bin/ironic-conductor &
 /usr/bin/ironic-api &
 
-sleep infinity
-
+wait -n


### PR DESCRIPTION
Using the default entrypoint, which runs both the ironic-api and
ironic-conductor processes in the same container, the container should
exit immediately if either of those processes ends.