### PR TITLE
Configure ironic-conductor to auth to ironic-inspector

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -80,12 +80,12 @@ fi
 
 
 # Configure auth for clients
-IRONIC_API_CONFIG_OPTIONS="--config-file /usr/share/ironic/ironic-dist.conf --config-file /etc/ironic/ironic.conf"
+IRONIC_CONFIG_OPTIONS="--config-file /etc/ironic/ironic.conf"
 
 configure_client_basic_auth() {
     local auth_config_file="/auth/$1/auth-config"
     if [ -f ${auth_config_file} ]; then
-        IRONIC_API_CONFIG_OPTIONS+=" --config-file ${auth_config_file}"
+        IRONIC_CONFIG_OPTIONS+=" --config-file ${auth_config_file}"
     fi
 }
 

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,4 +2,4 @@
 
 . /bin/configure-ironic.sh
 
-exec /usr/bin/ironic-api ${IRONIC_API_CONFIG_OPTIONS}
+exec /usr/bin/ironic-api --config-file /usr/share/ironic/ironic-dist.conf ${IRONIC_CONFIG_OPTIONS}

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -25,4 +25,4 @@ until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
   sleep 1
 done
 
-exec /usr/bin/ironic-conductor --config-file /etc/ironic/ironic.conf
+exec /usr/bin/ironic-conductor ${IRONIC_CONFIG_OPTIONS}

--- a/runironic.sh
+++ b/runironic.sh
@@ -11,8 +11,8 @@ rm -rf /shared/log/ironic
 
 mkdir -p /shared/log/ironic
 
-/usr/bin/ironic-conductor &
-/usr/bin/ironic-api ${IRONIC_API_CONFIG_OPTIONS} &
+/usr/bin/ironic-conductor ${IRONIC_CONFIG_OPTIONS} &
+/usr/bin/ironic-api --config-file /usr/share/ironic/ironic-dist.conf ${IRONIC_CONFIG_OPTIONS} &
 
 sleep infinity
 


### PR DESCRIPTION
The ironic-conductor process needs to authenticate to the
ironic-inspector API, so we need to pass the auth config file options to
it also.