### PR TITLE
Add option to build image using source code directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,13 @@ FROM $BASE_IMAGE
 ENV PKGS_LIST=main-packages-list.txt
 ARG EXTRA_PKGS_LIST
 ARG PATCH_LIST
+ARG INSTALL_TYPE=rpm
 
-COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
+COPY ironic-${INSTALL_TYPE}-list.txt ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
 COPY prepare-image.sh patch-image.sh /bin/
 
 RUN prepare-image.sh && \
   rm -f /bin/prepare-image.sh
-
 
 COPY scripts/ /bin/
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ The ironic configuration can be overridden by various environment variables. The
 - OS_CONDUCTOR__CLEAN_CALLBACK_TIMEOUT=1800 - timeout (seconds) to wait for a callback from the ramdisk doing the cleaning
 - OS_PXE__BOOT_RETRY_TIMEOUT=1200 - timeout (seconds) to enable boot retries.
 
+Build Ironic Image from source
+------------------------------
+
+Normally the ironic image is built using RPMs coming from the RDO project.  
+It is possible to build it using source code setting the **INSTALL_TYPE**
+argument to **source** at build time; the full command is for example:
+
+    podman build -t ironic-image -f Dockerfile --build-arg INSTALL_TYPE=source
+
 Apply project patches to the images during build
 ------------------------------------------------
 

--- a/ironic-rpm-list.txt
+++ b/ironic-rpm-list.txt
@@ -1,0 +1,11 @@
+crudini
+openstack-ironic-api
+openstack-ironic-conductor
+openstack-ironic-inspector
+python3-dracclient
+python3-ibmcclient
+python3-ironic-prometheus-exporter
+python3-proliantutils
+python3-scciclient
+python3-sushy
+python3-sushy-oem-idrac

--- a/ironic-source-list.txt
+++ b/ironic-source-list.txt
@@ -1,0 +1,11 @@
+crudini
+ironic @ git+https://opendev.org/openstack/ironic
+ironic-inspector @ git+https://opendev.org/openstack/ironic-inspector
+ironic-prometheus-exporter
+proliantutils
+PyMySQL>=0.8.0
+python-dracclient
+python-ibmcclient
+python-scciclient
+sushy
+sushy-oem-idrac

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,4 +1,3 @@
-crudini
 dnsmasq
 genisoimage
 httpd
@@ -8,20 +7,11 @@ ipmitool
 iproute
 mariadb-server
 mod_ssl
-openstack-ironic-api
-openstack-ironic-conductor
-openstack-ironic-inspector
+parted
 procps
-python3-dracclient
-python3-gunicorn
-python3-ibmcclient
-python3-ironic-prometheus-exporter
+psmisc
 python3-jinja2
 python3-mod_wsgi
-python3-proliantutils
-python3-scciclient
-python3-sushy
-python3-sushy-oem-idrac
 qemu-img
 sqlite
 syslinux-nonlinux

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -2,28 +2,54 @@
 
 set -euxo pipefail
 
+IRONIC_PKG_LIST=/tmp/ironic-${INSTALL_TYPE}-list.txt
+
 echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
 # Tell RPM to skip installing documentation
 echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
 
 dnf install -y python3 python3-requests epel-release 'dnf-command(config-manager)'
 dnf config-manager --set-disabled epel
-curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo
-dnf upgrade -y
+
+# RPM install #
+if [[ $INSTALL_TYPE == "rpm" ]]; then
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo
+    dnf upgrade -y
+    xargs -rtd'\n' dnf install -y < $IRONIC_PKG_LIST
+fi
+
+# SOURCE install #
+if [[ $INSTALL_TYPE == "source" ]]; then
+    dnf upgrade -y
+    dnf install -y python3-pip python3-devel gcc git-core
+    pip3 install --upgrade pip
+    pip3 install --prefix /usr -r $IRONIC_PKG_LIST -c https://raw.githubusercontent.com/openstack/requirements/master/upper-constraints.txt
+
+    # ironic and ironic-inspector system configuration
+    mkdir -p /var/log/ironic /var/log/ironic-inspector /var/lib/ironic /var/lib/ironic-inspector
+    getent group ironic >/dev/null || groupadd -r ironic
+    getent passwd ironic >/dev/null || useradd -r -g ironic -s /sbin/nologin ironic -d /var/lib/ironic
+    getent group ironic-inspector >/dev/null || groupadd -r ironic-inspector
+    getent passwd ironic-inspector >/dev/null || useradd -r -g ironic-inspector -s /sbin/nologin ironic-inspector -d /var/lib/ironic-inspector
+fi
+
 xargs -rtd'\n' dnf install -y < /tmp/${PKGS_LIST}
+
 if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
         xargs -rtd'\n' dnf install -y < /tmp/${EXTRA_PKGS_LIST}
     fi
 fi
-dnf install -y --enablerepo=epel inotify-tools
+
+dnf install -y --enablerepo=epel inotify-tools python3-gunicorn
 
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
+
+# apply patches if present #
 if [[ ! -z ${PATCH_LIST:-} ]]; then
     if [[ -s "/tmp/${PATCH_LIST}" ]]; then
         /bin/patch-image.sh;
     fi
 fi
 rm -f /bin/patch-image.sh
-

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -39,7 +39,10 @@ if [ ! -z "${IRONIC_EXTERNAL_IP}" ]; then
     export IRONIC_INSPECTOR_CALLBACK_ENDPOINT_OVERRIDE="https://${IRONIC_EXTERNAL_IP}:5050"
 fi
 
-cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
+if [ -f /etc/ironic/ironic.conf ]; then
+    # Make a copy of the original supposed empty configuration file
+    cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
+fi
 
 # oslo.config also supports Config Opts From Environment, log them
 echo '# Options set from Environment variables' | tee /etc/ironic/ironic.extra


### PR DESCRIPTION
This patch adds a build-time argument that allows to build the ironic container image using source code instead of RPMs
At the moment this option should only be used for testing purpose, to simplify building images using the latest code or local patches

It is possible to test it using metal3-dev-env with the patch https://github.com/metal3-io/metal3-dev-env/pull/839