### PR TITLE
Don't log OS_ prefixed variables to a file

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -50,9 +50,9 @@ if [ -f /etc/ironic/ironic.conf ]; then
     cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 fi
 
-# oslo.config also supports Config Opts From Environment, log them
-echo '# Options set from Environment variables' | tee /etc/ironic/ironic.extra
-env | grep "^OS_" | tee -a /etc/ironic/ironic.extra
+# oslo.config also supports Config Opts From Environment, log them to stdout
+echo 'Options set from Environment variables'
+env | grep "^OS_" || true
 
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter


### PR DESCRIPTION
Instead of logging `OS_`-prefixed environment variables to a file in `configure-ironic.sh`, simply log them to stdout. Oslo does not consume all `OS_`-prefixed variables, and nothing in this image or Ironic consumes the `ironic.extra` file.

Additionally, the addition of `|| true` to the line prevents the grep from returning non-zero in cases where there are no `OS_`-prefixed variables defined, and this would be particularly important if #370 were merged (it will need to be rebased and deconflicted from this).

For reference, downstream OKD images have `pipefail` set but the images have no `OS_`-prefixed variables set. They therefore cause a crashloop on the `metal3-ironic` container as documented in this downstream bug:
https://issues.redhat.com/projects/OCPBUGS/issues/OCPBUGS-2992