### PR TITLE
add clomonitor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repo contains the files needed to build the Ironic images used by Metal3.
 
 ## Build Status
 
+[![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/metal3-io/badge)](https://clomonitor.io/projects/cncf/metal3-io)
 [![Ubuntu daily main build status](https://jenkins.nordix.org/buildStatus/icon?job=metal3_daily_main_integration_test_ubuntu&subject=Ubuntu%20daily%20main)](https://jenkins.nordix.org/view/Metal3/job/metal3_daily_main_integration_test_ubuntu/)
 [![CentOS daily main build status](https://jenkins.nordix.org/buildStatus/icon?job=metal3_daily_main_integration_test_centos&subject=CentOS%20daily%20main)](https://jenkins.nordix.org/view/Metal3/job/metal3_daily_main_integration_test_centos/)
 


### PR DESCRIPTION
Add CLOMonitor badge to README as ironic-image is one of the included repos that is checked (starting tomorrow).