### PR TITLE
set docker registry url to docker.io

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/python:3.9
+FROM docker.io/library/python:3.9
 
 ARG SUSHY_TOOLS_VERSION="0.21.0"
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This is the last instance of registry.hub.docker.com to align in main branches of actively developed Metal3 repositories.