### PR TITLE
Make sensor_data collection configurable

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -35,6 +35,9 @@ export IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
 # Whether cleaning disks before and after deployment
 export IRONIC_AUTOMATED_CLEAN=${IRONIC_AUTOMATED_CLEAN:-true}
 
+# Wheter to enable the sensor data collection
+export SEND_SENSOR_DATA=${SEND_SENSOR_DATA:-false}
+
 wait_for_interface_or_ip
 
 if [ -f "$IRONIC_CERT_FILE" ]; then

--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -58,7 +58,7 @@ enable_ssl_api = true
 automated_clean = {{ env.IRONIC_AUTOMATED_CLEAN }}
 # NOTE(dtantsur): keep aligned with [pxe]boot_retry_timeout below.
 deploy_callback_timeout = 4800
-send_sensor_data = false
+send_sensor_data = {{ env.SEND_SENSOR_DATA }} 
 # NOTE(TheJulia): Do not lower this value below 120 seconds.
 # Power state is checked every 60 seconds and BMC activity should
 # be avoided more often than once every sixty seconds.


### PR DESCRIPTION
Previously we disabled for some reason, but we had people using
the ironic prometheus exporter in Metal3.

Add a new env variable `SEND_SENSOR_DATA` that will be used to
define if it will be enabled or not.