### PR TITLE
🌱 Rename IRONIC_INSPECTOR_VLAN_INTERFACES

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ functionality:
   use `IRONIC_EXTERNAL_IP` if available.
 - `IRONIC_INSPECTOR_CALLBACK_ENDPOINT_OVERRIDE` - Override Inspector's callback
   URL. Defaults to use `IRONIC_EXTERNAL_IP` if available.
+- `IRONIC_ENABLE_VLAN_INTERFACES` - Which VLAN interfaces to enable on the
+  agent start-up. Can be a list of interfaces or a special value `all`.
+  Defaults to `all`.
 
 The ironic configuration can be overridden by various environment variables.
 The following can serve as an example:

--- a/ironic-config/inspector.ipxe.j2
+++ b/ironic-config/inspector.ipxe.j2
@@ -5,6 +5,6 @@ echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in
 # ironic-inspector-image and configuration in configure-ironic.sh
-kernel --timeout 60000 http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/images/ironic-python-agent.kernel ipa-insecure=1 ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-enable-vlan-interfaces={{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {{ env.INSPECTOR_EXTRA_ARGS }} initrd=ironic-python-agent.initramfs {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} || goto retry_boot
+kernel --timeout 60000 http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/images/ironic-python-agent.kernel ipa-insecure=1 ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-enable-vlan-interfaces={{ env.IRONIC_ENABLE_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {{ env.INSPECTOR_EXTRA_ARGS }} initrd=ironic-python-agent.initramfs {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} || goto retry_boot
 initrd --timeout 60000 http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -141,7 +141,7 @@ power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
 # Also keep in mind that only parameters unique for inspection go here.
 # No need to duplicate pxe_append_params/kernel_append_params.
-extra_kernel_params = ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} ipa-enable-vlan-interfaces={{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1
+extra_kernel_params = ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} ipa-enable-vlan-interfaces={{ env.IRONIC_ENABLE_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1
 
 {% if env.USE_IRONIC_INSPECTOR == "true" %}
 endpoint_override = {{ env.IRONIC_INSPECTOR_BASE_URL }}

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -9,7 +9,7 @@ IRONIC_EXTERNAL_IP="${IRONIC_EXTERNAL_IP:-}"
 #   all - all VLANs on all interfaces using LLDP information
 #   <interface> - all VLANs on a particular interface using LLDP information
 #   <interface.vlan> - a particular VLAN on an interface, not relying on LLDP
-export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
+export IRONIC_ENABLE_VLAN_INTERFACES=${IRONIC_ENABLE_VLAN_INTERFACES:-${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}}
 
 # shellcheck disable=SC1091
 . /bin/tls-common.sh


### PR DESCRIPTION
This value is not specific to inspection, let alone its ironic-inspector
implementation. Rename to IRONIC_ENABLE_VLAN_INTERFACES. The old name is
still supported but deprecated.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>