### PR TITLE
🌱 Set require_managed_boot to False

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -133,6 +133,10 @@ external_callback_url = {{ env.IRONIC_EXTERNAL_CALLBACK_URL }}
 dhcp_provider = none
 
 [inspector]
+# NOTE(dtantsur): we properly configure the "unmanaged" inspection boot (i.e.
+# booting IPA through a separate inspector.ipxe rather than the driver's boot
+# interface), so managed boot is not required.
+require_managed_boot = False
 power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
 # Also keep in mind that only parameters unique for inspection go here.


### PR DESCRIPTION
This parameter is about to change its default value from False to True.
Since we configure both managed and unmanaged inspection boots (see docs),
we can leave this option as False.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>