### PR TITLE
Install nc for checking health of services

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -9,6 +9,7 @@ iproute
 iscsi-initiator-utils
 mariadb-server
 mod_ssl
+nc
 openstack-ironic-api
 openstack-ironic-conductor
 openstack-ironic-inspector


### PR DESCRIPTION
Install `nc` In order to test readiness and liveness of services. Some of the services.