### PR TITLE
⚠️ Remove ibmc and idrac drivers

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -4,17 +4,17 @@ debug = true
 default_deploy_interface = direct
 default_inspect_interface = {% if env.USE_IRONIC_INSPECTOR == "true" %}inspector{% else %}agent{% endif %}
 default_network_interface = noop
-enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish,irmc,ilo
+enabled_bios_interfaces = no-bios,redfish,idrac-redfish,irmc,ilo
 enabled_boot_interfaces = ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
 enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
-enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,ibmc,manual-management,ilo,ilo5
-enabled_inspect_interfaces = {% if env.USE_IRONIC_INSPECTOR == "true" %}inspector{% else %}agent{% endif %},idrac-wsman,irmc,fake,redfish,ilo
-enabled_management_interfaces = ipmitool,idrac-wsman,irmc,fake,redfish,idrac-redfish,ibmc,ilo,ilo5,noop
-enabled_power_interfaces = ipmitool,idrac-wsman,irmc,fake,redfish,idrac-redfish,ibmc,ilo
-enabled_raid_interfaces = no-raid,irmc,agent,fake,ibmc,idrac-wsman,redfish,idrac-redfish,ilo5
-enabled_vendor_interfaces = no-vendor,ipmitool,idrac-wsman,idrac-redfish,redfish,ilo,fake,ibmc
+enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
+enabled_inspect_interfaces = {% if env.USE_IRONIC_INSPECTOR == "true" %}inspector{% else %}agent{% endif %},irmc,fake,redfish,ilo
+enabled_management_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_power_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo
+enabled_raid_interfaces = no-raid,irmc,agent,fake,redfish,idrac-redfish,ilo5
+enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
 enabled_firmware_interfaces = no-firmware,fake,redfish
 {% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}
 rpc_transport = json-rpc

--- a/ironic-rpm-list
+++ b/ironic-rpm-list
@@ -3,9 +3,7 @@ openstack-ironic
 openstack-ironic-api
 openstack-ironic-conductor
 openstack-ironic-inspector
-python3-dracclient
 python3-gunicorn
-python3-ibmcclient
 python3-ironic-prometheus-exporter
 python3-proliantutils
 python3-scciclient

--- a/ironic-source-list
+++ b/ironic-source-list
@@ -30,8 +30,6 @@ ironic-lib
 ironic-prometheus-exporter
 proliantutils
 PyMySQL>=0.8.0
-python-dracclient
-python-ibmcclient
 python-scciclient
 {% if env.SUSHY_SOURCE %}
     {% if path.isdir('/sources/' + env.SUSHY_SOURCE) %}


### PR DESCRIPTION
Both drivers (in case of idrac - its wsman implementation) has been
unmaintained for years, same for their underlying libraries ibmcclient [1]
and dracclient [2]. Ironic has deprecated them in the 2024.1 cycle.

Dell users should use idrac-redfish:// and idrac-virtualmedia:// instead.
iBMC users should try using the generic Redfish drivers and report any
bugs to the Ironic team and any standard compatibility problems directly
to Huawei.

[1] https://github.com/IamFive/python-ibmcclient
[2] https://opendev.org/openstack/python-dracclient

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>