### PR TITLE
Explicitly set json_rpc.auth_strategy to noauth

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -76,6 +76,9 @@ set_http_basic_server_auth_strategy() {
 # Configure HTTP basic auth for ironic-api server
 if [ -f "${HTPASSWD_FILE}" ]; then
     set_http_basic_server_auth_strategy
+    # We've just set the DEFAULT auth_strategy to http_basic, we need to
+    # set the json_rpc auth_strategy back to noauth
+    crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy noauth
 fi
 
 

--- a/ironic.conf
+++ b/ironic.conf
@@ -42,7 +42,9 @@ send_sensor_data = true
 send_sensor_data_interval = 160
 
 [json_rpc]
-auth_strategy = noauth
+# crudini doesn't merge this into ironic.conf as it sees it as redundant (its set globably in DEFAULT)
+# so we set it in configure-ironic.sh if we change the DEFAULT
+# auth_strategy = noauth
 host_ip = localhost
 
 [deploy]


### PR DESCRIPTION
Using crudini to merge this into ironic.conf no longer
works as it gets ignored as it matches the DEFAULT and
it is redundant. But later we then change the DEFAULT in
set_http_basic_server_auth_strategy so we need to set
json_rpc.auth_strategy back to noauth.

Fixes: https://github.com/openshift-metal3/dev-scripts/issues/1099
