### PR TITLE
Set webserver_verify_ca to bool or certificate path

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -30,6 +30,13 @@ host = localhost
 host = {{ env.IRONIC_URL_HOST }}
 {% endif %}
 
+# If a path to a certificate is defined, use that first for webserver
+{% if env.WEBSERVER_CACERT_FILE %}
+webserver_verify_ca =  {{ env.WEBSERVER_CACERT_FILE }}
+{% elif env.IRONIC_INSECURE == "true" %}
+webserver_verify_ca = false
+{% endif %}
+
 isolinux_bin = /usr/share/syslinux/isolinux.bin
 
 # NOTE(dtantsur): this path is specific to the GRUB image that is built into


### PR DESCRIPTION
Set the ironic conf setting `webserver_verify_ca` to False
if IRONIC_INSECURE is True (to disable TLS validation) or set
it to path to CA_BUNDLE file if new IRONIC_CA_PATH env
variable is set.

By default it will be set to True.