### PR TITLE
python-ironicclient debug container image

### DIFF
--- a/resources/ironicclient/Dockerfile
+++ b/resources/ironicclient/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
+FROM $BASE_IMAGE
+
+COPY ironic.profile /etc/profile.d/ironic.sh
+
+RUN set -eux ; \
+    export LANG=C.UTF-8; \
+    BUILD_PACKAGES="gcc python3-pip" ; \
+    REQUIRED_PACKAGES="" ; \
+    yum update ; \
+    yum install -y ${BUILD_PACKAGES} ${REQUIRED_PACKAGES} ; \
+    pip install python-ironicclient ; \
+    yum remove -y ${BUILD_PACKAGES}
+
+CMD ["bash","-l"]

--- a/resources/ironicclient/README.md
+++ b/resources/ironicclient/README.md
@@ -1,0 +1,44 @@
+# Container Image Ironic Client
+
+This repository contains the build instructions
+for a container image of the [Python Ironic Client][PIC].
+
+This container can be used to debug the Ironic component of Metal³.
+
+Once a baremetal-operator-ironic container is running one can start the container
+as a debug container using the following command line:
+
+```sh
+kubectl debug -it -n baremetal-operator-system $(kubectl get -n baremetal-operator-system pods -o name|grep ironic) --image=ironicclient:0.0.1 --target ironic
+```
+
+This opens a shell to the debug container.
+
+The `baremetal` command can be used to access the
+[Python Ironic Client Standalone CLI][PICSCLI] e.g. one can use
+
+```sh
+baremetal node list
+```
+
+to list all nodes and their states registered in Ironic.
+
+
+## Implementation details
+
+The container image uses bash and starts it as login shell to source the profile
+files in `/etc/profile.d`. The `ironic.sh` in `/etc/profile.d` sets the
+following environment variables:
+
+* `OS_AUTH_TYPE`: static string "none" as ironic is running in standalone mode
+* `OS_ENDPOINT`: the ironic endpoint found in `/etc/ironic/ironic.conf` in the baremetal-ironic-container
+* `REQUESTS_CA_BUNDLE`: pointing to `/certs/ca/ironic-inspector/ca.crt` in the baremetal-ironic-container
+
+The environment variables are used by the Ironic CLI client to communicate with
+the ironic API endpoint.
+
+In the debug container the filesystem of the ironic container can be found in
+`/proc/1/root`.
+
+[PIC]: https://docs.openstack.org/python-ironicclient/latest/
+[PICSCLI]: https://docs.openstack.org/python-ironicclient/latest/cli/standalone.html

--- a/resources/ironicclient/ironic.profile
+++ b/resources/ironicclient/ironic.profile
@@ -1,0 +1,4 @@
+REQUESTS_CA_BUNDLE=/proc/1/root/certs/ca/ironic-inspector/ca.crt
+OS_AUTH_TYPE=none
+OS_ENDPOINT="$(grep endpoint_override /proc/1/root/etc/ironic/ironic.conf|grep 6385|cut -d\  -f3)"
+export REQUESTS_CA_BUNDLE OS_AUTH_TYPE OS_ENDPOINT


### PR DESCRIPTION
The Metal³ ironic container image does not include an ironic-client installation. Furthermore there is no longer a package in centos that provides the ironic-client via dnf.

This commit adds a Dockerfile for a docker container image which contains an installation of ironic-pythonclient. The docker image is configured such that it can be used as debug container alongside the Metal³ ironic container, providing an interactive shell environment which can be used to interact with Metal³ ironic using the "baremetal" cli.