### PR TITLE
Drop unused ipxe.efi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone --depth 1 --branch v1.21.1 https://github.com/ipxe/ipxe.git && \
       cd ipxe/src && \
       ARCH=$(uname -m | sed 's/aarch/arm/') && \
       # NOTE(elfosardo): warning should not be treated as errors by default
-      NO_WERROR=1 make bin/undionly.kpxe bin-$ARCH-efi/ipxe.efi bin-$ARCH-efi/snponly.efi
+      NO_WERROR=1 make bin/undionly.kpxe bin-$ARCH-efi/snponly.efi
 
 COPY prepare-efi.sh /bin/
 RUN prepare-efi.sh centos
@@ -43,7 +43,7 @@ RUN prepare-image.sh && \
 COPY scripts/ /bin/
 
 # IRONIC #
-COPY --from=ironic-builder /tmp/ipxe/src/bin/undionly.kpxe /tmp/ipxe/src/bin-x86_64-efi/snponly.efi /tmp/ipxe/src/bin-x86_64-efi/ipxe.efi /tftpboot/
+COPY --from=ironic-builder /tmp/ipxe/src/bin/undionly.kpxe /tmp/ipxe/src/bin-x86_64-efi/snponly.efi /tftpboot/
 COPY --from=ironic-builder /tmp/esp.img /tmp/uefi_esp.img
 
 COPY ironic-config/ironic.conf.j2 /etc/ironic/

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -12,7 +12,7 @@ mkdir -p /shared/html/images
 mkdir -p /shared/html/pxelinux.cfg
 
 # Copy files to shared mount
-cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftpboot
+cp /tftpboot/undionly.kpxe /tftpboot/snponly.efi /shared/tftpboot
 
 # Template and write dnsmasq.conf
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf


### PR DESCRIPTION
https://github.com/metal3-io/ironic-image/pull/152 seems to have removed the last use of ipxe.efi in favour of snponly.efi.

/cc @elfosardo
