### PR TITLE
Add sushy-tools & vbmc Dockerfiles

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.hub.docker.com/library/python:3.9
+
+RUN apt update && \
+    apt install -y libvirt-dev && \
+    pip3 install sushy-tools==0.15.0 libvirt-python
+
+CMD sushy-emulator -i :: -p 8000 --config /root/sushy/conf.py

--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/centos:centos8
+
+RUN dnf install -y python3 python3-requests python3-pip && \
+     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream && \
+     dnf upgrade -y && \
+     dnf install -y python3-virtualbmc && \
+     dnf clean all && \
+     rm -rf /var/cache/{yum,dnf}/*
+
+CMD /usr/bin/vbmcd --foreground


### PR DESCRIPTION
Move sushy-tools & vbmc Dockerfiles to ironic-image repo in order to avoid building their images on every single pull request in metal3-dev-env. This will reduce the time it takes for integration test to run in metal3-dev-env and for master jobs that run every day.
Discussion thread on [slack](https://kubernetes.slack.com/archives/CHD49TLE7/p1621868516039800).
After this PR is merged, I will update quay to point ironic-image repo.