### PR TITLE
Add options to disable TLS validations

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -3,8 +3,12 @@
 export IRONIC_CERT_FILE=/certs/ironic/tls.crt
 export IRONIC_KEY_FILE=/certs/ironic/tls.key
 export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
+export IRONIC_INSECURE=${IRONIC_INSECURE:-false}
+
 export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_INSECURE=${IRONIC_INSPECTOR_INSECURE:-$IRONIC_INSECURE}
+
 export MARIADB_CACERT_FILE=/certs/ca/mariadb/tls.crt
 
 mkdir -p /certs/ironic

--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -94,6 +94,7 @@ endpoint_override = {{ env.IRONIC_INSPECTOR_BASE_URL }}
 power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
 {% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" %}
 cafile = {{ env.IRONIC_INSPECTOR_CACERT_FILE }}
+insecure = {{ env.IRONIC_INSPECTOR_INSECURE }}
 {% endif %}
 # TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
 # not, so working around here.
@@ -135,6 +136,7 @@ host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env
 {% if env.IRONIC_TLS_SETUP == "true" %}
 use_ssl = true
 cafile = {{ env.IRONIC_CACERT_FILE }}
+insecure = {{ env.IRONIC_INSECURE }}
 {% endif %}
 
 [oslo_messaging_notifications]


### PR DESCRIPTION
We excluded these options from the initial proposal because they
reduce security. But since the provisioning IP may not be easily
predicted, it may be hard to generate suitable certificates, so
the insecure option is added to fascilitate two-step migration
from fully insecure HTTP to fully secure HTTPS.