### PR TITLE
Install the RPM of the combined Ironic

### DIFF
--- a/ironic-rpm-list.txt
+++ b/ironic-rpm-list.txt
@@ -1,4 +1,5 @@
 crudini
+openstack-ironic
 openstack-ironic-api
 openstack-ironic-conductor
 openstack-ironic-inspector


### PR DESCRIPTION
We support running API+conductor combined, but we don't actually install the corresponding RPM.