### PR TITLE
Provide a way to apply upstream patches to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,10 @@ FROM docker.io/centos:centos8
 
 ENV PKGS_LIST=main-packages-list.txt
 ARG EXTRA_PKGS_LIST
+ARG PATCH_LIST
 
-COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST} /tmp/
-COPY prepare-image.sh /bin/
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST} ${PATCH_LIST} /tmp/
+COPY prepare-image.sh patch-image.sh /bin/
 
 RUN prepare-image.sh && \
   rm -f /bin/prepare-image.sh

--- a/README.md
+++ b/README.md
@@ -43,3 +43,16 @@ The ironic configuration can be overridden by various environment variables. The
 - OS_CONDUCTOR__INSPECT_TIMEOUT=1800 - timeout (seconds) for waiting for node inspection
 - OS_CONDUCTOR__CLEAN_CALLBACK_TIMEOUT=1800 - timeout (seconds) to wait for a callback from the ramdisk doing the cleaning
 - OS_PXE__BOOT_RETRY_TIMEOUT=1200 - timeout (seconds) to enable boot retries.
+
+Applying Patches to the image
+-----------------------------
+
+When building the image, it is possible to specify a patch of one or more
+upstream projects to apply to the image, passing a file with the patch list
+using the PATCH_LIST build argument.
+At the moment, only projects hosted in opendev.org are supported.
+
+Each line of the file is in the form "project_dir refspec" where:
+- project is the last part of the project url including the org, for example openstack/ironic
+- refspec is the gerrit refspec of the patch we want to test, for example refs/changes/67/759567/1
+

--- a/patch-image.sh
+++ b/patch-image.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+set -ex
+
+patch_file="/tmp/${PATCH_LIST}"
+
+while IFS= read -r line
+do
+    # each line is in the form "project_dir refsspec" where:
+    # - project is the last part of the project url including the org,
+    # for example openstack/ironic
+    # - refspec is the gerrit refspec of the patch we want to test,
+    # for example refs/changes/67/759567/1
+    PROJECT=$(echo $line | cut -d " " -f1)
+    PROJ_NAME=$(echo $PROJECT | cut -d "/" -f2)
+    PROJ_URL="https://opendev.org/$PROJECT"
+    REFSPEC=$(echo $line | cut -d " " -f2)
+
+    cd /tmp
+    git clone "$PROJ_URL"
+    cd "$PROJ_NAME"
+    git fetch "$PROJ_URL" "$REFSPEC"
+    git checkout FETCH_HEAD
+
+    SKIP_GENERATE_AUTHORS=1 SKIP_WRITE_GIT_CHANGELOG=1 python3 setup.py sdist
+    pip3 install dist/*.tar.gz
+done < "$patch_file"
+
+cd /
+

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -13,3 +13,9 @@ if [[ ! -z ${EXTRA_PKGS_LIST} ]]; then
 fi
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
+if [[ ! -z ${PATCH_LIST} ]]; then
+    if [[ -s "/tmp/${PATCH_LIST}" ]]; then
+        /bin/patch-image.sh;
+    fi
+fi
+rm -f /bin/patch-image.sh


### PR DESCRIPTION
This change allows users to apply patches to the images during build
time directly from gerrit using the new arg PATCH.
At the moment, it's limited to a single project per image; future
patches will allow applying patches from multiple projects, and
also from local directories.