### PR TITLE
Use sushytools port from the config file

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -9,5 +9,5 @@ RUN apt-get update && \
     pip3 install --no-cache-dir \
         sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python
 
-CMD /usr/local/bin/sushy-emulator -i :: -p 8000 \
+CMD /usr/local/bin/sushy-emulator -i :: \
         --config /root/sushy/conf.py --debug


### PR DESCRIPTION
Sushy tools port is hard-coded in the Dockerfile this PR removes it since the default port is 8000 and allows parameterize the port from the config file e.g `SUSHY_EMULATOR_LISTEN_PORT = 8000`