### PR TITLE
Add more DHCP options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The following environment variables can be passed in to customize run-time funct
 - DNSMASQ_EXCEPT_INTERFACE - interfaces to exclude when providing DHCP address (default "lo")
 - HTTP_PORT - port used by http server (default 80)
 - DHCP_RANGE - dhcp range to use for provisioning (default 172.22.0.10-172.22.0.100)
+- DHCP_HOSTS - a `;` separated list of `dhcp-host` entries, e.g. known MAC addresses like `00:20:e0:3b:13:af;00:20:e0:3b:14:af` (empty by default). For more details on `dhcp-host` see [the man page](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html).
+- DHCP_IGNORE - a set of tags on hosts that should be ignored and not allocate DHCP leases for, e.g. `tag:!known` to ignore any unknown hosts (empty by default)
 - MARIADB_PASSWORD - The database password
 - OS_<section>_\_<name>=<value> - This format can be used to set arbitary ironic config options
 - IRONIC_RAMDISK_SSH_KEY - A public key to allow ssh access to nodes running IPA, takes the format "ssh-rsa AAAAB3....."

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -46,3 +46,13 @@ dhcp-option=3
 dhcp-option=6
 {% endif %}
 {% endif %}
+
+{%- if env.DHCP_IGNORE | length %}
+dhcp-ignore={{ env.DHCP_IGNORE }}
+{% endif %}
+
+{%- if env.DHCP_HOSTS | length %}
+{%- for item in env.DHCP_HOSTS.split(";") %}
+dhcp-host={{ item }}
+{%- endfor %}
+{% endif %}


### PR DESCRIPTION
Add variables for dhcp-host and dhcp-ignore. These allow us to specify known hosts by listing the known MACs and then telling dnsmasq to ignore any host that is not known. This is useful if running multiple instances in the same network.