### PR TITLE
Support idrac-redifsh driver in raid interfaces of ironic configuration

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -13,7 +13,7 @@ enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,ibmc,manual-manag
 enabled_inspect_interfaces = inspector,idrac,irmc,fake,redfish,ilo
 enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ibmc,ilo,ilo5,noop
 enabled_power_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish,ibmc,ilo
-enabled_raid_interfaces = no-raid,irmc,agent,fake,ibmc,idrac-wsman,ilo5
+enabled_raid_interfaces = no-raid,irmc,agent,fake,ibmc,idrac-wsman,redfish,idrac-redfish,ilo5
 enabled_vendor_interfaces = no-vendor,ipmitool,idrac,idrac-redfish,redfish,ilo,fake,ibmc
 {% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}
 rpc_transport = json-rpc


### PR DESCRIPTION
To provision Dell servers with redfish, we need to enable the idrac-redfish in the raid interfaces of the Ironic configuration.

Fixes: #384