### PR TITLE
Fix missing codepage 850 in conversion table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,15 @@ ARG BASE_IMAGE=quay.io/centos/centos:stream8
 
 FROM $BASE_IMAGE AS ironic-builder
 
-RUN dnf install -y gcc git make xz-devel
+# NOTE(elfosardo): glibc-gconv-extra was included by default in the past and
+# we need it otherwise mkfs.msdos will fail with:
+# ``Cannot initialize conversion from codepage 850 to ANSI_X3.4-1968: Invalid argument``
+# ``Cannot initialize conversion from ANSI_X3.4-1968 to codepage 850: Invalid argument``
+# subsequently making mmd fail with:
+# ``Error converting to codepage 850 Invalid argument``
+# ``Cannot initialize '::'``
+# This is due to the conversion table missing codepage 850, included in glibc-gconv-extra
+RUN dnf install -y gcc git make xz-devel glibc-gconv-extra
 WORKDIR /tmp
 RUN git clone --depth 1 --branch v1.21.1 https://github.com/ipxe/ipxe.git && \
       cd ipxe && \


### PR DESCRIPTION
glibc-gconv-extra was included by default in the past and
we need it otherwise mkfs.msdos will fail with:
``Cannot initialize conversion from codepage 850 to ANSI_X3.4-1968: Invalid argument``
``Cannot initialize conversion from ANSI_X3.4-1968 to codepage 850: Invalid argument``
subsequently making mmd fail with:
``Error converting to codepage 850 Invalid argument``
``Cannot initialize '::'``
This is due to the conversion table missing codepage 850, included
in glibc-gconv-extra

Fix https://github.com/metal3-io/ironic-image/issues/353