### PR TITLE
Keep only one httpd instance for the Ironic deployment

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -13,6 +13,10 @@ if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     fi
 fi
 dnf install -y --enablerepo=epel inotify-tools
+
+# Delete the line below after the PR: https://github.com/metal3-io/baremetal-operator/pull/886 goes in.
+dnf install -y net-tools
+
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
 if [[ ! -z ${PATCH_LIST:-} ]]; then

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -48,7 +48,10 @@ fi
 
 if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
     export IRONIC_INSPECTOR_TLS_SETUP="true"
-    render_j2_config $INSPECTOR_ORIG_HTTPD_CONFIG $INSPECTOR_RESULT_HTTPD_CONFIG
+    # Delete the line below after the PR: https://github.com/metal3-io/baremetal-operator/pull/886 goes in. 
+    INSPECTOR_PORT=5050
+    # Delete the condition statement after the PR above goes in. 
+    [ ! "$(netstat -l | grep ${INSPECTOR_PORT})" ] render_j2_config $INSPECTOR_ORIG_HTTPD_CONFIG $INSPECTOR_RESULT_HTTPD_CONFIG
 else
     export IRONIC_INSPECTOR_TLS_SETUP="false"
     export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -50,8 +50,10 @@ if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
     export IRONIC_INSPECTOR_TLS_SETUP="true"
     # Delete the line below after the PR: https://github.com/metal3-io/baremetal-operator/pull/886 goes in. 
     INSPECTOR_PORT=5050
-    # Delete the condition statement after the PR above goes in. 
-    [ ! "$(netstat -l | grep ${INSPECTOR_PORT})" ] render_j2_config $INSPECTOR_ORIG_HTTPD_CONFIG $INSPECTOR_RESULT_HTTPD_CONFIG
+    # Delete the netstate and grep statement after the PR above goes in. 
+    netstat -ln | grep ${INSPECTOR_PORT} -q || render_j2_config $INSPECTOR_ORIG_HTTPD_CONFIG $INSPECTOR_RESULT_HTTPD_CONFIG
+    # Add user 'apache' to the group `ironic-inspector`, so httpd can access /etc/ironic-inspector and read the pasword file
+    usermod -aG ironic-inspector apache
 else
     export IRONIC_INSPECTOR_TLS_SETUP="false"
     export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy

--- a/scripts/runironic-api
+++ b/scripts/runironic-api
@@ -14,8 +14,7 @@ while true ; do
   sleep 5
 done
 
-. /bin/configure-httpd-ipa.sh  
-# The code above avoids the httpd instance in this container to listen on port HTTP_PORT when it has been opened by BMO.
+. /bin/runhttpd
 
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic.conf
 sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf

--- a/scripts/runironic-api
+++ b/scripts/runironic-api
@@ -14,16 +14,9 @@ while true ; do
   sleep 5
 done
 
-. /bin/runhttpd
-
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic.conf
-sed -i "/Listen 80/c\#Listen 80" /etc/httpd/conf/httpd.conf
 
-if [[ "$IRONIC_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
-    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read file event; do
-      kill -WINCH $(pgrep httpd)
-    done &
-fi
+# Delete the line below after the PR: https://github.com/metal3-io/baremetal-operator/pull/886 goes in. 
+sleep 10 # Add a delay to avoid race condition. When ironic-api checks the port 5050 to determine the existence of another httpd instance that serves as the inspector reversed proxy, it can be the case that the other instance is only in initial phase and has not yet opened the port 5050. 
 
-exec /usr/sbin/httpd -DFOREGROUND
-
+. /bin/runhttpd


### PR DESCRIPTION
Currently, when deploying ironic and ironic-inspector, there are two httpd instances. One is deployed in the script `runironic-api`, and this instance is used to serve file for IPA and to run as a WSGI web server for ironic-api. The other one is deployed in the script `runhttpd`, and it is used to also serve file for IPA and to run as a reverse proxy for ironic-inspector. This causes the problem when two httpd instances open the same port to serve file for IPA. This PR removes one instance to fix the issue. Also, this removal will simplify the configuration and boost the overall performance.