### PR TITLE
🌱 Use bookworm slim to build sushy-tools image

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,13 +1,14 @@
-FROM docker.io/library/python:3.9
+FROM docker.io/library/python:3.9.18-slim-bookworm
 
 ARG SUSHY_TOOLS_VERSION="1.1.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y libvirt-dev && \
+    apt-get install -y libvirt-dev ssh gcc && \
     apt-get clean && \
     pip3 install --no-cache-dir \
-        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python openstacksdk
+        sushy-tools==${SUSHY_TOOLS_VERSION} libvirt-python openstacksdk && \
+    apt-get --purge autoremove -y gcc
 
 COPY redfish-emulator.sh /usr/local/bin/
 


### PR DESCRIPTION
It should reduce the final size of the image from 1.2GB to 500MB

