### PR TITLE
Update sushy-tools to 1.1.0

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/library/python:3.9
 
-ARG SUSHY_TOOLS_VERSION="1.0.1"
+ARG SUSHY_TOOLS_VERSION="1.1.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \


### PR DESCRIPTION
[sushy-tools 1.1.0](https://review.opendev.org/c/openstack/releases/+/903515) has just been released. It contains new features and bugfixes ([changelog](https://opendev.org/openstack/sushy-tools/compare/1.0.1...1.1.0)).