### PR TITLE
Move python3-pip install into patch-image script

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -6,7 +6,6 @@ ipmitool
 iproute
 mod_ssl
 procps
-python3-pip
 python3-jinja2
 python3-mod_wsgi
 qemu-img

--- a/patch-image.sh
+++ b/patch-image.sh
@@ -4,6 +4,8 @@ set -ex
 PATCH_FILE="/tmp/${PATCH_LIST}"
 VARS="PROJECT REFSPEC GIT_HOST"
 
+dnf install -y python3-pip
+
 while IFS= read -r line
 do
     IFS=' ' read -r $VARS <<< $line


### PR DESCRIPTION
It's not needed if not for the patch-image script, so install it only
when we run that script.