### PR TITLE
Allow dnsmasq to work as a DNS forwarder

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -2,9 +2,10 @@ interface={{ env.PROVISIONING_INTERFACE }}
 bind-dynamic
 enable-tftp
 tftp-root=/shared/tftpboot
+log-queries
 
-# Disable listening for DNS
-port=0
+# Configure listening for DNS (0 disables DNS)
+port={{ env.DNS_PORT }}
 
 {%- if env.DHCP_RANGE | length %}
 log-dhcp

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -4,6 +4,7 @@
 
 export HTTP_PORT=${HTTP_PORT:-"80"}
 DNSMASQ_EXCEPT_INTERFACE=${DNSMASQ_EXCEPT_INTERFACE:-"lo"}
+export DNS_PORT=${DNS_PORT:-0}
 
 wait_for_interface_or_ip
 


### PR DESCRIPTION
May be very useful when early resolving of hostnames is required.
