### PR TITLE
Update tripleo_repos location

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -8,7 +8,7 @@ echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
 
 dnf install -y python3 python3-requests epel-release 'dnf-command(config-manager)'
 dnf config-manager --set-disabled epel
-curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream
+curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream
 dnf upgrade -y
 xargs -rtd'\n' dnf install -y < /tmp/${PKGS_LIST}
 if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then

--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos8
 
 RUN dnf install -y python3 python3-requests python3-pip && \
-     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 | python3 - -b master current-tripleo --no-stream && \
+     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream && \
      dnf upgrade -y && \
      dnf install -y python3-virtualbmc && \
      dnf clean all && \

--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:centos8
 
 RUN dnf install -y python3 python3-requests python3-pip && \
-     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python3 - -b master current-tripleo --no-stream && \
+     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 | python3 - -b master current-tripleo --no-stream && \
      dnf upgrade -y && \
      dnf install -y python3-virtualbmc && \
      dnf clean all && \


### PR DESCRIPTION
The upstream openstack tripleo team decided to move the `tripleo_repos` folder under `plugins/module_utils/` https://github.com/openstack/tripleo-repos/commit/77dc5794ac880abc57927af08e70e99d2a972f84
Due to this, when building the ironic container, we end us with a `404 Not Found` error.
Updating the script as per as the new upstream repo structure.