### PR TITLE
Pin Werkzeug to 2.1.2 until newer version of sushy-tools is out

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update && \
     apt install -y libvirt-dev && \
     apt clean && \
     pip3 install --no-cache-dir \
-        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python
+        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python Werkzeug==2.1.2
 
 CMD /usr/local/bin/sushy-emulator -i :: -p 8000 \
         --config /root/sushy/conf.py --debug


### PR DESCRIPTION
Werkzeug 2.2.0 broke behavior of sushy-tools until version 0.20.0
is out.