### PR TITLE
Enable Lifecycle Controller job queue clear by default

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -68,6 +68,7 @@ send_sensor_data = {{ env.SEND_SENSOR_DATA }}
 # be avoided more often than once every sixty seconds.
 send_sensor_data_interval = 160
 bootloader = http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/uefi_esp.img
+verify_step_priority_override = management.clear_job_queue:90
 
 [database]
 {% if env.MARIADB_TLS_ENABLED == "true" %}


### PR DESCRIPTION
This commit enables code included in the following changes:
https://review.opendev.org/c/openstack/ironic/+/800001
https://review.opendev.org/c/openstack/ironic/+/804032
This is done by configuring a non-zero priority for clear_job_queue
verify step.