### PR TITLE
Add openstacksdk to sushy-tools container image

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -y libvirt-dev && \
     apt-get clean && \
     pip3 install --no-cache-dir \
-        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python
+        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python openstacksdk
 
 COPY redfish-emulator.sh /usr/local/bin/
 


### PR DESCRIPTION
This will allow sushy-tools containers to use the nova driver, as well as the libvirt driver.