### PR TITLE
Add inspector callback_endpoint_override

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -107,6 +107,9 @@ insecure = {{ env.IRONIC_INSPECTOR_INSECURE }}
 # Also keep in mind that only parameters unique for inspection go here.
 # No need to duplicate pxe_append_params/kernel_append_params.
 extra_kernel_params = ipa-inspection-collectors=default,extra-hardware,logs ipa-enable-vlan-interfaces={{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1
+{% if env.IRONIC_INSPECTOR_CALLBACK_ENDPOINT_OVERRIDE %}
+callback_endpoint_override = {{ env.IRONIC_INSPECTOR_CALLBACK_ENDPOINT_OVERRIDE }}
+{% endif %}
 
 [ipmi]
 # use_ipmitool_retries transfers the responsibility of retrying to ipmitool

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -88,6 +88,7 @@ if [ ! -z "${IRONIC_EXTERNAL_IP}" ]; then
 		export IRONIC_EXTERNAL_CALLBACK_URL="http://${IRONIC_EXTERNAL_IP}:6385"
 	fi
 	export IRONIC_EXTERNAL_HTTP_URL="http://${IRONIC_EXTERNAL_IP}:6180"
+	export IRONIC_INSPECTOR_CALLBACK_ENDPOINT_OVERRIDE="https://${IRONIC_EXTERNAL_IP}:5050"
 fi
 
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig


### PR DESCRIPTION
In order for IPA to call back into ironic inspector when being
used on external networks, we'll need to set this as well.