### PR TITLE
Add option to to listen on a single inspector interface

### DIFF
--- a/ironic-inspector-config/ironic-inspector.conf.j2
+++ b/ironic-inspector-config/ironic-inspector.conf.j2
@@ -6,8 +6,10 @@ use_stderr = true
 {% if env.INSPECTOR_REVERSE_PROXY_SETUP == "true" %}
 listen_port = {{ env.IRONIC_INSPECTOR_PRIVATE_PORT }}
 listen_address = 127.0.0.1
-{% else %}
+{% elif  env.LISTEN_ALL_INTERFACES | lower == "true" %}
 listen_address = ::
+{% else %}
+listen_address = {{ env.IRONIC_IP }}
 {% endif %}
 host = {{ env.IRONIC_IP }}
 {% if env.IRONIC_INSPECTOR_TLS_SETUP == "true" and env.INSPECTOR_REVERSE_PROXY_SETUP == "false" %}


### PR DESCRIPTION
When running ironic without TLS inspector is running without reverse proxy and it always listening on all interfaces, since we have already introduced an option to listen on a single interface #371 this PR add the option in the case we run ironic without TLS