### PR TITLE
Prevent installing docs via a DNF flag

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -2,14 +2,18 @@
 
 set -euxo pipefail
 
+echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+# Tell RPM to skip installing documentation
+echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
+
 dnf install -y python3 python3-requests epel-release 'dnf-command(config-manager)'
 dnf config-manager --set-disabled epel
 curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream
 dnf upgrade -y
-xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${PKGS_LIST}
+xargs -rtd'\n' dnf install -y < /tmp/${PKGS_LIST}
 if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
-        xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${EXTRA_PKGS_LIST}
+        xargs -rtd'\n' dnf install -y < /tmp/${EXTRA_PKGS_LIST}
     fi
 fi
 dnf install -y --enablerepo=epel inotify-tools


### PR DESCRIPTION
This change adds a flag that disables installing documentation from
RPMs. Additionally, prevent installing weak dependencies globally.
