### PR TITLE
Clean up deprecated and unnecessary PXE configuration

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -167,12 +167,9 @@ transport_url = fake://
 boot_retry_timeout = 1200
 images_path = /shared/html/tmp
 instance_master_path = /shared/html/master_images
-ipxe_enabled = true
-pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
 tftp_master_path = /shared/tftpboot/master_images
 tftp_root = /shared/tftpboot
-uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
-pxe_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }}
+kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }}
 # This makes networking boot templates generated even for nodes using local
 # boot (the default), ensuring that they boot correctly even if they start
 # netbooting for some reason (e.g. with the noop management interface).


### PR DESCRIPTION
* ipxe_enabled no longer exists
* pxe_append_params -> kernel_append_params
* (uefi_)pxe_config_template not used for iPXE
