### PR TITLE
move maelk to emeritus_reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,7 +9,9 @@ approvers:
 
 reviewers:
  - iurygregory
- - maelk
  - namnx228
  - stbenjam
  - zaneb
+
+emeritus_reviewers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.