### PR TITLE
Don't install ironic-lib from git when it's not requested

### DIFF
--- a/ironic-source-list
+++ b/ironic-source-list
@@ -25,7 +25,7 @@ git+file:///sources/{{ env.IRONIC_LIB_SOURCE }}
 ironic-lib @ git+https://opendev.org/openstack/ironic-lib@{{ env.IRONIC_LIB_SOURCE }}
     {% endif %}
 {% else %}
-ironic-lib @ git+https://opendev.org/openstack/ironic-lib
+ironic-lib
 {% endif %}
 ironic-prometheus-exporter
 proliantutils


### PR DESCRIPTION
When IRONIC_LIB_SOURCE is not set, we should use pip. Otherwise,
we can a conflict with upper-constraints.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
