### PR TITLE
Configure conductor heartbeat timeout

### DIFF
--- a/config/ironic.conf.j2
+++ b/config/ironic.conf.j2
@@ -60,6 +60,7 @@ enable_ssl_api = true
 
 [conductor]
 automated_clean = {{ env.IRONIC_AUTOMATED_CLEAN }}
+heartbeat_timeout = {{ env.IRONIC_HEARTBEAT_TIMEOUT }}
 # NOTE(dtantsur): keep aligned with [pxe]boot_retry_timeout below.
 deploy_callback_timeout = 4800
 send_sensor_data = {{ env.SEND_SENSOR_DATA }} 

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -25,6 +25,9 @@ if [ ! -f "$IRONIC_CERT_FILE" ] && [ -f "$IRONIC_KEY_FILE" ] ; then
     exit 1
 fi
 
+# Configure IRONIC_HEARTBEAT_TIMEOUT 
+export IRONIC_HEARTBEAT_TIMEOUT="${IRONIC_HEARTBEAT_TIMEOUT:-60}"
+
 . /bin/ironic-common.sh
 
 export HTTP_PORT=${HTTP_PORT:-"80"}


### PR DESCRIPTION
This PR enables ironic conductor's hearbeat timeout to be configurable through env/configmap. The goal is to make the IPA hearbeat checkup interval configurable as described here https://docs.openstack.org/ironic-python-agent/mitaka/#heartbeat