### PR TITLE
add condition for ipxe_tls template usage

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -221,7 +221,9 @@ kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC
 enable_netboot_fallback = true
 # Enable the fallback path to in-band inspection
 ipxe_fallback_script = inspector.ipxe
+{% if env.IPXE_TLS_SETUP | lower == "true" %}
 ipxe_config_template = /tmp/ipxe_config.template
+{% endif %}
 
 [redfish]
 use_swift = false


### PR DESCRIPTION
Previously custom ironic ipxe template was taken into use in ironic config even when the TLS support was not enabled for the ironic-image.

This commit:
  - Adds  a condition to exclude/include referencing custom ipxe template based on whether TLS is enabled for the ipxe.