### PR TITLE
Consolidate the authentication code

### DIFF
--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -26,7 +26,7 @@ configure_json_rpc_auth()
 {
     export JSON_RPC_AUTH_STRATEGY="noauth"
     if [[ -n "${IRONIC_HTPASSWD}" ]]; then
-        if [[ "$IRONIC_DEPLOYMENT" == "Conductor" ]]; then
+        if [[ "${IRONIC_DEPLOYMENT}" == "Conductor" ]]; then
             export JSON_RPC_AUTH_STRATEGY="http_basic"
             printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}-rpc"
         else
@@ -41,9 +41,9 @@ configure_ironic_auth()
     # Configure HTTP basic auth for API server
     if [[ -n "${IRONIC_HTPASSWD}" ]]; then
         printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}"
-        if [[ "$IRONIC_REVERSE_PROXY_SETUP" == "false" ]]; then
-            crudini --set "$config" DEFAULT auth_strategy http_basic
-            crudini --set "$config" DEFAULT http_basic_auth_user_file "${IRONIC_HTPASSWD_FILE}"
+        if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "false" ]]; then
+            crudini --set "${config}" DEFAULT auth_strategy http_basic
+            crudini --set "${config}" DEFAULT http_basic_auth_user_file "${IRONIC_HTPASSWD_FILE}"
         fi
     fi
 }
@@ -53,9 +53,9 @@ configure_inspector_auth()
     local config=/etc/ironic-inspector/ironic-inspector.conf
     if [[ -n "${INSPECTOR_HTPASSWD}" ]]; then
         printf "%s\n" "${INSPECTOR_HTPASSWD}" > "${INSPECTOR_HTPASSWD_FILE}"
-        if [[ "$INSPECTOR_REVERSE_PROXY_SETUP" == "false" ]]; then
-            crudini --set "$config" DEFAULT auth_strategy http_basic
-            crudini --set "$config" DEFAULT http_basic_auth_user_file "${INSPECTOR_HTPASSWD_FILE}"
+        if [[ "${INSPECTOR_REVERSE_PROXY_SETUP}" == "false" ]]; then
+            crudini --set "${config}" DEFAULT auth_strategy http_basic
+            crudini --set "${config}" DEFAULT http_basic_auth_user_file "${INSPECTOR_HTPASSWD_FILE}"
         fi
     fi
 }

--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+export IRONIC_DEPLOYMENT="${IRONIC_DEPLOYMENT:-}"
+export IRONIC_REVERSE_PROXY_SETUP=${IRONIC_REVERSE_PROXY_SETUP:-false}
+export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-false}
+
+IRONIC_HTPASSWD_FILE=/etc/ironic/htpasswd
+INSPECTOR_HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
+
+configure_client_basic_auth()
+{
+    local auth_config_file="/auth/$1/auth-config"
+    local dest="${2:-/etc/ironic/ironic.conf}"
+    if [[ -f "${auth_config_file}" ]]; then
+        # Merge configurations in the "auth" directory into the default ironic configuration file because there is no way to choose the configuration file
+        # when running the api as a WSGI app.
+        crudini --merge "${dest}" < "${auth_config_file}"
+    fi
+}
+
+configure_json_rpc_auth()
+{
+    export JSON_RPC_AUTH_STRATEGY="noauth"
+    if [[ -n "${IRONIC_HTPASSWD}" ]]; then
+        if [[ "$IRONIC_DEPLOYMENT" == "Conductor" ]]; then
+            export JSON_RPC_AUTH_STRATEGY="http_basic"
+            printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}-rpc"
+        else
+            printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}"
+        fi
+    fi
+}
+
+configure_ironic_auth()
+{
+    local config=/etc/ironic/ironic.conf
+    # Configure HTTP basic auth for API server
+    if [[ -n "${IRONIC_HTPASSWD}" ]]; then
+        printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}"
+        if [[ "$IRONIC_REVERSE_PROXY_SETUP" == "false" ]]; then
+            crudini --set "$config" DEFAULT auth_strategy http_basic
+            crudini --set "$config" DEFAULT http_basic_auth_user_file "${IRONIC_HTPASSWD_FILE}"
+        fi
+    fi
+}
+
+configure_inspector_auth()
+{
+    local config=/etc/ironic-inspector/ironic-inspector.conf
+    if [[ -n "${INSPECTOR_HTPASSWD}" ]]; then
+        printf "%s\n" "${INSPECTOR_HTPASSWD}" > "${INSPECTOR_HTPASSWD_FILE}"
+        if [[ "$INSPECTOR_REVERSE_PROXY_SETUP" == "false" ]]; then
+            crudini --set "$config" DEFAULT auth_strategy http_basic
+            crudini --set "$config" DEFAULT http_basic_auth_user_file "${INSPECTOR_HTPASSWD_FILE}"
+        fi
+    fi
+}
+
+write_htpasswd_files()
+{
+    if [[ -n "${IRONIC_HTPASSWD:-}" ]]; then
+        printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}"
+    fi
+    if [[ -n "${INSPECTOR_HTPASSWD:-}" ]]; then
+        printf "%s\n" "${INSPECTOR_HTPASSWD}" > "${INSPECTOR_HTPASSWD_FILE}"
+    fi
+}

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -3,6 +3,7 @@
 # shellcheck disable=SC1091
 . /bin/tls-common.sh
 . /bin/ironic-common.sh
+. /bin/auth-common.sh
 
 export HTTP_PORT=${HTTP_PORT:-80}
 export VMEDIA_TLS_PORT=${VMEDIA_TLS_PORT:-8083}
@@ -62,17 +63,7 @@ else
     export IRONIC_REVERSE_PROXY_SETUP="false" # If TLS is not used, we have no reason to use the reverse proxy
 fi
 
-export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
-export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
-
-# Set basic auth credentials for Ironic API server
-if [[ -n "${IRONIC_HTPASSWD:-}" ]]; then
-    printf "%s\n" "${IRONIC_HTPASSWD}" > /etc/ironic/htpasswd
-fi
-# Set basic auth credentials for Ironic Inspector server
-if [[ -n "${INSPECTOR_HTPASSWD:-}" ]]; then
-    printf "%s\n" "${INSPECTOR_HTPASSWD}" > /etc/ironic-inspector/htpasswd
-fi
+write_htpasswd_files
 
 # Render httpd TLS configuration for /shared/html/<redifsh;ilo>
 if [[ "$IRONIC_VMEDIA_TLS_SETUP" == "true" ]]; then

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -8,9 +8,6 @@ export IRONIC_EXPOSE_JSON_RPC=${IRONIC_EXPOSE_JSON_RPC:-false}
 # shellcheck disable=SC1091
 . /bin/configure-ironic.sh
 
-export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-}
-export IRONIC_REVERSE_PROXY_SETUP=${IRONIC_REVERSE_PROXY_SETUP:-false}
-
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
@@ -23,16 +20,6 @@ if [[ "$IRONIC_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UP
     done &
 fi
 
-CONFIG=/etc/ironic/ironic.conf
-
-# Configure HTTP basic auth for API server
-HTPASSWD_FILE=/etc/ironic/htpasswd
-if [[ -n "${IRONIC_HTPASSWD}" ]]; then
-    printf "%s\n" "${IRONIC_HTPASSWD}" >"${HTPASSWD_FILE}"
-    if [[ "$IRONIC_REVERSE_PROXY_SETUP" == "false" ]]; then
-        crudini --set "$CONFIG" DEFAULT auth_strategy http_basic
-        crudini --set "$CONFIG" DEFAULT http_basic_auth_user_file "${HTPASSWD_FILE}"
-    fi
-fi
+configure_ironic_auth
 
 exec /usr/bin/ironic

--- a/scripts/runironic-inspector
+++ b/scripts/runironic-inspector
@@ -11,6 +11,8 @@ export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-false}
 . /bin/tls-common.sh
 # shellcheck disable=SC1091
 . /bin/ironic-common.sh
+# shellcheck disable=SC1091
+. /bin/auth-common.sh
 
 wait_for_interface_or_ip
 
@@ -25,7 +27,6 @@ fi
 
 export IRONIC_INSPECTOR_BASE_URL="${IRONIC_INSPECTOR_SCHEME}://${IRONIC_URL_HOST}:${IRONIC_INSPECTOR_PORT}"
 export IRONIC_BASE_URL="${IRONIC_SCHEME}://${IRONIC_URL_HOST}:${IRONIC_ACCESS_PORT}"
-export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
 
 build_j2_config()
 {
@@ -36,24 +37,11 @@ build_j2_config()
 # Merge with the original configuration file from the package.
 build_j2_config "$CONFIG" | crudini --merge "$CONFIG"
 
-# Configure HTTP basic auth for API server
-HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
-if [[ -n "${INSPECTOR_HTPASSWD}" ]]; then
-    printf "%s\n" "${INSPECTOR_HTPASSWD}" >"${HTPASSWD_FILE}"
-    if [[ "$INSPECTOR_REVERSE_PROXY_SETUP" == "false" ]]; then
-        crudini --set "$CONFIG" DEFAULT auth_strategy http_basic
-        crudini --set "$CONFIG" DEFAULT http_basic_auth_user_file "${HTPASSWD_FILE}"
-    fi
-fi
+configure_inspector_auth
 
-# Configure auth for ironic client
-CONFIG_OPTIONS="--config-file ${CONFIG}"
-auth_config_file="/auth/ironic/auth-config"
-if [[ -f "${auth_config_file}" ]]; then
-    CONFIG_OPTIONS+=" --config-file ${auth_config_file}"
-fi
+configure_client_basic_auth ironic "${CONFIG}"
 
-ironic-inspector-dbsync --config-file /etc/ironic-inspector/ironic-inspector.conf upgrade
+ironic-inspector-dbsync --config-file "${CONFIG}" upgrade
 
 if [[ "$INSPECTOR_REVERSE_PROXY_SETUP" == "false" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
     # shellcheck disable=SC2034
@@ -66,4 +54,4 @@ fi
 export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"
 
 # shellcheck disable=SC2086
-exec /usr/bin/ironic-inspector $CONFIG_OPTIONS
+exec /usr/bin/ironic-inspector


### PR DESCRIPTION
To simplify future extensions and make the critical code easier to
review, move all credentials logic to a new script.
