### PR TITLE
Add cipher_suite_versions config

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -125,6 +125,10 @@ use_ipmitool_retries = true
 # interval of Y in between each tries.
 min_command_interval = 5
 command_retry_timeout = 60
+# List of possible cipher suites versions that can be
+# supported by the hardware in case the field `cipher_suite`
+# is not set for the node. (list value)
+cipher_suite_versions = 3,17
 
 [json_rpc]
 # We assume that when we run API and conductor in the same container, they use


### PR DESCRIPTION
This commit adds the new ironic configuration option
``[ipmi]/cipher_suite_versions``.
Allowing ipmi to try different values in case of the
default cipher suite is not supported.