### PR TITLE
🐛  Fix centos httpd

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 IRONIC_IP="${IRONIC_IP:-}"
 PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
 PROVISIONING_IP="${PROVISIONING_IP:-}"
+PROVISIONING_MACS="${PROVISIONING_MACS:-}"
 
 function get_provisioning_interface() {
   if [ -n "$PROVISIONING_INTERFACE" ]; then


### PR DESCRIPTION
httpd-infra is not running correctly on centos because of `PROVISIONING_MACS unbound value` after inroducing bash `set -u` in https://github.com/metal3-io/ironic-image/pull/370