### PR TITLE
Change variable to environment

### DIFF
--- a/scripts/configure-httpd-ipa.sh
+++ b/scripts/configure-httpd-ipa.sh
@@ -20,6 +20,7 @@ INSPECTOR_EXTRA_ARGS=" ipa-inspection-callback-url=${IRONIC_BASE_URL}:${IRONIC_I
 if [[ $IRONIC_FAST_TRACK == true ]]; then
     INSPECTOR_EXTRA_ARGS+=" ipa-api-url=${IRONIC_BASE_URL}:${IRONIC_ACCESS_PORT}"
 fi
+export INSPECTOR_EXTRA_ARGS
 
 # Copy files to shared mount
 render_j2_config /tmp/inspector.ipxe.j2 /shared/html/inspector.ipxe

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -26,6 +26,7 @@ INSPECTOR_EXTRA_ARGS=" ipa-inspection-callback-url=${IRONIC_BASE_URL}:${IRONIC_I
 if [[ $IRONIC_FAST_TRACK == true ]]; then
     INSPECTOR_EXTRA_ARGS+=" ipa-api-url=${IRONIC_BASE_URL}:${IRONIC_ACCESS_PORT}"
 fi
+export INSPECTOR_EXTRA_ARGS
 
 . /bin/coreos-ipa-common.sh
 


### PR DESCRIPTION
```
cat /shared/html/inspector.ipxe  |grep callback
```

```
cat /shared/html/inspector.ipxe  |grep ipa
kernel --timeout 60000 http://x:6180/images/ironic-python-agent.kernel ipa-insecure=1 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-enable-vlan-interfaces= ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1  initrd=ironic-python-agent.initramfs console=ttyS0 ipa-ntp-server=x || goto retry_boot
```

ipa-inspection-callback-url value is empty.