### PR TITLE
Add space before ']'

### DIFF
--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -29,7 +29,7 @@ wait_for_interface_or_ip
 if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
     export IRONIC_INSPECTOR_TLS_SETUP="true"
     export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5050"
-    if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}"]; then
+    if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}" ]; then
         cp "${IRONIC_INSPECTOR_CERT_FILE}" "${IRONIC_INSPECTOR_CACERT_FILE}"
     fi
 else
@@ -41,7 +41,7 @@ fi
 if [ -f "$IRONIC_CERT_FILE" ] || [ -f "$IRONIC_CACERT_FILE" ]; then
     export IRONIC_TLS_SETUP="true"
     export IRONIC_BASE_URL="https://${IRONIC_URL_HOST}:6385"
-    if [ ! -f "${IRONIC_CACERT_FILE}"]; then
+    if [ ! -f "${IRONIC_CACERT_FILE}" ]; then
         cp "${IRONIC_CERT_FILE}" "${IRONIC_CACERT_FILE}"
     fi
 else


### PR DESCRIPTION
Solve the following issues:
/bin/runironic-inspector: line 32: [: missing `]'
/bin/runironic-inspector: line 44: [: missing `]'

Signed-off-by: Ma Xinjian <maxj.fnst@fujitsu.com>