### PR TITLE
Merge ironic and ironic-inspector repositories, 2 Dockerfiles

### DIFF
--- a/Dockerfile.ironic
+++ b/Dockerfile.ironic
@@ -1,0 +1,62 @@
+## Build iPXE w/ IPv6 Support
+## Note: we are pinning to a specific commit for reproducible builds.
+## Updated as needed.
+FROM docker.io/centos:centos8 AS ironic-builder
+RUN dnf install -y gcc git make xz-devel
+WORKDIR /tmp
+COPY . .
+RUN git clone https://github.com/ipxe/ipxe.git && \
+      cd ipxe && \
+      git checkout 3fe683ebab29afacf224e6b0921f6329bebcdca7 && \
+      cd src && \
+      sed -i -e "s/#undef.*NET_PROTO_IPV6/#define NET_PROTO_IPV6/g" config/general.h && \
+      make bin/undionly.kpxe bin-x86_64-efi/ipxe.efi bin-x86_64-efi/snponly.efi
+
+## TODO(TheJulia): At some point we may want to try and make the size
+## of the ESP image file to be sized smaller for the files that need to
+## be copied in, however that requires more advanced scripting beyond
+## an MVP.
+RUN if [ $(uname -m) = "x86_64" ]; then \
+      dnf install -y genisoimage grub2 grub2-efi-x64 shim dosfstools mtools && \
+      dd bs=1024 count=3200 if=/dev/zero of=esp.img && \
+      mkfs.msdos -F 12 -n 'ESP_IMAGE' ./esp.img && \
+      mmd -i esp.img EFI && \
+      mmd -i esp.img EFI/BOOT && \
+      mcopy -i esp.img -v /boot/efi/EFI/BOOT/BOOTX64.EFI ::EFI/BOOT && \
+      mcopy -i esp.img -v /boot/efi/EFI/centos/grubx64.efi ::EFI/BOOT && \
+      mdir -i esp.img ::EFI/BOOT; \
+    else \
+      touch /tmp/esp.img; \
+    fi
+
+FROM docker.io/centos:centos8
+
+ENV PKGS_LIST=ironic-packages-list.txt
+ARG EXTRA_PKGS_LIST
+ARG PATCH_LIST
+
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
+COPY prepare-image.sh patch-image.sh /bin/
+
+RUN prepare-image.sh && \
+  rm -f /bin/prepare-image.sh
+
+RUN chown ironic:ironic /var/log/ironic && \
+  # This file is generated after installing mod_ssl and it affects our configuration
+  rm -f /etc/httpd/conf.d/ssl.conf
+
+COPY --from=ironic-builder /tmp/ipxe/src/bin/undionly.kpxe /tmp/ipxe/src/bin-x86_64-efi/snponly.efi /tmp/ipxe/src/bin-x86_64-efi/ipxe.efi /tftpboot/
+
+COPY --from=ironic-builder /tmp/esp.img /tmp/uefi_esp.img
+
+COPY ironic-config/ironic.conf.j2 /etc/ironic/
+
+COPY ironic-scripts/ /bin/
+COPY ironic-config/dnsmasq.conf.j2 /etc/
+COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe /tmp/
+
+# Custom httpd config, removes all but the bare minimum needed modules
+RUN rm -f /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf
+COPY ironic-config/httpd.conf /etc/httpd/conf.d/
+COPY ironic-config/httpd-modules.conf /etc/httpd/conf.modules.d/
+COPY ironic-config/apache2-ironic-api.conf.j2 /etc/httpd-ironic-api.conf.j2

--- a/Dockerfile.ironic-inspector
+++ b/Dockerfile.ironic-inspector
@@ -1,0 +1,25 @@
+FROM docker.io/centos:centos8
+
+ENV PKGS_LIST=main-packages-list.txt
+ARG EXTRA_PKGS_LIST
+ARG PATCH_LIST
+
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
+COPY prepare-image.sh patch-image.sh /bin/
+
+RUN prepare-image.sh && \
+  rm -f /bin/prepare-image.sh
+
+RUN mkdir -p /var/lib/ironic-inspector && \
+  sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
+  dnf remove -y sqlite
+
+COPY ironic-inspector-config/ironic-inspector.conf.j2 /etc/ironic-inspector/
+COPY ironic-inspector-scripts/ /bin/
+
+COPY ironic-inspector-config/inspector-apache.conf.j2 /etc/httpd/conf.d/ironic-inspector.conf.j2
+HEALTHCHECK CMD /bin/runhealthcheck
+RUN rm /etc/httpd/conf.d/ssl.conf -f
+RUN chmod +x /bin/runironic-inspector 
+
+ENTRYPOINT ["/bin/runironic-inspector"]

--- a/ironic-inspector-config/inspector-apache.conf.j2
+++ b/ironic-inspector-config/inspector-apache.conf.j2
@@ -1,0 +1,43 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+Listen 5050
+<VirtualHost *:5050>
+    ProxyPass "/"  "http://127.0.0.1:5049/"
+    ProxyPassReverse "/"  "http://127.0.0.1:5049/"
+
+    SetEnv APACHE_RUN_USER ironic-inspector
+    SetEnv APACHE_RUN_GROUP ironic-inspector
+
+    ErrorLog /dev/stdout
+    LogLevel debug
+    CustomLog /dev/stdout combined
+
+    ServerName 172.22.0.2
+
+    SSLEngine On
+    SSLCertificateFile {{ env.IRONIC_INSPECTOR_CERT_FILE }} 
+    SSLCertificateKeyFile {{ env.IRONIC_INSPECTOR_KEY_FILE }}
+
+
+     <Location /v1/introspection/ >
+         {% if "HTTP_BASIC_HTPASSWD" in env and env.HTTP_BASIC_HTPASSWD | length %}
+            AuthType Basic
+            AuthName "Restricted area"
+            AuthUserFile "/etc/ironic-inspector/htpasswd"
+            Require valid-user
+         {% endif %}
+     </Location>
+
+
+</VirtualHost>

--- a/ironic-inspector-config/ironic-inspector.conf.j2
+++ b/ironic-inspector-config/ironic-inspector.conf.j2
@@ -1,0 +1,57 @@
+[DEFAULT]
+auth_strategy = noauth
+debug = true
+transport_url = fake://
+use_stderr = true
+{% if env.INSPECTOR_REVERSE_PROXY_SETUP == "true" %}
+listen_port = 5049
+listen_address = 127.0.0.1
+{% else %}
+listen_address = ::
+{% endif %}
+host = {{ env.IRONIC_IP }}
+{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" and env.INSPECTOR_REVERSE_PROXY_SETUP == "false" %}
+use_ssl = true
+{% endif %}
+
+[database]
+connection = sqlite:///var/lib/ironic-inspector/ironic-inspector.db
+
+{% if env.IRONIC_INSPECTOR_ENABLE_DISCOVERY == "true" %}
+[discovery]
+enroll_node_driver = ipmi
+{% endif %}
+
+[ironic]
+auth_type = none
+endpoint_override = {{ env.IRONIC_BASE_URL }}
+{% if env.IRONIC_TLS_SETUP == "true" %}
+cafile = {{ env.IRONIC_CACERT_FILE }}
+insecure = {{ env.IRONIC_INSECURE }}
+{% endif %}
+
+[processing]
+add_ports = all
+always_store_ramdisk_logs = true
+keep_ports = present
+{% if env.IRONIC_INSPECTOR_ENABLE_DISCOVERY == "true" %}
+node_not_found_hook = enroll
+{% endif %}
+permit_active_introspection = true
+power_off = false
+processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic
+ramdisk_logs_dir = /shared/log/ironic-inspector/ramdisk
+store_data = database
+
+[pxe_filter]
+driver = noop
+
+[service_catalog]
+auth_type = none
+endpoint_override = {{ env.IRONIC_INSPECTOR_BASE_URL }}
+
+{% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" and env.INSPECTOR_REVERSE_PROXY_SETUP == "false" %}
+[ssl]
+cert_file = {{ env.IRONIC_INSPECTOR_CERT_FILE }}
+key_file = {{ env.IRONIC_INSPECTOR_KEY_FILE }}
+{% endif %}

--- a/ironic-inspector-packages-list.txt
+++ b/ironic-inspector-packages-list.txt
@@ -1,0 +1,7 @@
+crudini
+iproute
+openstack-ironic-inspector >= 10.5.1-0.20201223120908.379b892.el8
+psmisc
+sqlite
+httpd
+mod_ssl 

--- a/ironic-inspector-scripts/ironic-common.sh
+++ b/ironic-inspector-scripts/ironic-common.sh
@@ -1,0 +1,38 @@
+export PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
+
+# Wait for the interface or IP to be up, sets $IRONIC_IP
+function get_ironic_ip() {
+  # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
+  if [ ! -z "${PROVISIONING_IP}" ];
+  then
+    local prov_ip=$(printf %s "${PROVISIONING_IP}" | sed -e 's%/.*%%')
+    echo "Waiting for ${prov_ip} to be configured on an interface"
+    if ip -br addr show | grep -q -F " ${prov_ip}/"; then
+      export IRONIC_IP="${prov_ip}"
+    fi
+  else
+    echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+    export IRONIC_IP=$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)
+  fi
+
+  if [ ! -z "${IRONIC_IP}" ]; then
+    # If the IP contains a colon, then it's an IPv6 address, and the HTTP
+    # host needs surrounding with brackets
+    if [[ "$IRONIC_IP" =~ .*:.* ]]
+    then
+      export IPV=6
+      export IRONIC_URL_HOST="[$IRONIC_IP]"
+    else
+      export IPV=4
+      export IRONIC_URL_HOST=$IRONIC_IP
+    fi
+  fi
+}
+
+function wait_for_interface_or_ip() {
+  export IRONIC_IP=""
+  until [ ! -z "${IRONIC_IP}" ]; do
+    get_ironic_ip
+    sleep 1
+  done
+}

--- a/ironic-inspector-scripts/runhealthcheck
+++ b/ironic-inspector-scripts/runhealthcheck
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
+IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
+
+. /bin/ironic-common.sh
+get_ironic_ip
+#If the IP is not set, we are not running yet
+[ -z $IRONIC_IP ] && exit 1
+
+if [ ! -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_CACERT_FILE" ]; then
+    curl -s http://${IRONIC_URL_HOST}:5050
+else
+    CACERT_FILE="${IRONIC_INSPECTOR_CACERT_FILE}"
+    if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}" ]; then
+        CACERT_FILE="${IRONIC_INSPECTOR_CERT_FILE}"
+    fi
+    curl --cacert "$CACERT_FILE" -s "https://${IRONIC_URL_HOST}:5050"
+fi

--- a/ironic-inspector-scripts/runhttpd
+++ b/ironic-inspector-scripts/runhttpd
@@ -1,0 +1,42 @@
+#!/usr/bin/bash
+
+APACHE_CONFIG=/etc/httpd/conf.d/ironic-inspector.conf
+
+export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key
+export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"false"}
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate key file /certs/ironic-inspector/tls.key"
+    exit 1
+fi
+if [ ! -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate file /certs/ironic-inspector/tls.crt"
+    exit 1
+fi
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
+    export IRONIC_INSPECTOR_TLS_SETUP="true"
+else
+    export IRONIC_INSPECTOR_TLS_SETUP="false"
+    export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
+    exit 0
+fi
+
+function build_j2_config() {
+  CONFIG_FILE=$1
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
+}
+
+# Configure HTTP basic auth for API server
+HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
+if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
+    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
+fi
+
+build_j2_config $APACHE_CONFIG > $APACHE_CONFIG
+sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
+sed -i 's/User apache/User ironic-inspector/g' /etc/httpd/conf/httpd.conf
+sed -i 's/Group apache/Group ironic-inspector/g' /etc/httpd/conf/httpd.conf
+exec /usr/sbin/httpd -DFOREGROUND
+

--- a/ironic-inspector-scripts/runironic-inspector
+++ b/ironic-inspector-scripts/runironic-inspector
@@ -1,0 +1,83 @@
+#!/usr/bin/bash
+
+CONFIG=/etc/ironic-inspector/ironic-inspector.conf
+
+export IRONIC_INSPECTOR_ENABLE_DISCOVERY=${IRONIC_INSPECTOR_ENABLE_DISCOVERY:-false}
+
+export IRONIC_CERT_FILE=/certs/ironic/tls.crt
+export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
+export IRONIC_INSECURE=${IRONIC_INSECURE:-false}
+
+export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
+export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key
+export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"false"}
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate key file /certs/ironic-inspector/tls.key"
+    exit 1
+fi
+if [ ! -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
+    echo "Missing TLS Certificate file /certs/ironic-inspector/tls.crt"
+    exit 1
+fi
+
+. /bin/ironic-common.sh
+
+wait_for_interface_or_ip
+
+if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
+    export IRONIC_INSPECTOR_TLS_SETUP="true"
+    export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5050"
+    if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}"]; then
+        cp "${IRONIC_INSPECTOR_CERT_FILE}" "${IRONIC_INSPECTOR_CACERT_FILE}"
+    fi
+else
+    export IRONIC_INSPECTOR_TLS_SETUP="false"
+    export IRONIC_INSPECTOR_BASE_URL="http://${IRONIC_URL_HOST}:5050"
+    export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
+fi
+
+if [ -f "$IRONIC_CERT_FILE" ] || [ -f "$IRONIC_CACERT_FILE" ]; then
+    export IRONIC_TLS_SETUP="true"
+    export IRONIC_BASE_URL="https://${IRONIC_URL_HOST}:6385"
+    if [ ! -f "${IRONIC_CACERT_FILE}"]; then
+        cp "${IRONIC_CERT_FILE}" "${IRONIC_CACERT_FILE}"
+    fi
+else
+    export IRONIC_TLS_SETUP="false"
+    export IRONIC_BASE_URL="http://${IRONIC_URL_HOST}:6385"
+fi
+
+cp $CONFIG $CONFIG.orig
+
+function build_j2_config() {
+  CONFIG_FILE=$1
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
+}
+
+# Merge with the original configuration file from the package.
+build_j2_config $CONFIG | crudini --merge /etc/ironic-inspector/ironic-inspector.conf
+
+
+# Configure HTTP basic auth for API server
+HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
+if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
+    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
+    if [[ $INSPECTOR_REVERSE_PROXY_SETUP == "false" ]]
+    then
+      crudini --set $CONFIG DEFAULT auth_strategy http_basic
+      crudini --set $CONFIG DEFAULT http_basic_auth_user_file "${HTPASSWD_FILE}"
+    fi
+fi
+
+# Configure auth for ironic client
+CONFIG_OPTIONS="--config-file ${CONFIG}"
+auth_config_file="/auth/ironic/auth-config"
+if [ -f ${auth_config_file} ]; then
+    CONFIG_OPTIONS+=" --config-file ${auth_config_file}"
+fi
+
+ironic-inspector-dbsync --config-file /etc/ironic-inspector/ironic-inspector.conf upgrade
+
+exec /usr/bin/ironic-inspector $CONFIG_OPTIONS

--- a/ironic-inspector-scripts/runlogwatch.sh
+++ b/ironic-inspector-scripts/runlogwatch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+# Ramdisk logs path
+LOG_DIR="/shared/log/ironic-inspector/ramdisk"
+
+while :
+do
+    until  ls "${LOG_DIR}"/*.tar.gz 1> /dev/null 2>&1
+    do
+        sleep 5
+    done
+
+    for fn in "${LOG_DIR}"/*.tar.gz
+    do
+        echo "************ Contents of $fn ramdisk log file bundle **************"
+        tar -xOzvvf $fn | sed -e "s/^/$(basename $fn): /"
+        rm -f $fn
+    done
+done


### PR DESCRIPTION
This change moves Dockerfile, configuration and scripts from the
ironic-inspector container image repository to the ironic one.

This approach provides two separate Dockerfiles in the same repository,
one for ironic and one for ironic-inspector, that share part of the
logic needed to build the images.
The scripts and configurations are kept separated for the time being as
some of them conflict with each other (e.g. runhttpd).

The original Dockerfile is kept until we make the necessary changes to
the CI.

This change is mutually exclusive with #253