### PR TITLE
Adding dosfstools and util-linux tools to ironic-image

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,4 +1,5 @@
 dnsmasq
+dosfstools
 httpd
 httpd-tools
 ipcalc
@@ -11,4 +12,5 @@ python3-mod_wsgi
 qemu-img
 sqlite
 syslinux-nonlinux
+util-linux
 xorriso


### PR DESCRIPTION
Dosfstools and util-linux provide mkfs and mkfs.vfat binaries which are required for image creation operations performed by iLO driver.