### PR TITLE
Disable bios interfaces idrac-wsman

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -5,7 +5,6 @@ default_boot_interface = ipxe
 default_deploy_interface = direct
 default_inspect_interface = inspector
 default_network_interface = noop
-enabled_bios_interfaces = idrac-wsman
 enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media,idrac-redfish-virtual-media
 enabled_deploy_interfaces = direct,fake
 # NOTE(dtantsur): when changing this, make sure to update the driver


### PR DESCRIPTION
A temporary fix for the issue #188 

We can enable idrac once we have done proper investigation.  

 