### PR TITLE
Allow Node network_data in any format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN chown ironic:ironic /var/log/ironic && \
 COPY --from=ironic-builder /tmp/ipxe/src/bin/undionly.kpxe /tmp/ipxe/src/bin-x86_64-efi/snponly.efi /tmp/ipxe/src/bin-x86_64-efi/ipxe.efi /tftpboot/
 COPY --from=ironic-builder /tmp/esp.img /tmp/uefi_esp.img
 
-COPY ironic-config/ironic.conf.j2 /etc/ironic/
+COPY ironic-config/ironic.conf.j2 ironic-config/network-data-schema.json /etc/ironic/
 COPY ironic-config/dnsmasq.conf.j2 /etc/
 COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe /tmp/
 

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -51,6 +51,7 @@ api_workers = {{ env.NUMWORKERS }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 enable_ssl_api = true
 {% endif %}
+network_data_schema = /etc/ironic/network-data-schema.json
 
 [conductor]
 automated_clean = {{ env.IRONIC_AUTOMATED_CLEAN }}

--- a/ironic-config/network-data-schema.json
+++ b/ironic-config/network-data-schema.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "description": "JSON Schema to allow any network data format",
+  "additionalProperties": true
+}


### PR DESCRIPTION
Currently, metal³ does not set the network_data field in the Ironic
Node. However it does pass the network_data upon provisioning, and
currently places no restrictions on the format of the network_data.

In order to pass the network_data to the deploy ramdisk, we need to also
set the network_data field in the Node. However, if the same
network_data is used then this would cause the data to start getting
validated against the Nova network_data schema, which may break existing
Hosts that had invalid or non-standard data.

To allow us to start passing the network_data without placing new
restrictions on the format, configure the schema to allow any JSON
object.