### PR TITLE
Add procps package to make `ps` available

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -26,4 +26,5 @@ python3-sushy
 python3-sushy-oem-idrac
 qemu-img
 sqlite
-syslinux-nonlinux
+syslinux-nonlinux 
+procps


### PR DESCRIPTION
`procps` is missing in centos 8 stream. However, we need it to use `ps` at some places, like this: https://github.com/metal3-io/ironic-image/blob/abc12be6df2a01e489e70b54aa7e291710fe1ef5/scripts/runhttpd#L91
This PS adds `procps` to the image, so `ps` is available.