### PR TITLE
Secure boot compatible ESP image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,15 @@ RUN git clone https://github.com/ipxe/ipxe.git && \
 ## of the ESP image file to be sized smaller for the files that need to
 ## be copied in, however that requires more advanced scripting beyond
 ## an MVP.
-## NOTE(derekh): We need to build our own grub image because the one
-## that gets installed by grub2-efi-x64 (/boot/efi/EFI/centos/grubx64.efi)
-## looks for grub.cnf in /EFI/centos, ironic puts it in /boot/grub
 RUN if [ $(uname -m) = "x86_64" ]; then \
-      dnf install -y genisoimage grub2 grub2-efi-x64-modules shim dosfstools mtools && \
+      dnf install -y genisoimage grub2 grub2-efi-x64 shim dosfstools mtools && \
       dd bs=1024 count=3200 if=/dev/zero of=esp.img && \
       mkfs.msdos -F 12 -n 'ESP_IMAGE' ./esp.img && \
       mmd -i esp.img EFI && \
       mmd -i esp.img EFI/BOOT && \
-      grub2-mkimage -C xz -O x86_64-efi -p /boot/grub -o /tmp/grubx64.efi boot linux search normal configfile part_gpt btrfs ext2 fat iso9660 loopback test keystatus gfxmenu regexp probe efi_gop efi_uga all_video gfxterm font scsi echo read ls cat png jpeg halt reboot && \
+      mmd -i esp.img EFI/centos && \
       mcopy -i esp.img -v /boot/efi/EFI/BOOT/BOOTX64.EFI ::EFI/BOOT && \
-      mcopy -i esp.img -v /tmp/grubx64.efi ::EFI/BOOT && \
+      mcopy -i esp.img -v /boot/efi/EFI/centos/grubx64.efi ::EFI/centos && \
       mdir -i esp.img ::EFI/BOOT; \
     else \
       touch /tmp/esp.img; \

--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -38,6 +38,10 @@ host = {{ env.IRONIC_URL_HOST }}
 
 isolinux_bin = /usr/share/syslinux/isolinux.bin
 
+# NOTE(dtantsur): this path is specific to the GRUB image that is built into
+# the ESP provided in [conductor]bootloader.
+grub_config_path = EFI/centos/grub.cfg
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy


### PR DESCRIPTION
Avoid rebuilding GRUB2 since it invalidates its signature. Ironic
is able to build correct ISO images if you provide it with
a distribution specific EFI config path.

See https://review.opendev.org/760434