### PR TITLE
Add a combined Ironic launcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ COPY ironic-config/apache2-ironic-api.conf.j2 /etc/httpd-ironic-api.conf.j2
 COPY ironic-config/apache2-vmedia.conf.j2 /etc/httpd-vmedia.conf.j2
 
 # IRONIC-INSPECTOR #
-RUN mkdir -p /var/lib/ironic-inspector && \
+RUN mkdir -p /var/lib/ironic /var/lib/ironic-inspector && \
+  sqlite3 /var/lib/ironic/ironic.db "pragma journal_mode=wal" && \
   sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
   dnf remove -y sqlite
 

--- a/ironic-config/apache2-ironic-api.conf.j2
+++ b/ironic-config/apache2-ironic-api.conf.j2
@@ -18,8 +18,13 @@ Listen 6385
  <VirtualHost {{ env.IRONIC_URL_HOST }}:6385>
 {% endif %}
 
+    {% if env.IRONIC_REVERSE_PROXY_SETUP | lower == "true" %}
+    ProxyPass "/"  "http://127.0.0.1:6388/"
+    ProxyPassReverse "/"  "http://127.0.0.1:6388/"
+    {% else %}
     WSGIDaemonProcess ironic user=ironic group=ironic threads=10 display-name=%{GROUP}
     WSGIScriptAlias / /usr/bin/ironic-api-wsgi
+    {% endif %}
 
     SetEnv APACHE_RUN_USER ironic
     SetEnv APACHE_RUN_GROUP ironic
@@ -45,6 +50,17 @@ Listen 6385
     <Location ~ "^/(v1/?)?$">
         Require all granted
     </Location>    
+
+    {% if env.IRONIC_REVERSE_PROXY_SETUP | lower == "true" %}
+    <Location ~ "^/v1/.+">
+         {% if "HTTP_BASIC_HTPASSWD" in env and env.HTTP_BASIC_HTPASSWD | length %}
+            AuthType Basic
+            AuthName "Restricted area"
+            AuthUserFile "/etc/ironic/htpasswd"
+            Require valid-user
+         {% endif %}
+    </Location>
+    {% else %}
     <Directory /usr/bin >
         WSGIProcessGroup ironic
         WSGIApplicationGroup %{GLOBAL}
@@ -59,4 +75,5 @@ Listen 6385
         Require all granted
         {% endif %}
     </Directory>
+    {% endif %}
  </VirtualHost>

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -82,6 +82,10 @@ verify_step_priority_override = management.clear_job_queue:90
 [database]
 {% if env.IRONIC_USE_MARIADB | lower == "false" %}
 connection = sqlite:////var/lib/ironic/ironic.sqlite
+# Synchronous mode is required for data integrity in case of operating system
+# crash. In our case we restart the container from scratch, so we can save some
+# IO by not doing syncs all the time.
+sqlite_synchronous = False
 {% elif env.MARIADB_TLS_ENABLED == "true" %}
 connection = mysql+pymysql://ironic:{{ env.MARIADB_PASSWORD }}@127.0.0.1/ironic?charset=utf8&ssl=on&ssl_ca={{ env.MARIADB_CACERT_FILE }}
 {% else %}

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -15,7 +15,11 @@ enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,i
 enabled_power_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ibmc,ilo
 enabled_raid_interfaces = no-raid,irmc,agent,fake,ibmc,idrac-wsman,ilo5
 enabled_vendor_interfaces = no-vendor,ipmitool,idrac,idrac-redfish,redfish,ilo,fake,ibmc
+{% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}
 rpc_transport = json-rpc
+{% else %}
+rpc_transport = none
+{% endif %}
 use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
@@ -71,7 +75,9 @@ bootloader = http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/uefi_esp.img
 verify_step_priority_override = management.clear_job_queue:90
 
 [database]
-{% if env.MARIADB_TLS_ENABLED == "true" %}
+{% if env.IRONIC_USE_MARIADB | lower == "false" %}
+connection = sqlite:////var/lib/ironic/ironic.sqlite
+{% elif env.MARIADB_TLS_ENABLED == "true" %}
 connection = mysql+pymysql://ironic:{{ env.MARIADB_PASSWORD }}@127.0.0.1/ironic?charset=utf8&ssl=on&ssl_ca={{ env.MARIADB_CACERT_FILE }}
 {% else %}
 connection = mysql+pymysql://ironic:{{ env.MARIADB_PASSWORD }}@127.0.0.1/ironic?charset=utf8
@@ -135,6 +141,7 @@ command_retry_timeout = 60
 # is not set for the node. (list value)
 cipher_suite_versions = 3,17
 
+{% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}
 [json_rpc]
 # We assume that when we run API and conductor in the same container, they use
 # authentication over localhost, using the same credentials as API, to prevent
@@ -153,6 +160,7 @@ host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env
 use_ssl = true
 cafile = {{ env.IRONIC_CACERT_FILE }}
 insecure = {{ env.IRONIC_INSECURE }}
+{% endif %}
 {% endif %}
 
 [oslo_messaging_notifications]

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -56,11 +56,16 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 max_command_attempts = 30
 
 [api]
+{% if env.IRONIC_REVERSE_PROXY_SETUP == "true" %}
+host_ip = 127.0.0.1
+port = 6388
+{% else %}
 host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
-api_workers = {{ env.NUMWORKERS }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 enable_ssl_api = true
 {% endif %}
+{% endif %}
+api_workers = {{ env.NUMWORKERS }}
 
 [conductor]
 automated_clean = {{ env.IRONIC_AUTOMATED_CLEAN }}

--- a/ironic-inspector-config/ironic-inspector.conf.j2
+++ b/ironic-inspector-config/ironic-inspector.conf.j2
@@ -15,7 +15,7 @@ use_ssl = true
 {% endif %}
 
 [database]
-connection = sqlite:///var/lib/ironic-inspector/ironic-inspector.db
+connection = sqlite:////var/lib/ironic-inspector/ironic-inspector.db
 
 {% if env.IRONIC_INSPECTOR_ENABLE_DISCOVERY == "true" %}
 [discovery]

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -20,9 +20,10 @@ fi
 
 # SOURCE install #
 if [[ $INSTALL_TYPE == "source" ]]; then
-    BUILD_DEPS="python3-pip python3-devel gcc git-core"
+    BUILD_DEPS="python3-devel gcc git-core"
     dnf upgrade -y
-    dnf install -y $BUILD_DEPS
+    # NOTE(dtantsur): pip is a requirement of python3 in CentOS
+    dnf install -y python3-pip $BUILD_DEPS
     pip3 install pip==21.3.1
     pip3 install --prefix /usr -r $IRONIC_PKG_LIST -c https://raw.githubusercontent.com/openstack/requirements/master/upper-constraints.txt
 

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -19,6 +19,9 @@ NUMPROC=$(( NUMPROC <= 4 ? NUMPROC : 4 ))
 export NUMWORKERS=${NUMWORKERS:-$NUMPROC}
 export LISTEN_ALL_INTERFACES="${LISTEN_ALL_INTERFACES:-"true"}"
 
+export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-true}
+export IRONIC_EXPOSE_JSON_RPC=${IRONIC_EXPOSE_JSON_RPC:-true}
+
 # Whether to enable fast_track provisioning or not
 export IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
 

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -51,3 +51,18 @@ function wait_for_interface_or_ip() {
 function render_j2_config () {
     python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $1 > $2
 }
+
+function run_ironic_dbsync() {
+    if [[ "${IRONIC_USE_MARIADB:-true}" == "true" ]]; then
+        # It's possible for the dbsync to fail if mariadb is not up yet, so
+        # retry until success
+        until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
+          echo "WARNING: ironic-dbsync failed, retrying"
+          sleep 1
+        done
+    else
+        # SQLite does not support some statements. Fortunately, we can just create
+        # the schema in one go instead of going through an upgrade.
+        ironic-dbsync --config-file /etc/ironic/ironic.conf create_schema
+    fi
+}

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -9,6 +9,7 @@ export VMEDIA_TLS_PORT=${VMEDIA_TLS_PORT:-8083}
 
 INSPECTOR_ORIG_HTTPD_CONFIG=/etc/httpd/conf.d/inspector-apache.conf.j2
 INSPECTOR_RESULT_HTTPD_CONFIG=/etc/httpd/conf.d/ironic-inspector.conf
+export IRONIC_REVERSE_PROXY_SETUP=${IRONIC_REVERSE_PROXY_SETUP:-"false"}
 export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-"false"}
 
 # Whether to enable fast_track provisioning or not
@@ -44,10 +45,20 @@ else
     export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
 fi
 
+if [ "$IRONIC_TLS_SETUP" = "true" ]; then
+    if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "true" ]]; then
+      render_j2_config /etc/httpd-ironic-api.conf.j2 /etc/httpd/conf.d/ironic.conf
+    fi
+    # Add user 'apache' to the group `ironic-inspector`, so httpd can access /etc/ironic-inspector and read the pasword file
+    usermod -aG ironic apache
+else
+    export IRONIC_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
+fi
+
 # Configure HTTP basic auth for API server
-HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
 if [ -n "${HTTP_BASIC_HTPASSWD:-}" ]; then
-    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
+    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" > /etc/ironic/htpasswd
+    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" > /etc/ironic-inspector/htpasswd
 fi
 
 # Use configured values

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+# These settings must go before configure-ironic since it has different
+# defaults.
+export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-false}
+export IRONIC_EXPOSE_JSON_RPC=${IRONIC_EXPOSE_JSON_RPC:-false}
+
+. /bin/configure-ironic.sh
+
+# Ramdisk logs
+mkdir -p /shared/log/ironic/deploy
+
+# It's possible for the dbsync to fail if mariadb is not up yet, so
+# retry until success
+until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
+  echo "WARNING: ironic-dbsync failed, retrying"
+  sleep 1
+done
+
+if [[ "$IRONIC_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
+    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read file event; do
+     kill $(pgrep ironic)
+    done &
+fi
+
+exec /usr/bin/ironic

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -10,12 +10,7 @@ export IRONIC_EXPOSE_JSON_RPC=${IRONIC_EXPOSE_JSON_RPC:-false}
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
-# It's possible for the dbsync to fail if mariadb is not up yet, so
-# retry until success
-until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
-  echo "WARNING: ironic-dbsync failed, retrying"
-  sleep 1
-done
+run_ironic_dbsync
 
 if [[ "$IRONIC_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
     inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read file event; do

--- a/scripts/runironic-api
+++ b/scripts/runironic-api
@@ -4,6 +4,8 @@ export IRONIC_DEPLOYMENT="API"
 
 . /bin/configure-ironic.sh
 
+export IRONIC_REVERSE_PROXY_SETUP=false
+
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic.conf
 
 . /bin/runhttpd

--- a/scripts/runironic-conductor
+++ b/scripts/runironic-conductor
@@ -7,12 +7,7 @@ export IRONIC_DEPLOYMENT="Conductor"
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
-# It's possible for the dbsync to fail if mariadb is not up yet, so
-# retry until success
-until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do
-  echo "WARNING: ironic-dbsync failed, retrying"
-  sleep 1
-done
+run_ironic_dbsync
 
 if [[ "$IRONIC_TLS_SETUP" == "true"  && "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
     inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read file event; do


### PR DESCRIPTION
This series of commits adds a new entrypoint `/bin/runironic` that uses the new combined `ironic` executable to start both API and conductor in one process. TLS is expected to be handled by a reverse proxy setup, similar to Inspector. The default for the new executable is to be backed by SQLite, not MariaDB for a smaller footprint.