### PR TITLE
:book: add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repo contains the files needed to build the Ironic images used by Metal3.
 ## Build Status
 
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/metal3-io/badge)](https://clomonitor.io/projects/cncf/metal3-io)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/metal3-io/ironic-image/badge)](https://securityscorecards.dev/viewer/?uri=github.com/metal3-io/ironic-image)
 [![Ubuntu daily main build status](https://jenkins.nordix.org/buildStatus/icon?job=metal3_daily_main_integration_test_ubuntu&subject=Ubuntu%20daily%20main)](https://jenkins.nordix.org/view/Metal3/job/metal3_daily_main_integration_test_ubuntu/)
 [![CentOS daily main build status](https://jenkins.nordix.org/buildStatus/icon?job=metal3_daily_main_integration_test_centos&subject=CentOS%20daily%20main)](https://jenkins.nordix.org/view/Metal3/job/metal3_daily_main_integration_test_centos/)
 


### PR DESCRIPTION
Add OpenSSF Scorecard badge to README. It is checked by the CLOmonitor and lowers our score by not having it. We have worked to improve the scores, so we can display the score as well.