### PR TITLE
🌱 add ARG BASE_IMAGE to sushy-tools Dockerfile

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/library/python:3.9.18-slim-bookworm
+ARG BASE_IMAGE=docker.io/library/python:3.9.18-slim-bookworm
+
+FROM $BASE_IMAGE
 
 ARG SUSHY_TOOLS_VERSION="1.1.0"
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
To be consistent with other Dockerfiles, and to allow easy replacement of the base image, add ARG BASE_IMAGE to sushy-tools Dockerfile.
