### PR TITLE
remove irmc from enabled_bios_interfaces

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -4,7 +4,7 @@ debug = true
 default_deploy_interface = direct
 default_inspect_interface = inspector
 default_network_interface = noop
-enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish,irmc,ilo
+enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish,ilo
 enabled_boot_interfaces = ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
 enabled_deploy_interfaces = direct,fake,ramdisk
 # NOTE(dtantsur): when changing this, make sure to update the driver


### PR DESCRIPTION
When bios_interface  set to irmc, the master will continue to restart during the IPI
configuration process, see https://github.com/openshift/installer/issues/4963
so temporarily remove irmc from enabled_bios_interfaces.



Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>