### PR TITLE
Support for unix sockets in reverse proxy mode

### DIFF
--- a/ironic-config/apache2-ironic-api.conf.j2
+++ b/ironic-config/apache2-ironic-api.conf.j2
@@ -19,8 +19,15 @@ Listen 6385
 {% endif %}
 
     {% if env.IRONIC_REVERSE_PROXY_SETUP | lower == "true" %}
+
+    {% if env.IRONIC_PRIVATE_PORT == "unix" %}
+    ProxyPass "/"  "unix:/shared/ironic.sock|http://127.0.0.1/"
+    ProxyPassReverse "/"  "unix:/shared/ironic.sock|http://127.0.0.1/"
+    {% else %}
     ProxyPass "/"  "http://127.0.0.1:{{ env.IRONIC_PRIVATE_PORT }}/"
     ProxyPassReverse "/"  "http://127.0.0.1:{{ env.IRONIC_PRIVATE_PORT }}/"
+    {% endif %}
+
     {% else %}
     WSGIDaemonProcess ironic user=ironic group=ironic threads=10 display-name=%{GROUP}
     WSGIScriptAlias / /usr/bin/ironic-api-wsgi

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -57,8 +57,15 @@ max_command_attempts = 30
 
 [api]
 {% if env.IRONIC_REVERSE_PROXY_SETUP == "true" %}
+{% if env.IRONIC_PRIVATE_PORT == "unix" %}
+unix_socket = /shared/ironic.sock
+# NOTE(dtantsur): this is not ideal, but since the socket is accessed from
+# another container, we need to make it world-writeable.
+unix_socket_mode = 0666
+{% else %}
 host_ip = 127.0.0.1
 port = {{ env.IRONIC_PRIVATE_PORT }}
+{% endif %}
 public_endpoint = {{ env.IRONIC_BASE_URL }}
 {% else %}
 host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}

--- a/ironic-inspector-config/inspector-apache.conf.j2
+++ b/ironic-inspector-config/inspector-apache.conf.j2
@@ -17,8 +17,13 @@ Listen 5050
 {% else %}
  <VirtualHost {{ env.IRONIC_URL_HOST }}:5050>
 {% endif %}
+    {% if env.IRONIC_INSPECTOR_PRIVATE_PORT == "unix" %}
+    ProxyPass "/"  "unix:/shared/inspector.sock|http://127.0.0.1/"
+    ProxyPassReverse "/"  "unix:/shared/inspector.sock|http://127.0.0.1/"
+    {% else %}
     ProxyPass "/"  "http://127.0.0.1:{{ env.IRONIC_INSPECTOR_PRIVATE_PORT }}/"
     ProxyPassReverse "/"  "http://127.0.0.1:{{ env.IRONIC_INSPECTOR_PRIVATE_PORT }}/"
+    {% endif %}
 
     SetEnv APACHE_RUN_USER ironic-inspector
     SetEnv APACHE_RUN_GROUP ironic-inspector

--- a/ironic-inspector-config/ironic-inspector.conf.j2
+++ b/ironic-inspector-config/ironic-inspector.conf.j2
@@ -4,8 +4,15 @@ debug = true
 transport_url = fake://
 use_stderr = true
 {% if env.INSPECTOR_REVERSE_PROXY_SETUP == "true" %}
+{% if env.IRONIC_INSPECTOR_PRIVATE_PORT == "unix" %}
+listen_unix_socket = /shared/inspector.sock
+# NOTE(dtantsur): this is not ideal, but since the socket is accessed from
+# another container, we need to make it world-writeable.
+listen_unix_socket_mode = 0666
+{% else %}
 listen_port = {{ env.IRONIC_INSPECTOR_PRIVATE_PORT }}
 listen_address = 127.0.0.1
+{% endif %}
 {% elif  env.LISTEN_ALL_INTERFACES | lower == "true" %}
 listen_address = ::
 {% else %}

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -69,5 +69,6 @@ function run_ironic_dbsync() {
     fi
 }
 
+# Use the special value "unix" for unix sockets
 export IRONIC_PRIVATE_PORT=${IRONIC_PRIVATE_PORT:-6388}
 export IRONIC_INSPECTOR_PRIVATE_PORT=${IRONIC_INSPECTOR_PRIVATE_PORT:-5049}

--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -16,7 +16,7 @@ wait_for_interface_or_ip
 
 IRONIC_INSPECTOR_PORT=5050
 if [ "$IRONIC_INSPECTOR_TLS_SETUP" = "true" ]; then
-    if [[ "${INSPECTOR_REVERSE_PROXY_SETUP}" == "true" ]]; then
+    if [[ "${INSPECTOR_REVERSE_PROXY_SETUP}" == "true" && "${IRONIC_INSPECTOR_PRIVATE_PORT}" != "unix" ]]; then
         IRONIC_INSPECTOR_PORT=$IRONIC_INSPECTOR_PRIVATE_PORT
     fi
 else


### PR DESCRIPTION
Since httpd, ironic and inspector share a volume, there is no point
in allocating private ports and making their communication go through
the network stack. Allow using unix sockets instead.
