### PR TITLE
Fix the "permisison denied" bug properly

### DIFF
--- a/scripts/runmariadb
+++ b/scripts/runmariadb
@@ -18,7 +18,6 @@ if [ ! -f "$MARIADB_CERT_FILE" ] && [ -f "$MARIADB_KEY_FILE" ] ; then
 fi
 
 ln -sf /proc/self/fd/1 /var/log/mariadb/mariadb.log
-rm -f /usr/bin/mysqld_safe_helper # Avoid this script being used which results in a permission denied error.
 
 # Restart mysqld when the certificate is updated
 if [[ -f "$MARIADB_CERT_FILE" && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
@@ -32,6 +31,7 @@ if [ ! -d "${DATADIR}/mysql" ]; then
     crudini --set "$MARIADB_CONF_FILE" mysqld max_heap_table_size 1M
     crudini --set "$MARIADB_CONF_FILE" mysqld innodb_buffer_pool_size 5M
     crudini --set "$MARIADB_CONF_FILE" mysqld innodb_log_buffer_size 512K
+    crudini --set "$MARIADB_CONF_FILE" mysqld user root
 
     # Config MariaDB to enable TLS
     if [ -f "$MARIADB_CERT_FILE" ]


### PR DESCRIPTION
Issue: For some reason the script mysqld_safe_helper is used to run mysqld. This script runs with `--user=mysql` and `--log-error=/var/log/mariadb/mariadb.log`. This causes the `permisison denied` error because user mysql tries to  write to `/var/log/mariadb/mariadb.log` which, in this repo, is a symlink of root's stdout. 
Error message:
`/usr/bin/mysqld_safe_helper: Can't create/write to file '/var/log/mariadb/mariadb.log' (Errcode: 13 "Permission denied")`
This PR solves the problem by removing the symlink hack and make the error log go to stdout in a proper way. 