### PR TITLE
Increase power_state_change_timeout setting

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -81,6 +81,8 @@ bootloader = http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/uefi_esp.img
 verify_step_priority_override = management.clear_job_queue:90
 # We don't use this feature, and it creates an additional load on the database
 node_history = False
+# Provide for a timeout longer than 60 seconds for certain vendor's hardware
+power_state_change_timeout = 120
 
 [database]
 {% if env.IRONIC_USE_MARIADB | lower == "false" %}


### PR DESCRIPTION
There have been cases on some hardware where the power state change takes longer than the current default (60 seconds) to be reported. This does not need to be configurable.