### PR TITLE
Remove ServerName from httpd.conf

### DIFF
--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -8,8 +8,6 @@ Include conf.modules.d/*.conf
 User apache
 Group apache
 
-ServerName {{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}
-
 <Directory />
     AllowOverride none
     Require all denied


### PR DESCRIPTION
The ServerName value is not mandatory and it's not really needed as apache can get that from /etc/hosts.
Also this configuration will never work in an ipv6 environemnt as ipv6 ips are not allowed as values for ServerName.