### PR TITLE
Move LISTEN_ALL_INTERFACES to ironic-common

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -17,7 +17,6 @@ export MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
 NUMPROC=$(( NUMPROC <= 4 ? NUMPROC : 4 ))
 export NUMWORKERS=${NUMWORKERS:-$NUMPROC}
-export LISTEN_ALL_INTERFACES="${LISTEN_ALL_INTERFACES:-"true"}"
 
 export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-true}
 export IRONIC_EXPOSE_JSON_RPC=${IRONIC_EXPOSE_JSON_RPC:-true}

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -17,6 +17,8 @@ function get_provisioning_interface() {
 
 export PROVISIONING_INTERFACE=$(get_provisioning_interface)
 
+export LISTEN_ALL_INTERFACES="${LISTEN_ALL_INTERFACES:-"true"}"
+
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 function wait_for_interface_or_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP


### PR DESCRIPTION
When Ironic is in reverse proxy mode, it is also used by runhttpd.
