### PR TITLE
Fix authentication for inspector in reverse proxy mode

### DIFF
--- a/ironic-inspector-config/inspector-apache.conf.j2
+++ b/ironic-inspector-config/inspector-apache.conf.j2
@@ -29,15 +29,20 @@ Listen 5050
     SSLCertificateFile {{ env.IRONIC_INSPECTOR_CERT_FILE }} 
     SSLCertificateKeyFile {{ env.IRONIC_INSPECTOR_KEY_FILE }}
 
+    {% if "INSPECTOR_HTPASSWD" in env and env.INSPECTOR_HTPASSWD | length %}
+    <Location / >
+        AuthType Basic
+        AuthName "Restricted area"
+        AuthUserFile "/etc/ironic-inspector/htpasswd"
+        Require valid-user
+    </Location>
 
-     <Location /v1/introspection/ >
-         {% if "INSPECTOR_HTPASSWD" in env and env.INSPECTOR_HTPASSWD | length %}
-            AuthType Basic
-            AuthName "Restricted area"
-            AuthUserFile "/etc/ironic-inspector/htpasswd"
-            Require valid-user
-         {% endif %}
-     </Location>
+    <Location ~ "^/(v1/?)?$" >
+        Require all granted
+    </Location>
 
-
+    <Location /v1/continue >
+        Require all granted
+    </Location>
+    {% endif %}
 </VirtualHost>


### PR DESCRIPTION
1) It blocks /v1/introspection/ but allows /v1/introspection, which
   lists introspection results per node.
2) It does not block /v1/rules used to create introspection rules.
