### PR TITLE
Update the inspector endpoint to port 5049 when using the reverse proxy

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -14,9 +14,6 @@ if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
 fi
 dnf install -y --enablerepo=epel inotify-tools
 
-# Delete the line below after the PR: https://github.com/metal3-io/baremetal-operator/pull/886 goes in.
-dnf install -y net-tools
-
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
 if [[ ! -z ${PATCH_LIST:-} ]]; then

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -50,8 +50,10 @@ if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
     export IRONIC_INSPECTOR_TLS_SETUP="true"
     # Delete the line below after the PR: https://github.com/metal3-io/baremetal-operator/pull/886 goes in. 
     INSPECTOR_PORT=5050
-    # Delete the netstate and grep statement after the PR above goes in. 
-    netstat -ln | grep ${INSPECTOR_PORT} -q || render_j2_config $INSPECTOR_ORIG_HTTPD_CONFIG $INSPECTOR_RESULT_HTTPD_CONFIG
+
+    if [[ "${INSPECTOR_REVERSE_PROXY_SETUP}" == "true" ]]; then
+      render_j2_config $INSPECTOR_ORIG_HTTPD_CONFIG $INSPECTOR_RESULT_HTTPD_CONFIG
+    fi
     # Add user 'apache' to the group `ironic-inspector`, so httpd can access /etc/ironic-inspector and read the pasword file
     usermod -aG ironic-inspector apache
 else
@@ -82,6 +84,12 @@ sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
 
 if [[ "$IRONIC_INSPECTOR_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
     inotifywait -m -e delete_self "${IRONIC_INSPECTOR_CERT_FILE}" | while read file event; do
+      kill -WINCH $(pgrep httpd)
+    done &
+fi
+
+if [[ "$IRONIC_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read file event; do
       kill -WINCH $(pgrep httpd)
     done &
 fi

--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -28,7 +28,7 @@ wait_for_interface_or_ip
 
 if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
     export IRONIC_INSPECTOR_TLS_SETUP="true"
-    export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5050"
+    export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5049"
     if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}" ]; then
         cp "${IRONIC_INSPECTOR_CERT_FILE}" "${IRONIC_INSPECTOR_CACERT_FILE}"
     fi

--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -12,6 +12,7 @@ export IRONIC_INSPECTOR_CACERT_FILE=/certs/ca/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_CERT_FILE=/certs/ironic-inspector/tls.crt
 export IRONIC_INSPECTOR_KEY_FILE=/certs/ironic-inspector/tls.key
 export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"false"}
+export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 
 if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ] && [ ! -f "$IRONIC_INSPECTOR_KEY_FILE" ] ; then
     echo "Missing TLS Certificate key file /certs/ironic-inspector/tls.key"
@@ -28,7 +29,13 @@ wait_for_interface_or_ip
 
 if [ -f "$IRONIC_INSPECTOR_CERT_FILE" ]; then
     export IRONIC_INSPECTOR_TLS_SETUP="true"
-    export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5049"
+
+    if [[ "${INSPECTOR_REVERSE_PROXY_SETUP}" == "true" ]]; then
+      export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5049"
+    else
+      export IRONIC_INSPECTOR_BASE_URL="https://${IRONIC_URL_HOST}:5050"
+    fi
+
     if [ ! -f "${IRONIC_INSPECTOR_CACERT_FILE}" ]; then
         cp "${IRONIC_INSPECTOR_CERT_FILE}" "${IRONIC_INSPECTOR_CACERT_FILE}"
     fi
@@ -49,15 +56,13 @@ else
     export IRONIC_BASE_URL="http://${IRONIC_URL_HOST}:6385"
 fi
 
-cp $CONFIG $CONFIG.orig
-
 function build_j2_config() {
   CONFIG_FILE=$1
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
 }
 
 # Merge with the original configuration file from the package.
-build_j2_config $CONFIG | crudini --merge /etc/ironic-inspector/ironic-inspector.conf
+build_j2_config $CONFIG | crudini --merge $CONFIG
 
 
 # Configure HTTP basic auth for API server
@@ -79,5 +84,11 @@ if [ -f ${auth_config_file} ]; then
 fi
 
 ironic-inspector-dbsync --config-file /etc/ironic-inspector/ironic-inspector.conf upgrade
+
+if [[ "$INSPECTOR_REVERSE_PROXY_SETUP" == "false" && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    inotifywait -m -e delete_self "${IRONIC_INSPECTOR_CERT_FILE}" | while read file event; do
+    kill $(pgrep ironic)
+    done &
+fi
 
 exec /usr/bin/ironic-inspector $CONFIG_OPTIONS


### PR DESCRIPTION
When using httpd as the reverse proxy for ironic inspector, the httpd server will listen at 5050, and forward the traffic to port 5049. For that reason, we need to set the ironic inspector endpoint to this port. Otherwise, the traffic between ironic inspector and other components are not encrypted.
Also, this PR solves a problem with non-proxy case. Currently, if TLS is enabled, but we don't use the reverse proxy, it can cause problem. This PR solves that. 