### PR TITLE
Install configure for syslinux-nonlinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN dnf install -y python3 python3-requests && \
         iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk psmisc \
         mariadb-server genisoimage python3-ironic-prometheus-exporter \
         python3-jinja2 python3-sushy-oem-idrac python3-ibmcclient \
-        ipmitool python3-dracclient python3-scciclient python3-sushy && \
+        ipmitool python3-dracclient python3-scciclient python3-sushy syslinux-nonlinux && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 

--- a/ironic.conf
+++ b/ironic.conf
@@ -22,6 +22,8 @@ require_agent_token = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
 
+isolinux_bin = /usr/share/syslinux/isolinux.bin
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy


### PR DESCRIPTION
ironic needs syslinux-nonlinux to generate a
bootable ISO image for virtmedia install on bios.