### PR TITLE
Removed ServerName from VirtualHost Directives

### DIFF
--- a/ironic-config/apache2-ironic-api.conf.j2
+++ b/ironic-config/apache2-ironic-api.conf.j2
@@ -42,7 +42,6 @@ Listen {{ env.IRONIC_LISTEN_PORT }}
     CustomLog /dev/stdout combined
 
 {% if env.IRONIC_TLS_SETUP == "true" %}
-    ServerName {{ env.IRONIC_IP }}
     SSLEngine on
     SSLProtocol {{ env.IRONIC_SSL_PROTOCOL }}
     SSLCertificateFile {{ env.IRONIC_CERT_FILE }}

--- a/ironic-config/apache2-vmedia.conf.j2
+++ b/ironic-config/apache2-vmedia.conf.j2
@@ -5,7 +5,6 @@ Listen {{ env.VMEDIA_TLS_PORT }}
     LogLevel debug
     CustomLog /dev/stdout combined
 
-    ServerName {{ env.IRONIC_IP }}
     SSLEngine on
     SSLProtocol {{ env.IRONIC_VMEDIA_SSL_PROTOCOL }}
     SSLCertificateFile {{ env.IRONIC_VMEDIA_CERT_FILE }}

--- a/ironic-inspector-config/inspector-apache.conf.j2
+++ b/ironic-inspector-config/inspector-apache.conf.j2
@@ -32,8 +32,6 @@ Listen {{ env.IRONIC_INSPECTOR_LISTEN_PORT }}
     LogLevel debug
     CustomLog /dev/stdout combined
 
-    ServerName {{ env.IRONIC_IP }}
-
     SSLEngine On
     SSLProtocol {{ env.IRONIC_SSL_PROTOCOL }}
     SSLCertificateFile {{ env.IRONIC_INSPECTOR_CERT_FILE }} 


### PR DESCRIPTION
ServerName does not support IPv6 addresses, the verification fails when the second segment doesn't begin in a digit(it doesn't look enough like a port number).

We only have a single VirtualHost per "Listen" so it is the default. Remove the use of ServerName as we're not using it to differentiate between VirtualHosts.