### PR TITLE
🐛 Stop reading ironic and inspector HTPASSWD from environment variables

### DIFF
--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -2,8 +2,6 @@
 
 set -euxo pipefail
 
-export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
-export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
 export IRONIC_REVERSE_PROXY_SETUP=${IRONIC_REVERSE_PROXY_SETUP:-false}
 export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-false}
 
@@ -14,8 +12,35 @@ else
     export IRONIC_EXPOSE_JSON_RPC="${IRONIC_EXPOSE_JSON_RPC:-false}"
 fi
 
+set +x
 IRONIC_HTPASSWD_FILE=/etc/ironic/htpasswd
+if [[ -f "/auth/ironic/username" ]]; then
+    read -r IRONIC_HTPASSWD_USERNAME<"/auth/ironic/username"
+fi
+IRONIC_HTPASSWD_USERNAME=${IRONIC_HTPASSWD_USERNAME:-}
+if [[ -f "/auth/ironic/password" ]]; then
+    read -r IRONIC_HTPASSWD_PASSWORD<"/auth/ironic/password"
+fi
+IRONIC_HTPASSWD_PASSWORD=${IRONIC_HTPASSWD_PASSWORD:-}
+if [[ -n "${IRONIC_HTPASSWD_USERNAME}" ]]; then
+    IRONIC_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_HTPASSWD_USERNAME}" "${IRONIC_HTPASSWD_PASSWORD}")"
+fi
+export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+
 INSPECTOR_HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
+if [[ -f "/auth/inspector/username" ]]; then
+    read -r INSPECTOR_HTPASSWD_USERNAME<"/auth/inspector/username"
+fi
+INSPECTOR_HTPASSWD_USERNAME=${INSPECTOR_HTPASSWD_USERNAME:-}
+if [[ -f "/auth/inspector/password" ]]; then
+    read -r INSPECTOR_HTPASSWD_PASSWORD<"/auth/inspector/password"
+fi
+INSPECTOR_HTPASSWD_PASSWORD=${INSPECTOR_HTPASSWD_PASSWORD:-}
+if [[ -n "${INSPECTOR_HTPASSWD_USERNAME}" ]]; then
+    INSPECTOR_HTPASSWD="$(htpasswd -n -b -B "${INSPECTOR_HTPASSWD_USERNAME}" "${INSPECTOR_HTPASSWD_PASSWORD}")"
+fi
+export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+set -x
 
 configure_client_basic_auth()
 {


### PR DESCRIPTION
Security baselines such as CIS do not recommend using secrets as environment variables, but using files instead. Therefore, the IRONIC_HTPASSWD and INSPECTOR_HTPASSWD will now be populated from files instead of environment variables. 