### PR TITLE
Add configure-coreos-ipa script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=ironic-builder /tmp/esp.img /tmp/uefi_esp.img
 
 COPY ironic-config/ironic.conf.j2 /etc/ironic/
 COPY ironic-config/dnsmasq.conf.j2 /etc/
-COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe /tmp/
+COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe ironic-config/ironic-python-agent.ign.j2 /tmp/
 
 # Custom httpd config, removes all but the bare minimum needed modules
 RUN rm -f /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf

--- a/ironic-config/ironic-python-agent.ign.j2
+++ b/ironic-config/ironic-python-agent.ign.j2
@@ -1,0 +1,59 @@
+{% set service %}
+[Unit]
+Description=Ironic Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+TimeoutStartSec=0
+ExecStartPre=/bin/podman pull {{ env.IRONIC_AGENT_REGISTRY }}/ironic-agent --tls-verify=false
+ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent ironic-agent
+
+[Install]
+WantedBy=multi-user.target
+{% endset -%}
+
+{% set ipa_config %}
+[DEFAULT]
+api_url = {{ env.IRONIC_BASE_URL }}:6385
+inspection_callback_url = {{ env.IRONIC_BASE_URL }}:5050/v1/continue
+
+collect_lldp = True
+enable_vlan_interfaces = {{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }}
+inspection_collectors = default,extra-hardware,logs
+inspection_dhcp_all_interfaces = True
+{% endset -%}
+
+
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  {% if env.IRONIC_RAMDISK_SSH_KEY %}
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "{{ env.IRONIC_RAMDISK_SSH_KEY | trim }}"
+        ]
+      }
+    ]
+  },
+  {% endif -%}
+  "storage": {
+    "files": [{
+      "path": "/etc/ironic-python-agent.conf",
+      "contents": {"source": "data:,{{ ipa_config | urlencode }}"}
+    }]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "{{ service | trim | replace('\n', '\\n') }}",
+        "enabled": true,
+        "name": "ironic-agent.service"
+      }
+    ]
+  }
+}

--- a/ironic-config/ironic-python-agent.ign.j2
+++ b/ironic-config/ironic-python-agent.ign.j2
@@ -6,8 +6,8 @@ Wants=network-online.target
 
 [Service]
 TimeoutStartSec=0
-ExecStartPre=/bin/podman pull {{ env.IRONIC_AGENT_REGISTRY }}/ironic-agent --tls-verify=false
-ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent ironic-agent
+ExecStartPre=/bin/podman pull {{ env.IRONIC_AGENT_IMAGE }} {{ env.IRONIC_AGENT_PODMAN_FLAGS }} {% if env.IRONIC_AGENT_PULL_SECRET %}--authfile=/etc/authfile.json{% endif %}
+ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent {{ env.IRONIC_AGENT_IMAGE }}
 
 [Install]
 WantedBy=multi-user.target
@@ -42,10 +42,17 @@ inspection_dhcp_all_interfaces = True
   },
   {% endif -%}
   "storage": {
-    "files": [{
-      "path": "/etc/ironic-python-agent.conf",
-      "contents": {"source": "data:,{{ ipa_config | urlencode }}"}
-    }]
+    "files": [
+      {
+        "path": "/etc/ironic-python-agent.conf",
+        "contents": {"source": "data:,{{ ipa_config | urlencode }}"}
+      }{% if env.IRONIC_AGENT_PULL_SECRET %},
+      {
+        "path": "/etc/authfile.json",
+        "contents": {"source": "data:;base64,{{ env.IRONIC_AGENT_PULL_SECRET | trim }}"}
+      }
+      {% endif %}
+    ]
   },
   "systemd": {
     "units": [

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -9,8 +9,7 @@ export IRONIC_AGENT_PULL_SECRET=${IRONIC_AGENT_PULL_SECRET:-}
 set -x
 
 export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
-# FIXME(dtantsur): the default is most certainly undesired
-export IRONIC_AGENT_IMAGE=${IRONIC_AGENT_IMAGE:-quay.io/dtantsur/ironic-agent}
+export IRONIC_AGENT_IMAGE
 export IRONIC_AGENT_PODMAN_FLAGS=${IRONIC_AGENT_PODMAN_FLAGS:---tls-verify=false}
 
 IRONIC_CERT_FILE=/certs/ironic/tls.crt

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -6,11 +6,13 @@
 set -x
 
 export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
+# FIXME(dtantsur): the default is most certainly undesired
+export IRONIC_AGENT_IMAGE=${IRONIC_AGENT_IMAGE:-quay.io/dtantsur/ironic-agent}
+export IRONIC_AGENT_PODMAN_FLAGS=${IRONIC_AGENT_PODMAN_FLAGS:---tls-verify=false}
+# Base64 encoded pull secret
+export IRONIC_AGENT_PULL_SECRET=${IRONIC_AGENT_PULL_SECRET:-}
 
 IRONIC_CERT_FILE=/certs/ironic/tls.crt
-
-# FIXME(dtantsur): the default is most certainly undesired
-export IRONIC_AGENT_REGISTRY=${IRONIC_AGENT_REGISTRY:-quay.io/dtantsur}
 
 wait_for_interface_or_ip
 

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -3,6 +3,8 @@
 . /bin/ironic-common.sh
 . /bin/coreos-ipa-common.sh
 
+set -x
+
 export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
 
 IRONIC_CERT_FILE=/certs/ironic/tls.crt
@@ -19,6 +21,9 @@ else
 fi
 
 render_j2_config /tmp/ironic-python-agent.ign.j2 "$IGNITION_FILE"
+# Print the generated ignition for debugging purposes.
+cat "$IGNITION_FILE"
+
 if [ -f "$ISO_FILE" ]; then
     coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"
 fi

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -3,14 +3,15 @@
 . /bin/ironic-common.sh
 . /bin/coreos-ipa-common.sh
 
+# Base64 encoded pull secret
+export IRONIC_AGENT_PULL_SECRET=${IRONIC_AGENT_PULL_SECRET:-}
+
 set -x
 
 export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
 # FIXME(dtantsur): the default is most certainly undesired
 export IRONIC_AGENT_IMAGE=${IRONIC_AGENT_IMAGE:-quay.io/dtantsur/ironic-agent}
 export IRONIC_AGENT_PODMAN_FLAGS=${IRONIC_AGENT_PODMAN_FLAGS:---tls-verify=false}
-# Base64 encoded pull secret
-export IRONIC_AGENT_PULL_SECRET=${IRONIC_AGENT_PULL_SECRET:-}
 
 IRONIC_CERT_FILE=/certs/ironic/tls.crt
 
@@ -24,7 +25,7 @@ fi
 
 render_j2_config /tmp/ironic-python-agent.ign.j2 "$IGNITION_FILE"
 # Print the generated ignition for debugging purposes.
-cat "$IGNITION_FILE"
+cat "$IGNITION_FILE" | sed '/authfile/,+1 s/data:.*"/<redacted>"/'
 
 if [ -f "$ISO_FILE" ]; then
     coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -19,4 +19,6 @@ else
 fi
 
 render_j2_config /tmp/ironic-python-agent.ign.j2 "$IGNITION_FILE"
-coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"
+if [ -f "$ISO_FILE" ]; then
+    coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"
+fi

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+. /bin/ironic-common.sh
+. /bin/coreos-ipa-common.sh
+
+export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
+
+IRONIC_CERT_FILE=/certs/ironic/tls.crt
+
+# FIXME(dtantsur): the default is most certainly undesired
+export IRONIC_AGENT_REGISTRY=${IRONIC_AGENT_REGISTRY:-quay.io/dtantsur}
+
+wait_for_interface_or_ip
+
+if [ -f "$IRONIC_CERT_FILE" ]; then
+    export IRONIC_BASE_URL="https://${IRONIC_URL_HOST}"
+else
+    export IRONIC_BASE_URL="http://${IRONIC_URL_HOST}"
+fi
+
+render_j2_config /tmp/ironic-python-agent.ign.j2 "$IGNITION_FILE"
+coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"

--- a/scripts/coreos-ipa-common.sh
+++ b/scripts/coreos-ipa-common.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/bash
 
-ROOTFS_FILE=/shared/html/images/ironic-python-agent.rootfs
-IGNITION_FILE=/shared/html/ironic-python-agent.ign
-ISO_FILE=/shared/html/images/ironic-python-agent.iso
+ROOTFS_FILE=${ROOTFS_FILE:-/shared/html/images/ironic-python-agent.rootfs}
+IGNITION_FILE=${IGNITION_FILE:-/shared/html/ironic-python-agent.ign}
+ISO_FILE=${ISO_FILE:-/shared/html/images/ironic-python-agent.iso}
 
 function coreos_kernel_params {
     echo -n "coreos.live.rootfs_url=http://$IRONIC_IP:$HTTP_PORT/images/ironic-python-agent.rootfs"

--- a/scripts/coreos-ipa-common.sh
+++ b/scripts/coreos-ipa-common.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+ROOTFS_FILE=/shared/html/images/ironic-python-agent.rootfs
+IGNITION_FILE=/shared/html/ironic-python-agent.ign
+ISO_FILE=/shared/html/images/ironic-python-agent.iso
+
+function coreos_kernel_params {
+    echo -n "coreos.live.rootfs_url=http://$IRONIC_IP:$HTTP_PORT/images/ironic-python-agent.rootfs"
+    echo -n " ignition.config.url=http://$IRONIC_IP:$HTTP_PORT/ironic-python-agent.ign"
+    echo " ignition.firstboot ignition.platform.id=metal"
+}
+
+function use_coreos_ipa {
+    [ -f "$ROOTFS_FILE" ] && [ -f "$IGNITION_FILE" ] && return 0 || return 1
+}
+
+if use_coreos_ipa; then
+    export IRONIC_KERNEL_PARAMS="${IRONIC_KERNEL_PARAMS:-} $(coreos_kernel_params)"
+fi

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -27,6 +27,8 @@ else
     INSPECTOR_EXTRA_ARGS=" ipa-inspection-callback-url=${IRONIC_BASE_URL}:5050/v1/continue"
 fi
 
+. /bin/coreos-ipa-common.sh
+
 # Copy files to shared mount
 render_j2_config /tmp/inspector.ipxe.j2 /shared/html/inspector.ipxe
 cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe


### PR DESCRIPTION
This adds a script we initially created [downstream](https://github.com/openshift/ironic-image/blob/master/scripts/configure-coreos-ipa) 

This is useful for testing metal3 with coreos based builds and the [ironic-agent-image](https://github.com/metal3-io/ironic-agent-image/) via the [customizable deploy procedure](https://github.com/metal3-io/metal3-docs/blob/master/design/deploy-steps.md) that [landed in BMO](https://github.com/metal3-io/baremetal-operator/pull/884).

Adding this means we can close a docs gap and show how to deploy e.g [Fedora CoreOS](https://getfedora.org/en/coreos?stream=stable) via metal3 and also enable easier developer testing of this flow.

This script can be deployed alongside Ironic in the same pod (which is how we use this script downstream as an initContainer), but for upstream testing it may be more useful standalone, e.g:

```
sudo podman run -it -e IRONIC_IP=192.168.3.4 -e IGNITION_FILE=/mnt/ironic-python-agent.ign -v /tmp:/mnt ironic-image configure-coreos-ipa
```

This will use the provided `IRONIC_IP` to template an [ignition](https://github.com/coreos/ignition/) file, and write it to `/tmp`

This process will be used in pending docs updates to show how to achieve the e2e coreos flow in an upstream [metal3-dev-env](https://github.com/metal3-io/metal3-dev-env) environment.