### PR TITLE
make ironic-image runnable as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ARG SUSHY_SOURCE
 COPY sources /sources/
 
 COPY ironic-${INSTALL_TYPE}-list ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
-COPY prepare-image.sh patch-image.sh /bin/
+COPY prepare-image.sh patch-image.sh configure-nonroot.sh /bin/
 
 RUN prepare-image.sh && \
   rm -f /bin/prepare-image.sh
@@ -64,3 +64,6 @@ RUN mkdir -p /var/lib/ironic /var/lib/ironic-inspector && \
 COPY ironic-inspector-config/ironic-inspector.conf.j2 /etc/ironic-inspector/
 COPY ironic-inspector-config/inspector-apache.conf.j2 /etc/httpd/conf.d/
 
+# configure non-root user and set relevant permissions
+RUN configure-nonroot.sh && \
+  rm -f /bin/configure-nonroot.sh

--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+
+# This script changes permissions to allow Ironic container to run as non-root
+# user. As the same image is used to run ironic, ironic-httpd, ironic-dsnmasq,
+# ironic-inspector and ironic-log-watch via BMO's ironic k8s manifest, it has
+# to be configured to work with multiple different users and groups, while they
+# share files via bind mounts (/shared, /certs/*), which can only get one
+# group id as "fsGroup". Additionally, dnsmasq needs three capabilities to run
+# which we provide via "setcap", and "allowPrivilegeEscalation: true" in
+# manifest.
+
+set -eux
+
+# user and group are from ironic rpms (uid 997, gid 994)
+IRONIC_USER="ironic"
+IRONIC_GROUP="ironic"
+INSPECTOR_GROUP="ironic-inspector"
+
+# we'll bind mount shared ca and ironic/inspector certificate dirs here
+# that need to have correct ownership as the entire ironic in BMO
+# deployment shares a single fsGroup in manifest's securityContext
+mkdir -p /certs
+chown "${IRONIC_USER}":"${INSPECTOR_GROUP}" /certs
+chmod 2775 /certs
+
+# ironic, inspector and httpd related changes
+chown -R root:"${IRONIC_GROUP}" /etc/ironic /etc/httpd/conf /etc/httpd/conf.d
+chown -R "${IRONIC_USER}":"${INSPECTOR_GROUP}" /etc/ironic-inspector
+chmod 2775 /etc/ironic /etc/ironic-inspector /etc/httpd/conf /etc/httpd/conf.d
+chmod 664 /etc/ironic/* /etc/ironic-inspector/* /etc/httpd/conf/* /etc/httpd/conf.d/*
+
+chown -R root:"${IRONIC_GROUP}" /var/lib/ironic
+chown -R root:"${INSPECTOR_GROUP}" /var/lib/ironic-inspector
+chmod 2775 /var/lib/ironic /var/lib/ironic-inspector
+chmod 664 /var/lib/ironic/ironic.db /var/lib/ironic-inspector/ironic-inspector.db
+
+# dnsmasq, and the capabilities required to run it as non-root user
+chown -R root:"${IRONIC_GROUP}" /etc/dnsmasq.conf /var/lib/dnsmasq
+chmod 2775 /var/lib/dnsmasq
+touch /var/lib/dnsmasq/dnsmasq.leases
+chmod 664 /etc/dnsmasq.conf /var/lib/dnsmasq/dnsmasq.leases
+
+setcap "cap_net_raw,cap_net_admin,cap_net_bind_service=+eip" /usr/sbin/dnsmasq

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -21,6 +21,11 @@ fi
 
 # SOURCE install #
 if [[ $INSTALL_TYPE == "source" ]]; then
+    # emulate uid/gid configuration to match rpm install
+    IRONIC_UID=997
+    IRONIC_GID=994
+    INSPECTOR_UID=996
+    INSPECTOR_GID=993
     BUILD_DEPS="python3-devel gcc git-core python3-setuptools python3-jinja2"
     dnf upgrade -y
     # NOTE(dtantsur): pip is a requirement of python3 in CentOS
@@ -32,7 +37,7 @@ if [[ $INSTALL_TYPE == "source" ]]; then
 
     python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ, path=os.path))' < "${IRONIC_PKG_LIST}" > "${IRONIC_PKG_LIST_FINAL}"
 
-    if [ -n $SUSHY_SOURCE ]; then
+    if [[ -n $SUSHY_SOURCE ]]; then
         curl -L ${UPPER_CONSTRAINTS_FILE:-"https://releases.openstack.org/constraints/upper/master"} -o /tmp/sushy-constraints.txt
         UPPER_CONSTRAINTS_FILE="/tmp/sushy-constraints.txt"
         sed -i '/^sushy===/d' $UPPER_CONSTRAINTS_FILE
@@ -42,10 +47,10 @@ if [[ $INSTALL_TYPE == "source" ]]; then
 
     # ironic and ironic-inspector system configuration
     mkdir -p /var/log/ironic /var/log/ironic-inspector /var/lib/ironic /var/lib/ironic-inspector
-    getent group ironic >/dev/null || groupadd -r ironic
-    getent passwd ironic >/dev/null || useradd -r -g ironic -s /sbin/nologin ironic -d /var/lib/ironic
-    getent group ironic-inspector >/dev/null || groupadd -r ironic-inspector
-    getent passwd ironic-inspector >/dev/null || useradd -r -g ironic-inspector -s /sbin/nologin ironic-inspector -d /var/lib/ironic-inspector
+    getent group ironic >/dev/null || groupadd -r ironic -g "${IRONIC_GID}"
+    getent passwd ironic >/dev/null || useradd -r -g ironic -u "${IRONIC_UID}" -s /sbin/nologin ironic -d /var/lib/ironic
+    getent group ironic-inspector >/dev/null || groupadd -r ironic-inspector -g "${INSPECTOR_GID}"
+    getent passwd ironic-inspector >/dev/null || useradd -r -g ironic-inspector -u "${INSPECTOR_UID}" -s /sbin/nologin ironic-inspector -d /var/lib/ironic-inspector
 
     # clean installed build dependencies
     dnf remove -y $BUILD_DEPS
@@ -53,7 +58,7 @@ fi
 
 xargs -rtd'\n' dnf install -y < /tmp/${PKGS_LIST}
 
-if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
+if [[ -n ${EXTRA_PKGS_LIST:-} ]]; then
     if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
         xargs -rtd'\n' dnf install -y < /tmp/${EXTRA_PKGS_LIST}
     fi
@@ -74,11 +79,15 @@ rm -f /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/autoindex.conf /etc/httpd/con
 # RDO-provided configuration forces creating log files
 rm -f /usr/share/ironic/ironic-dist.conf /etc/ironic-inspector/inspector-dist.conf
 
+# add ironic and ironic-inspector to apache group
+usermod -aG ironic apache
+usermod -aG ironic-inspector apache
+
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
 
 # apply patches if present #
-if [[ ! -z ${PATCH_LIST:-} ]]; then
+if [[ -n ${PATCH_LIST:-} ]]; then
     if [[ -s "/tmp/${PATCH_LIST}" ]]; then
         /bin/patch-image.sh;
     fi

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -1,5 +1,8 @@
 #!/usr/bin/bash
 
+set -eux
+
+# shellcheck disable=SC1091
 . /bin/ironic-common.sh
 
 export HTTP_PORT=${HTTP_PORT:-"80"}
@@ -11,7 +14,6 @@ if [[ "${DNS_IP:-}" == "provisioning" ]]; then
     export DNS_IP="$IRONIC_URL_HOST"
 fi
 
-
 mkdir -p /shared/tftpboot
 mkdir -p /shared/html/images
 mkdir -p /shared/html/pxelinux.cfg
@@ -20,10 +22,14 @@ mkdir -p /shared/html/pxelinux.cfg
 cp /tftpboot/undionly.kpxe /tftpboot/snponly.efi /shared/tftpboot
 
 # Template and write dnsmasq.conf
-python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
+# we template via /tmp as sed otherwise creates temp files in /etc directory
+# where we can't write
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/tmp/dnsmasq.conf
 
 for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
-    sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf
+    sed -i -e "/^interface=.*/ a\except-interface=${iface}" /tmp/dnsmasq.conf
 done
+cat /tmp/dnsmasq.conf > /etc/dnsmasq.conf
+rm /tmp/dnsmasq.conf
 
 exec /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -38,8 +38,6 @@ if [ "$IRONIC_INSPECTOR_TLS_SETUP" = "true" ]; then
     if [[ "${INSPECTOR_REVERSE_PROXY_SETUP}" == "true" ]]; then
       render_j2_config $INSPECTOR_ORIG_HTTPD_CONFIG $INSPECTOR_RESULT_HTTPD_CONFIG
     fi
-    # Add user 'apache' to the group `ironic-inspector`, so httpd can access /etc/ironic-inspector and read the pasword file
-    usermod -aG ironic-inspector apache
 else
     export INSPECTOR_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
 fi
@@ -48,8 +46,6 @@ if [ "$IRONIC_TLS_SETUP" = "true" ]; then
     if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "true" ]]; then
       render_j2_config /etc/httpd-ironic-api.conf.j2 /etc/httpd/conf.d/ironic.conf
     fi
-    # Add user 'apache' to the group `ironic-inspector`, so httpd can access /etc/ironic-inspector and read the pasword file
-    usermod -aG ironic apache
 else
     export IRONIC_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
 fi
@@ -77,6 +73,11 @@ sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
 # Log to std out/err
 sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
 sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
+
+# put pidfile somewhere we can write as nonroot
+cat <<'EOF' >>/etc/httpd/conf/httpd.conf
+PidFile /var/tmp/httpd.pid
+EOF
 
 if [ "$IRONIC_VMEDIA_TLS_SETUP" = "true" ]; then
     render_j2_config /etc/httpd-vmedia.conf.j2 /etc/httpd/conf.d/vmedia.conf

--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -30,7 +30,7 @@ export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
 
 function build_j2_config() {
   CONFIG_FILE=$1
-python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
+  python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < $CONFIG_FILE.j2
 }
 
 # Merge with the original configuration file from the package.


### PR DESCRIPTION
BMO ironic has no reason to run as root. Make it run as "ironic" user.
    
dnsmasq requires elevated capabiities. k8s is missing the feature of ambient capabilities, so it requires us to setcap the binaries with expected capabilities and container must be running with "allowPrivilegeEscalation: true" in the manifest to allow elevation.
    
Read the ambient capabilities KEP for more details: https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/2763-ambient-capabilities/README.md
    
Most of the changed here are making runtime configuration possible by changing file and directory ownership from root:root to root:ironic and applying 775/664 perms to allow modification/creation of files.
