### PR TITLE
⚠️ Disable ironic-inspector by default

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -158,6 +158,10 @@ add_ports = all
 keep_ports = present
 {% endif %}
 
+[auto_discovery]
+enabled = {{ env.IRONIC_INSPECTOR_ENABLE_DISCOVERY }}
+driver = ipmi
+
 [ipmi]
 # use_ipmitool_retries transfers the responsibility of retrying to ipmitool
 # when supported. If set to false, then ipmitool is called as follows :

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -103,9 +103,5 @@ export IRONIC_INSPECTOR_ACCESS_PORT=${IRONIC_INSPECTOR_ACCESS_PORT:-5050}
 export IRONIC_INSPECTOR_LISTEN_PORT=${IRONIC_INSPECTOR_LISTEN_PORT:-$IRONIC_INSPECTOR_ACCESS_PORT}
 
 # If this is false, built-in inspection is used.
-export USE_IRONIC_INSPECTOR=${USE_IRONIC_INSPECTOR:-true}
+export USE_IRONIC_INSPECTOR=${USE_IRONIC_INSPECTOR:-false}
 export IRONIC_INSPECTOR_ENABLE_DISCOVERY=${IRONIC_INSPECTOR_ENABLE_DISCOVERY:-false}
-if [[ "${USE_IRONIC_INSPECTOR}" != "true" ]] && [[ "${IRONIC_INSPECTOR_ENABLE_DISCOVERY}" == "true" ]]; then
-    echo "Discovery is only supported with ironic-inspector at this point"
-    exit 1
-fi


### PR DESCRIPTION
Allow auto-discovery to be enabled with the built-in inspection.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>