### PR TITLE
Call configure-coreos-ipa in httpd to create the Ignition file

### DIFF
--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -4,6 +4,8 @@
 
 . /bin/ironic-common.sh
 
+. /bin/configure-coreos-ipa
+
 HTTP_PORT=${HTTP_PORT:-"80"}
 export VMEDIA_TLS_PORT=${VMEDIA_TLS_PORT:-8083}
 


### PR DESCRIPTION
Fixed the issue of missing Ignition file during IPI deployment.
configure-coreos-ipa is not called in httpd and the IGNITION_FILE is not created,
so the address of IGNITION_FILE is not added to the boot kernel parameters.

Fixes: https://github.com/openshift/installer/issues/5542

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>