### PR TITLE
Add different variables for htpasswd of ironic and inspector

### DIFF
--- a/ironic-config/apache2-ironic-api.conf.j2
+++ b/ironic-config/apache2-ironic-api.conf.j2
@@ -53,7 +53,7 @@ Listen 6385
 
     {% if env.IRONIC_REVERSE_PROXY_SETUP | lower == "true" %}
     <Location ~ "^/v1/.+">
-         {% if "HTTP_BASIC_HTPASSWD" in env and env.HTTP_BASIC_HTPASSWD | length %}
+         {% if "IRONIC_HTPASSWD" in env and env.IRONIC_HTPASSWD | length %}
             AuthType Basic
             AuthName "Restricted area"
             AuthUserFile "/etc/ironic/htpasswd"
@@ -66,7 +66,7 @@ Listen 6385
         WSGIApplicationGroup %{GLOBAL}
         AllowOverride None  
         
-        {% if "HTTP_BASIC_HTPASSWD" in env and env.HTTP_BASIC_HTPASSWD | length %}
+        {% if "IRONIC_HTPASSWD" in env and env.IRONIC_HTPASSWD | length %}
         AuthType Basic
         AuthName "Restricted WSGI area"
         AuthUserFile "/etc/ironic/htpasswd"

--- a/ironic-inspector-config/inspector-apache.conf.j2
+++ b/ironic-inspector-config/inspector-apache.conf.j2
@@ -31,7 +31,7 @@ Listen 5050
 
 
      <Location /v1/introspection/ >
-         {% if "HTTP_BASIC_HTPASSWD" in env and env.HTTP_BASIC_HTPASSWD | length %}
+         {% if "INSPECTOR_HTPASSWD" in env and env.INSPECTOR_HTPASSWD | length %}
             AuthType Basic
             AuthName "Restricted area"
             AuthUserFile "/etc/ironic-inspector/htpasswd"

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -55,16 +55,17 @@ mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter
 
 HTPASSWD_FILE=/etc/ironic/htpasswd
+export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
 # The user can provide HTTP_BASIC_HTPASSWD and HTTP_BASIC_HTPASSWD_RPC. If
 # - we are running conductor and HTTP_BASIC_HTPASSWD is set,
 #   use HTTP_BASIC_HTPASSWD for RPC.
 export JSON_RPC_AUTH_STRATEGY="noauth"
-if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
+if [ -n "${IRONIC_HTPASSWD}" ]; then
     if [ "${IRONIC_DEPLOYMENT}" == "Conductor" ]; then
         export JSON_RPC_AUTH_STRATEGY="http_basic"
-        printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}-rpc"
+        printf "%s\n" "${IRONIC_HTPASSWD}" >"${HTPASSWD_FILE}-rpc"
     else
-        printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
+        printf "%s\n" "${IRONIC_HTPASSWD}" >"${HTPASSWD_FILE}"
     fi
 fi
 

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -54,10 +54,15 @@ else
     export IRONIC_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
 fi
 
+export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+
 # Configure HTTP basic auth for API server
-if [ -n "${HTTP_BASIC_HTPASSWD:-}" ]; then
-    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" > /etc/ironic/htpasswd
-    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" > /etc/ironic-inspector/htpasswd
+if [ -n "${IRONIC_HTPASSWD:-}" ]; then
+    printf "%s\n" "${IRONIC_HTPASSWD}" > /etc/ironic/htpasswd
+fi
+if [ -n "${INSPECTOR_HTPASSWD:-}" ]; then
+    printf "%s\n" "${INSPECTOR_HTPASSWD}" > /etc/ironic-inspector/htpasswd
 fi
 
 # Use configured values

--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -24,6 +24,8 @@ export IRONIC_INSPECTOR_BASE_URL="${IRONIC_INSPECTOR_SCHEME}://${IRONIC_URL_HOST
 
 export IRONIC_BASE_URL="${IRONIC_SCHEME}://${IRONIC_URL_HOST}:6385"
 
+export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+
 function build_j2_config() {
   CONFIG_FILE=$1
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
@@ -35,8 +37,8 @@ build_j2_config $CONFIG | crudini --merge $CONFIG
 
 # Configure HTTP basic auth for API server
 HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
-if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
-    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
+if [ -n "${INSPECTOR_HTPASSWD}" ]; then
+    printf "%s\n" "${INSPECTOR_HTPASSWD}" >"${HTPASSWD_FILE}"
     if [[ $INSPECTOR_REVERSE_PROXY_SETUP == "false" ]]
     then
       crudini --set $CONFIG DEFAULT auth_strategy http_basic


### PR DESCRIPTION
It's common to use different values, which gets confusing when both
services are proxied through the same HTTPd.