### PR TITLE
🐛 Add python3-pip package to packages list to use pip3 in patch image script

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -6,6 +6,7 @@ ipmitool
 iproute
 mod_ssl
 procps
+python3-pip
 python3-jinja2
 python3-mod_wsgi
 qemu-img


### PR DESCRIPTION
After switching to CentOS Stream 9 base image, our main custom IPA image building [jobs](https://jenkins.nordix.org/view/Metal3/job/metal3_main_openstack_ipa_and_ironic_image_building/71/console) started failing with pip3 being not found while doing a patch in the image. 
```

[91m+ pip3 install --prefix /usr dist/ironic-20.0.1.dev38.tar.gz
/bin/patch-image.sh: line 20: pip3: command not found
[0mThe command '/bin/sh -c prepare-image.sh &&   rm -f /bin/prepare-image.sh' returned a non-zero code: 127
make: *** [Makefile:145: build_ipa] Error 127
```

This PR adds [python3-pip](https://centos.pkgs.org/9-stream/centos-appstream-x86_64/python3-pip-21.2.3-5.el9.noarch.rpm.html) to the main packages list ~and uses that in the patch image script instead of pip3~