### PR TITLE
Remove unnecessary flag of ipcalc

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -23,7 +23,7 @@ function wait_for_interface_or_ip() {
   if [ ! -z "${PROVISIONING_IP}" ];
   then
     # Convert the address using ipcalc which strips out the subnet. For IPv6 addresses, this will give the short-form address
-    export IRONIC_IP=$(ipcalc -s "${PROVISIONING_IP}" | grep "^Address:" | awk '{print $2}')
+    export IRONIC_IP=$(ipcalc "${PROVISIONING_IP}" | grep "^Address:" | awk '{print $2}')
     until ip -br addr show | grep -q -F " ${IRONIC_IP}/"; do
       echo "Waiting for ${IRONIC_IP} to be configured on an interface"
       sleep 1


### PR DESCRIPTION
This PR removes the -s parameter of `ipcalc`. 
- `-s ` makes `ipcalc` not printing error message when error occurs. Therefore, removing this parameter should not affect the workflow, but can also provide some clues when there is an error.
- Folks who are more familiar to Ubuntu or other OSes may feel confusing when reading code because in other OSes, `-s` mean splitting. Therefore, removing this parameter makes it easier to maintain the code. 
