### PR TITLE
🌱 reduce github actions permissions

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -1,53 +1,58 @@
 name: build-images-action
+
 on:
   push:
     branches:
-      - 'main'
-      - 'release-*'
+    - 'main'
+    - 'release-*'
     tags:
-      - 'v*'
+    - 'v*'
+
 permissions: {}
+
 jobs:
   build:
     name: Build container images
     runs-on: ubuntu-latest
-    if: github.repository == 'metal3-io/ironic-image'
+
     permissions:
       contents: read
+
+    if: github.repository == 'metal3-io/ironic-image'
     steps:
-      - name: build ironic image
-        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-        with:
-          jenkins_url: "https://jenkins.nordix.org/"
-          jenkins_user: "metal3.bot@gmail.com"
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "metal3_ironic_container_image_building"
-          job_params: |
-            {
-              "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-            }
-          job_timeout: "1000"
-      - name: build sushy-tools image
-        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-        with:
-          jenkins_url: "https://jenkins.nordix.org/"
-          jenkins_user: "metal3.bot@gmail.com"
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "metal3_sushy-tools_container_image_building"
-          job_params: |
-            {
-              "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-            }
-          job_timeout: "1000"
-      - name: build vbmc image
-        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-        with:
-          jenkins_url: "https://jenkins.nordix.org/"
-          jenkins_user: "metal3.bot@gmail.com"
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "metal3_vbmc_container_image_building"
-          job_params: |
-            {
-              "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-            }
-          job_timeout: "1000"
+    - name: build ironic image
+      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+      with:
+        jenkins_url: "https://jenkins.nordix.org/"
+        jenkins_user: "metal3.bot@gmail.com"
+        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+        job_name: "metal3_ironic_container_image_building"
+        job_params: |
+          {
+            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
+          }
+        job_timeout: "1000"
+    - name: build sushy-tools image
+      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+      with:
+        jenkins_url: "https://jenkins.nordix.org/"
+        jenkins_user: "metal3.bot@gmail.com"
+        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+        job_name: "metal3_sushy-tools_container_image_building"
+        job_params: |
+          {
+            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
+          }
+        job_timeout: "1000"
+    - name: build vbmc image
+      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+      with:
+        jenkins_url: "https://jenkins.nordix.org/"
+        jenkins_user: "metal3.bot@gmail.com"
+        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+        job_name: "metal3_vbmc_container_image_building"
+        job_params: |
+          {
+            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
+          }
+        job_timeout: "1000"

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -4,13 +4,16 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  checks: write
+permissions: {}
 
 jobs:
   verify:
     runs-on: ubuntu-latest
     name: verify PR contents
+
+    permissions:
+      checks: write
+
     steps:
     - name: Verifier action
       id: verifier


### PR DESCRIPTION
Cleanup GH actions, and move permissions from top-level to job-level. Restrict job running to the main repository.

This restores token permission score to 10/10.

/hold
until https://github.com/metal3-io/ip-address-manager/pull/408 is reviewed and merged as this is replication of that.