### PR TITLE
Add TLS support in Ironic configuration

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/bash
 
+export IRONIC_CERT_FILE=/certs/ironic/tls.crt
+export IRONIC_KEY_FILE=/certs/ironic/tls.key
+export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
+export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
+
+mkdir -p /certs/ironic
+mkdir -p /certs/ironic-inspector
+mkdir -p /certs/ca/ironic
+mkdir -p /certs/ca/ironic-inspector
+
+if [ -f "$IRONIC_CERT_FILE" ] && [ ! -f "$IRONIC_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate key file /certs/ironic/key"
+    exit 1
+fi
+if [ ! -f "$IRONIC_CERT_FILE" ] && [ -f "$IRONIC_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate file /certs/ironic/crt"
+    exit 1
+fi
+
 . /bin/ironic-common.sh
 
 export HTTP_PORT=${HTTP_PORT:-"80"}
@@ -16,6 +36,28 @@ export IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
 export IRONIC_AUTOMATED_CLEAN=${IRONIC_AUTOMATED_CLEAN:-true}
 
 wait_for_interface_or_ip
+
+if [ -f "$IRONIC_CERT_FILE" ]; then
+    export IRONIC_TLS_SETUP="true"
+    export IRONIC_BASE_URL="https://${IRONIC_URL_HOST}:6385"
+    if [ ! -f "$IRONIC_CACERT_FILE" ]; then
+        cp "$IRONIC_CERT_FILE" "$IRONIC_CACERT_FILE"
+    fi
+else
+    export IRONIC_TLS_SETUP="false"
+    export IRONIC_BASE_URL="http://${IRONIC_URL_HOST}:6385"
+fi
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ] || [ -f "$IRONIC_INSPECTOR_CACERT_FILE" ]; then
+    export IRONIC_INSPECTOR_TLS_SETUP="true"
+    export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5050"
+    if [ ! -f "$IRONIC_INSPECTOR_CACERT_FILE" ]; then
+        cp "$IRONIC_INSPECTOR_CERT_FILE" "$IRONIC_INSPECTOR_CACERT_FILE"
+    fi
+else
+    export IRONIC_INSPECTOR_TLS_SETUP="false"
+    export IRONIC_INSPECTOR_BASE_URL="http://${IRONIC_URL_HOST}:5050"
+fi
 
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -5,6 +5,6 @@ echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in
 # ironic-inspector-image and configuration in configure-ironic.sh
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel console=ttyS0 ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 EXTRA_ARGS initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel console=ttyS0 ipa-insecure=1 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 EXTRA_ARGS initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -50,6 +50,9 @@ max_command_attempts = 30
 [api]
 host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
 api_workers = {{ env.NUMWORKERS }}
+{% if env.IRONIC_TLS_SETUP == "true" %}
+enable_ssl_api = true
+{% endif %}
 
 [conductor]
 automated_clean = {{ env.IRONIC_AUTOMATED_CLEAN }}
@@ -77,12 +80,15 @@ fast_track = {{ env.IRONIC_FAST_TRACK }}
 dhcp_provider = none
 
 [inspector]
-endpoint_override = http://{{ env.IRONIC_URL_HOST }}:5050
+endpoint_override = {{ env.IRONIC_INSPECTOR_BASE_URL }}
 power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
+{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" %}
+cafile = {{ env.IRONIC_INSPECTOR_CACERT_FILE }}
+{% endif %}
 # TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
 # not, so working around here.
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
-extra_kernel_params = console=ttyS0 ipa-insecure=1 ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {% if env.IRONIC_FAST_TRACK == "true" %} ipa-api-url=http://{{ env.IRONIC_URL_HOST }}:6385 {% endif %}
+extra_kernel_params = console=ttyS0 ipa-insecure=1 ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {% if env.IRONIC_FAST_TRACK == "true" %} ipa-api-url={{ env.IRONIC_BASE_URL }} {% endif %}
 
 [ipmi]
 # use_ipmitool_retries transfers the responsibility of retrying to ipmitool
@@ -101,7 +107,6 @@ use_ipmitool_retries = true
 min_command_interval = 5
 command_retry_timeout = 60
 
-
 [json_rpc]
 # We assume that when we run API and conductor in the same container, they use
 # authentication over localhost, using the same credentials as API, to prevent
@@ -116,6 +121,10 @@ http_basic_auth_user_file = /etc/ironic/htpasswd-rpc
 host_ip = localhost
 {% else %}
 host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+{% endif %}
+{% if env.IRONIC_TLS_SETUP == "true" %}
+use_ssl = true
+cafile = {{ env.IRONIC_CACERT_FILE }}
 {% endif %}
 
 [oslo_messaging_notifications]
@@ -142,4 +151,10 @@ use_swift = false
 kernel_append_params = console=ttyS0 nofb nomodeset vga=normal ipa-insecure=1
 
 [service_catalog]
-endpoint_override = http://{{ env.IRONIC_URL_HOST }}:6385
+endpoint_override = {{ env.IRONIC_BASE_URL }}
+
+{% if env.IRONIC_TLS_SETUP == "true" %}
+[ssl]
+cert_file = {{ env.IRONIC_CERT_FILE }}
+key_file = {{ env.IRONIC_KEY_FILE }}
+{% endif %}

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -2,6 +2,7 @@
 
 . /bin/ironic-common.sh
 
+IRONIC_CERT_FILE=/certs/ironic/tls.crt
 HTTP_PORT=${HTTP_PORT:-"80"}
 
 # Whether to enable fast_track provisioning or not
@@ -12,10 +13,16 @@ wait_for_interface_or_ip
 mkdir -p /shared/html
 chmod 0777 /shared/html
 
-if [[ $IRONIC_FAST_TRACK == true ]]; then
-    INSPECTOR_EXTRA_ARGS="ipa-api-url=http://${IRONIC_URL_HOST}:6385"
+if [ -f "$IRONIC_CERT_FILE" ]; then
+    IRONIC_BASE_URL="https://${IRONIC_URL_HOST}"
 else
-    INSPECTOR_EXTRA_ARGS=""
+    IRONIC_BASE_URL="http://${IRONIC_URL_HOST}"
+fi
+
+if [[ $IRONIC_FAST_TRACK == true ]]; then
+    INSPECTOR_EXTRA_ARGS=" ipa-api-url=${IRONIC_BASE_URL}:6385 ipa-inspection-callback-url=${IRONIC_BASE_URL}:5050/v1/continue"
+else
+    INSPECTOR_EXTRA_ARGS=" ipa-inspection-callback-url=${IRONIC_BASE_URL}:5050/v1/continue"
 fi
 
 # Copy files to shared mount


### PR DESCRIPTION
This commit allows the user to start Ironic using TLS on all
endpoints, by setting the following environment variables:

- CACERT_FILE: path to the CA cert
- CERT_FILE: path to the cert
- KEY_FILE: path to the key