### PR TITLE
Supply a default for COPY args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV PKGS_LIST=main-packages-list.txt
 ARG EXTRA_PKGS_LIST
 ARG PATCH_LIST
 
-COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST} ${PATCH_LIST} /tmp/
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
 COPY prepare-image.sh patch-image.sh /bin/
 
 RUN prepare-image.sh && \


### PR DESCRIPTION
Supplying a blank arg to COPY results in all of
the files in the source directory being copied into
the image into /tmp for docker/podman build (or "/"
if using imagebuilder). Give it a default of a file
that exists to avoid this happening.