### PR TITLE
Default installation from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM $BASE_IMAGE
 ENV PKGS_LIST=main-packages-list.txt
 ARG EXTRA_PKGS_LIST
 ARG PATCH_LIST
-ARG INSTALL_TYPE=rpm
+ARG INSTALL_TYPE=source
 
 # build arguments for source build customization
 ARG IRONIC_SOURCE

--- a/README.md
+++ b/README.md
@@ -82,15 +82,18 @@ The following can serve as an example:
    callback from the ramdisk doing the cleaning
 - `OS_PXE__BOOT_RETRY_TIMEOUT=1200` - timeout (seconds) to enable boot retries.
 
-## Build Ironic Image from source
+## Build Ironic Image from RPMs
 
-Normally the ironic image is built using RPMs coming from the RDO project.
-It is possible to build it using source code setting the **INSTALL_TYPE**
-argument to **source** at build time; for example:
+The ironic image is built using RPMs for system software and source
+code for ironic specific software and libraries.
+It is possible to build it using RPMs from RDO project code setting the **INSTALL_TYPE**
+argument to **rpm** at build time; for example:
 
 ```bash
-podman build -t ironic-image -f Dockerfile --build-arg INSTALL_TYPE=source
+podman build -t ironic-image -f Dockerfile --build-arg INSTALL_TYPE=rpm
 ```
+
+## Custom source for ironic software
 
 When building the ironic image from source, it is also possible to specify a
 different source for ironic, ironic-inspector or the sushy library using the

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -10,6 +10,8 @@ echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
 
 dnf install -y python3 python3-requests 'dnf-command(config-manager)'
 
+# NOTE(elfosardo): building the container using ironic RPMs is
+# now deprecated and it will be removed in the future.
 # RPM install #
 if [[ "$INSTALL_TYPE" == "rpm" ]]; then
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo


### PR DESCRIPTION
Change the default method to install ironic software and its dependencies from source code instead of RPMs.
The "rpm" method is deprecated and it will be removed in the future.