### PR TITLE
Use collector config param in ironic.conf expected by IPA

### DIFF
--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -92,7 +92,7 @@ cafile = {{ env.IRONIC_INSPECTOR_CACERT_FILE }}
 # TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
 # not, so working around here.
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
-extra_kernel_params = console=ttyS0 ipa-insecure=1 ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {% if env.IRONIC_FAST_TRACK == "true" %} ipa-api-url={{ env.IRONIC_BASE_URL }} {% endif %}
+extra_kernel_params = console=ttyS0 ipa-insecure=1 ipa-inspection-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {% if env.IRONIC_FAST_TRACK == "true" %} ipa-api-url={{ env.IRONIC_BASE_URL }} {% endif %}
 
 [ipmi]
 # use_ipmitool_retries transfers the responsibility of retrying to ipmitool


### PR DESCRIPTION
This had been fixed already but the wrong name came back,
presumably missed on a rebase.