### PR TITLE
Fix source build if building sushy from source

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -32,6 +32,12 @@ if [[ $INSTALL_TYPE == "source" ]]; then
 
     python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ, path=os.path))' < "${IRONIC_PKG_LIST}" > "${IRONIC_PKG_LIST_FINAL}"
 
+    if [ -n $SUSHY_SOURCE ]; then
+        curl -L ${UPPER_CONSTRAINTS_FILE:-"https://releases.openstack.org/constraints/upper/master"} -o /tmp/sushy-constraints.txt
+        UPPER_CONSTRAINTS_FILE="/tmp/sushy-constraints.txt"
+        sed -i '/^sushy===/d' $UPPER_CONSTRAINTS_FILE
+    fi
+
     python3 -m pip install --ignore-installed --prefix /usr -r $IRONIC_PKG_LIST_FINAL -c ${UPPER_CONSTRAINTS_FILE:-"https://releases.openstack.org/constraints/upper/master"}
 
     # ironic and ironic-inspector system configuration


### PR DESCRIPTION
The sushy library is present in upper-consraints blocking the installation of any newer version (like dev versions). When installing sushy from source we need to remove it from the upper-constraints file.