### PR TITLE
fix: ensure dualboot.ipxe read permission for others

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY ironic-config/ironic.conf.j2 /etc/ironic/
 COPY ironic-scripts/ /bin/
 COPY ironic-config/dnsmasq.conf.j2 /etc/
 COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe /tmp/
+RUN chmod 644 /tmp/dualboot.ipxe
 
 # Custom httpd config, removes all but the bare minimum needed modules
 RUN rm -f /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf


### PR DESCRIPTION
In order for ipxe to read this dualboot.ipxe, the file has to be readable.
This can be a problem if the image was built on systems with a strict umask
such as 0027. Ensure the file is readable using chmod in Dockerfile.

Otherwise one might see errors like the following:

```
Filename: http://21.0.12.28:6180/dualboot.ipxe
http://21.0.12.28:6180/dualboot.ipxe... Operation not permitted (http://ipxe.org/410c618f)
```