### PR TITLE
Introduce separate ARG for extra packages list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,10 @@ RUN if [ $(uname -m) = "x86_64" ]; then \
 
 FROM docker.io/centos:centos8
 
-ARG PKGS_LIST=main-packages-list.txt
+ENV PKGS_LIST=main-packages-list.txt
+ARG EXTRA_PKGS_LIST
 
-COPY ${PKGS_LIST} /tmp/main-packages-list.txt
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST} /tmp/
 COPY prepare-image.sh /bin/
 
 RUN prepare-image.sh && \

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -5,6 +5,11 @@ set -ex
 dnf install -y python3 python3-requests
 curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo
 dnf upgrade -y
-dnf --setopt=install_weak_deps=False install -y $(cat /tmp/main-packages-list.txt)
+dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${PKGS_LIST})
+if [[ ! -z ${EXTRA_PKGS_LIST} ]]; then
+    if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
+        dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${EXTRA_PKGS_LIST})
+    fi
+fi
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
Convert the current PKGS_LIST to ENV as we should not really touch it.
Introduce the EXTRA_PKGS_LIST ARG to allow specifying a file
containing a list of extra packages to install.
The goal is to allow installing packages from different sources
to test them.