### PR TITLE
Create /shared in configure-nonroot.sh

### DIFF
--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -16,6 +16,10 @@ IRONIC_USER="ironic"
 IRONIC_GROUP="ironic"
 INSPECTOR_GROUP="ironic-inspector"
 
+# most containers mount /shared but dnsmasq can live without it
+mkdir -p /shared
+chown "${IRONIC_USER}":"${INSPECTOR_GROUP}" /shared
+
 # we'll bind mount shared ca and ironic/inspector certificate dirs here
 # that need to have correct ownership as the entire ironic in BMO
 # deployment shares a single fsGroup in manifest's securityContext


### PR DESCRIPTION
Currently, all containers mount it, but it's actually not required for
dnsmasq since it only needs a few bits of static configuration.
