### PR TITLE
Add basic authentication setup for json-rpc

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -76,6 +76,7 @@ set_http_basic_server_auth_strategy() {
 # Configure HTTP basic auth for ironic-api server
 if [ -f "${HTPASSWD_FILE}" ]; then
     set_http_basic_server_auth_strategy
+    set_http_basic_server_auth_strategy json-rpc
 fi
 
 


### PR DESCRIPTION
The default htpasswd file is incorrect when using basic auth
for json rpc. This sets the configuration properly.

This approach goes against https://github.com/metal3-io/ironic-image/pull/196 . We have a requirement to authenticate all endpoints of Ironic, even if listening only on the loopback interface. So we would prefer this fix over removing the authentication on json_rpc.

/cc @dtantsur 
/cc @zaneb 
/cc @dhellmann 