### PR TITLE
Allow guessing PROVISIONING_INTERFACE by PROVISIONING_IP

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -16,12 +16,20 @@ get_provisioning_interface()
     fi
 
     local interface="provisioning"
+
+    if [[ -n "${PROVISIONING_IP}" ]]; then
+        if ip -br addr show | grep -qi " ${PROVISIONING_IP}/"; then
+            interface="$(ip -br addr show | grep -i " ${PROVISIONING_IP}/" | cut -f 1 -d ' ' | cut -f 1 -d '@')"
+        fi
+    fi
+
     for mac in ${PROVISIONING_MACS//,/ }; do
         if ip -br link show up | grep -qi "$mac"; then
             interface="$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ' | cut -f 1 -d '@')"
             break
         fi
     done
+
     echo "$interface"
 }
 


### PR DESCRIPTION
This simplifies the case where PROVISIONING_IP is known but
the exact interface name is not.
