### PR TITLE
Stop using extra-hardware by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ functionality:
 - `GATEWAY_IP` - gateway IP address to use for ironic dnsmasq(dhcpd)
 - `DNS_IP` - DNS IP address to use for ironic dnsmasq(dhcpd)
 - `IRONIC_IPA_COLLECTORS` - Use a custom set of collectors to be run on
-   inspection. (default `default,extra-hardware,logs`)
+   inspection. (default `default,logs`)
 
 The ironic configuration can be overridden by various environment variables.
 The following can serve as an example:

--- a/ironic-config/ironic-python-agent.ign.j2
+++ b/ironic-config/ironic-python-agent.ign.j2
@@ -20,7 +20,7 @@ inspection_callback_url = {{ env.IRONIC_BASE_URL }}:{{ env.IRONIC_INSPECTOR_ACCE
 
 collect_lldp = True
 enable_vlan_interfaces = {{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }}
-inspection_collectors = default,extra-hardware,logs
+inspection_collectors = default,logs
 inspection_dhcp_all_interfaces = True
 {% endset -%}
 

--- a/ironic-inspector-config/ironic-inspector.conf.j2
+++ b/ironic-inspector-config/ironic-inspector.conf.j2
@@ -50,7 +50,7 @@ node_not_found_hook = enroll
 {% endif %}
 permit_active_introspection = true
 power_off = false
-processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic
+processing_hooks = $default_processing_hooks,lldp_basic
 ramdisk_logs_dir = /shared/log/ironic-inspector/ramdisk
 store_data = database
 

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -39,7 +39,7 @@ export IRONIC_AUTOMATED_CLEAN=${IRONIC_AUTOMATED_CLEAN:-true}
 export SEND_SENSOR_DATA=${SEND_SENSOR_DATA:-false}
 
 # Set of collectors that should be used with IPA inspection
-export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,extra-hardware,logs}
+export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
 
 wait_for_interface_or_ip
 

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -16,7 +16,7 @@ export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-false}
 IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
 
 # Set of collectors that should be used with IPA inspection
-export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,extra-hardware,logs}
+export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
 
 wait_for_interface_or_ip
 


### PR DESCRIPTION
After https://github.com/metal3-io/baremetal-operator/pull/1297,
it is no longer needed. Upstream ramdisks do not support it.
