### PR TITLE
Restart Ironic when certificate is updated

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -2,7 +2,8 @@
 
 set -euxo pipefail
 
-dnf install -y python3 python3-requests
+dnf install -y python3 python3-requests epel-release 'dnf-command(config-manager)'
+dnf config-manager --set-disabled epel
 curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream
 dnf upgrade -y
 xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${PKGS_LIST}
@@ -11,7 +12,7 @@ if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
         xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${EXTRA_PKGS_LIST}
     fi
 fi
-
+dnf install -y --enablerepo=epel inotify-tools
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
 if [[ ! -z ${PATCH_LIST:-} ]]; then

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -8,6 +8,7 @@ export IRONIC_INSECURE=${IRONIC_INSECURE:-false}
 export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_INSECURE=${IRONIC_INSPECTOR_INSECURE:-$IRONIC_INSECURE}
+export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 
 # Define the VLAN interfaces to be included in introspection report, e.g.
 #   all - all VLANs on all interfaces using LLDP information

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -10,6 +10,7 @@ INSPECTOR_RESULT_HTTPD_CONFIG=/etc/httpd/conf.d/ironic-inspector.conf
 export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key
 export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"false"}
+export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 
 # Whether to enable fast_track provisioning or not
 IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
@@ -73,5 +74,11 @@ sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
 # Log to std out/err
 sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
 sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
+
+if [[ "$IRONIC_INSPECTOR_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    inotifywait -m -e delete_self "${IRONIC_INSPECTOR_CERT_FILE}" | while read file event; do
+      kill -WINCH $(pgrep httpd)
+    done &
+fi
 
 exec /usr/sbin/httpd -DFOREGROUND

--- a/scripts/runironic-api
+++ b/scripts/runironic-api
@@ -19,5 +19,12 @@ done
 
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic.conf
 sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
+
+if [[ "$IRONIC_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read file event; do
+      kill -WINCH $(pgrep httpd)
+    done &
+fi
+
 exec /usr/sbin/httpd -DFOREGROUND
 

--- a/scripts/runironic-conductor
+++ b/scripts/runironic-conductor
@@ -13,4 +13,11 @@ until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
   echo "WARNING: ironic-dbsync failed, retrying"
   sleep 1
 done
+
+if [[ "$IRONIC_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read file event; do
+     kill $(pgrep ironic)
+    done &
+fi
+
 exec /usr/bin/ironic-conductor

--- a/scripts/runmariadb
+++ b/scripts/runmariadb
@@ -5,6 +5,7 @@ MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 MARIADB_CONF_FILE="/etc/my.cnf.d/mariadb-server.cnf"
 MARIADB_CERT_FILE=/certs/mariadb/tls.crt
 MARIADB_KEY_FILE=/certs/mariadb/tls.key
+RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 
 mkdir -p $(dirname ${MARIADB_CERT_FILE})
 if [ -f "$MARIADB_CERT_FILE" ] && [ ! -f "$MARIADB_KEY_FILE" ] ; then
@@ -18,6 +19,13 @@ fi
 
 ln -sf /proc/self/fd/1 /var/log/mariadb/mariadb.log
 rm -f /usr/bin/mysqld_safe_helper # Avoid this script being used which results in a permission denied error.
+
+# Restart mysqld when the certificate is updated
+if [[ -f "$MARIADB_CERT_FILE" && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    inotifywait -m -e delete_self "${MARIADB_CERT_FILE}" | while read file event; do
+       kill $(pgrep -f mysqld)
+    done &
+fi
 
 if [ ! -d "${DATADIR}/mysql" ]; then
     crudini --set "$MARIADB_CONF_FILE" mysqld max_connections 64


### PR DESCRIPTION
When the TLS certificate is updated, Ironic will reload (or restart) to get the new certificate.