### PR TITLE
Fix authentication with Ironic reverse proxy

### DIFF
--- a/ironic-config/apache2-ironic-api.conf.j2
+++ b/ironic-config/apache2-ironic-api.conf.j2
@@ -41,18 +41,8 @@ Listen 6385
     SSLCertificateKeyFile {{ env.IRONIC_KEY_FILE }}
 {% endif %}
 
-    <Location /v1/lookup >
-        Require all granted
-    </Location>
-    <Location /v1/heartbeat >
-        Require all granted
-    </Location>
-    <Location ~ "^/(v1/?)?$">
-        Require all granted
-    </Location>    
-
     {% if env.IRONIC_REVERSE_PROXY_SETUP | lower == "true" %}
-    <Location ~ "^/v1/.+">
+    <Location />
          {% if "IRONIC_HTPASSWD" in env and env.IRONIC_HTPASSWD | length %}
             AuthType Basic
             AuthName "Restricted area"
@@ -64,8 +54,8 @@ Listen 6385
     <Directory /usr/bin >
         WSGIProcessGroup ironic
         WSGIApplicationGroup %{GLOBAL}
-        AllowOverride None  
-        
+        AllowOverride None
+
         {% if "IRONIC_HTPASSWD" in env and env.IRONIC_HTPASSWD | length %}
         AuthType Basic
         AuthName "Restricted WSGI area"
@@ -76,4 +66,12 @@ Listen 6385
         {% endif %}
     </Directory>
     {% endif %}
- </VirtualHost>
+
+    <Location ~ "^/(v1/?)?$" >
+        Require all granted
+    </Location>
+
+    <Location ~ "^/(v1/)?(lookup|heartbeat)" >
+        Require all granted
+    </Location>
+</VirtualHost>


### PR DESCRIPTION
1) The authentication code assumes /v1 prefix, but Ironic has redirects,
   e.g. /drivers -> /v1/drivers
2) The lookup/heartbeat endpoint rules are overridden by the generic
   rule, so they don't have effect.

While here, fix some whitespace.
