### PR TITLE
Update sushy-tools to version 0.20.0

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,12 +1,12 @@
 FROM registry.hub.docker.com/library/python:3.9
 
-ARG SUSHY_TOOLS_VERSION="0.18.1"
+ARG SUSHY_TOOLS_VERSION="0.20.0"
 
 RUN apt update && \
     apt install -y libvirt-dev && \
     apt clean && \
     pip3 install --no-cache-dir \
-        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python Werkzeug==2.1.2
+        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python
 
 CMD /usr/local/bin/sushy-emulator -i :: -p 8000 \
         --config /root/sushy/conf.py --debug


### PR DESCRIPTION
This brings back full compatibility with latest versions of Werkzeug
after changes in 2.2.0