### PR TITLE
Dockerfile: stop copying . to builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ FROM $BASE_IMAGE AS ironic-builder
 
 RUN dnf install -y gcc git make xz-devel
 WORKDIR /tmp
-COPY . .
 RUN git clone https://github.com/ipxe/ipxe.git && \
       cd ipxe && \
       git checkout 3fe683ebab29afacf224e6b0921f6329bebcdca7 && \


### PR DESCRIPTION
Builder does not use any local content. Copying it causes constant
rebuilds of iPXE when building locally.
