### PR TITLE
Add support for noop management and manual-management

### DIFF
--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -15,9 +15,9 @@ enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media,idrac-redfish-virt
 enabled_deploy_interfaces = direct,fake
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
-enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,ibmc
+enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,ibmc,manual-management
 enabled_inspect_interfaces = inspector,idrac,irmc,fake,redfish
-enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ibmc
+enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ibmc,noop
 enabled_power_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ibmc
 enabled_raid_interfaces = no-raid,irmc,agent,fake,ibmc,idrac-wsman
 enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake,ibmc
@@ -157,6 +157,10 @@ tftp_master_path = /shared/tftpboot
 tftp_root = /shared/tftpboot
 uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
 pxe_append_params = nofb nomodeset vga=normal ipa-insecure=1
+# This makes networking boot templates generated even for nodes using local
+# boot (the default), ensuring that they boot correctly even if they start
+# netbooting for some reason (e.g. with the noop management interface).
+enable_netboot_fallback = true
 
 [redfish]
 use_swift = false


### PR DESCRIPTION
This adds three closely related features:
* The noop management interface allows skip management actions
  (boot device and mode) for a node. The PXE netboot fallback
  is enabled for it to be able to local boot properly.
* The manual-management hardware type also skips power actions.

This change misses the agent power interface that can allow
the manual-management hardware type to use a running agent
for power actions to achieve a limited deploy capability
without BMC credentials [1]. We need to enable it conditional
on fast-track (and it's disabled in the metal3 CI).

[1] https://docs.openstack.org/ironic/latest/admin/agent-power.html