### PR TITLE
Promote Iury to approvers, remove Stephen

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,12 +6,12 @@ approvers:
  - dtantsur
  - elfosardo
  - hardys
+ - iurygregory
 
 reviewers:
- - iurygregory
  - namnx228
- - stbenjam
  - zaneb
 
 emeritus_reviewers:
  - maelk
+ - stbenjam


### PR DESCRIPTION
Iury is the Ironic PTL (project team lead) and has been consistently
reviewing ironic-image changes in his reviewer role.

Stephen has moved to another role.
