### PR TITLE
Remove the trailing slash from the heartbeat rule

### DIFF
--- a/ironic-config/apache2-ironic-api.conf.j2
+++ b/ironic-config/apache2-ironic-api.conf.j2
@@ -39,7 +39,7 @@ Listen 6385
     <Location /v1/lookup >
         Require all granted
     </Location>
-    <Location /v1/heartbeat/ >
+    <Location /v1/heartbeat >
         Require all granted
     </Location>
     <Location ~ "^/(v1/?)?$">


### PR DESCRIPTION
Just `/v1/heartbeat` is also valid.