### PR TITLE
Dockerfiles: use apt-get instead of apt

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,10 +1,11 @@
 FROM registry.hub.docker.com/library/python:3.9
 
 ARG SUSHY_TOOLS_VERSION="0.21.0"
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && \
-    apt install -y libvirt-dev && \
-    apt clean && \
+RUN apt-get update && \
+    apt-get install -y libvirt-dev && \
+    apt-get clean && \
     pip3 install --no-cache-dir \
         sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python
 


### PR DESCRIPTION
Apt gives out warnings that it doesn't have stable CLI for script usage. Replace apt with apt-get in Dockerfiles.

Also, it is a best practise to define DEBIAN_FRONTEND=noninteractive so the build will not ask you questions, but accepts the defaults, in case it needs any confirmation from user. Setting this avoids stalling builds in case there is a conflict, or configuration option added to the installed packages.