### PR TITLE
add dhcp-sequential-ip to dnsmasq config

### DIFF
--- a/dnsmasq.conf.j2
+++ b/dnsmasq.conf.j2
@@ -9,6 +9,7 @@ port=0
 {%- if env["DHCP_RANGE"]|length %}
 log-dhcp
 dhcp-range={{ env["DHCP_RANGE"] }}
+dhcp-sequential-ip
 
 # Disable default router(s) and DNS over provisioning network
 dhcp-option=3


### PR DESCRIPTION
To prevent collisions on address allocation for MAC addresses
that are too close to each other when starting nodes in batch

Fixes: #195 