### PR TITLE
Remove net-tools installation

### DIFF
--- a/ironic-scripts/runironic-api
+++ b/ironic-scripts/runironic-api
@@ -14,10 +14,7 @@ while true ; do
   sleep 5
 done
 
-
-# TODO: Delete the line of code below and uncomment the next line after the PR https://github.com/metal3-io/baremetal-operator/pull/728 goes in
-[ ! "$(netstat -l | grep ${HTTP_PORT})" ] && . /bin/configure-httpd-ipa.sh  
-# . /bin/configure-httpd-ipa.sh  
+. /bin/configure-httpd-ipa.sh  
 # The code above avoids the httpd instance in this container to listen on port HTTP_PORT when it has been opened by BMO.
 
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic.conf

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -12,9 +12,6 @@ if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     fi
 fi
 
-# TODO: Delete the below line of code after the PR https://github.com/metal3-io/baremetal-operator/pull/728 go in
-dnf install -y net-tools
-
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
 if [[ ! -z ${PATCH_LIST:-} ]]; then


### PR DESCRIPTION
Now that https://github.com/metal3-io/baremetal-operator/pull/728 has
merged, we can remove net-tools installation command.