### PR TITLE
Let Ironic handle retry instead of ipmitool

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -137,7 +137,7 @@ callback_endpoint_override = {{ env.IRONIC_INSPECTOR_CALLBACK_ENDPOINT_OVERRIDE 
 # when supported. If set to false, then ipmitool is called as follows :
 #    $ipmitool -R 1 -N 1 ...
 # and Ironic handles the retry loop.
-use_ipmitool_retries = true
+use_ipmitool_retries = false
 # The following parameters are the defaults in Ironic. They are used in the
 # following way if use_ipmitool_retries is set to true:
 #    $ipmitool -R <X> -N <Y> ...


### PR DESCRIPTION
There seems to be an issue where ipmitool does not retry with different
ciphers. This could be worked around by letting Ironic handle the retry
instead.

Discussion on slack: https://kubernetes.slack.com/archives/CHD49TLE7/p1645523770977829

Here is a description of the issue we are having:

We have a (very old) hardware where IPMI cipher suite 3 is supported, but not 17. Due to https://github.com/metal3-io/ironic-image/blob/307e765800a701da39d6d2febd1bdbf6d36cb700/ironic-config/ironic.conf.j2#L140, we let ipmitool handle the retry loop. but then ipmitool only uses cipher 17 (we don't have https://github.com/ipmitool/ipmitool/commit/7772254b62826b894ca629df8c597030a98f4f72 in our ipmitool release). Due to https://github.com/openstack/ironic/blob/53a38f18d47d3fef5e9a7a8f6ecf5ab99b2f8e0f/ironic/drivers/modules/ipmitool.py#L662, Ironic does not handle the retry loop and does not actually change the ciphers that we provide in https://github.com/metal3-io/ironic-image/blob/307e765800a701da39d6d2febd1bdbf6d36cb700/ironic-config/ironic.conf.j2#L154 . So that last setting has no effect. The question is then : What would be the impact of changing the config to let Ironic handle the retry loop? Would there be any inconvenient vs using ipmitool to do the retries?