### PR TITLE
Use [] around IPv6 address for conductor host config

### DIFF
--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -33,7 +33,7 @@ my_ip = {{ env.IRONIC_IP }}
 # If we run both API and conductor in the same pod, use localhost
 host = localhost
 {% else %}
-host = {{ env.IRONIC_IP }}
+host = {{ env.IRONIC_URL_HOST }}
 {% endif %}
 
 isolinux_bin = /usr/share/syslinux/isolinux.bin


### PR DESCRIPTION
Work around https://storyboard.openstack.org/#!/story/2008288 by setting
the DEFAULT.host config option to the host portion of a URL, meaning
that IPv6 addresses are surrounded by [], rather than just the raw IP
address. This is how it is ultimately used inside Ironic.

This solution works both with and without the fix for the issue in
Ironic (https://review.opendev.org/759877).

Fixes #210