### PR TITLE
Fixing patch-image.sh script for "$INSTALL_TYPE" == "source" 

### DIFF
--- a/patch-image.sh
+++ b/patch-image.sh
@@ -4,7 +4,7 @@ set -ex
 PATCH_FILE="/tmp/${PATCH_LIST}"
 VARS="PROJECT REFSPEC GIT_HOST"
 
-dnf install -y python3-pip
+dnf install -y python3-pip git-core
 
 while IFS= read -r line; do
     # shellcheck disable=SC2086,SC2229
@@ -22,4 +22,5 @@ while IFS= read -r line; do
     pip3 install --prefix /usr dist/*.tar.gz
 done < "$PATCH_FILE"
 
+dnf remove -y python3-pip git-core
 cd /


### PR DESCRIPTION
metal3_daily_main_fullstack_building is failing with error 
`
/bin/patch-image.sh: line 16: git: command not found
`
ref to failed test: https://jenkins.nordix.org/view/Metal3%20Periodic/job/metal3_daily_main_fullstack_building/187/consoleFull

Fix: install git-core in the patch-image.sh before git clone