### PR TITLE
✨ Provide scripts to be used as liveness/readiness probes

### DIFF
--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -44,4 +44,9 @@ chmod 2775 /var/lib/dnsmasq
 touch /var/lib/dnsmasq/dnsmasq.leases
 chmod 664 /etc/dnsmasq.conf /var/lib/dnsmasq/dnsmasq.leases
 
+# probes that are created before start
+touch /bin/ironic-{readi,live}ness
+chown root:"${IRONIC_GROUP}" /bin/ironic-{readi,live}ness
+chmod 775 /bin/ironic-{readi,live}ness
+
 setcap "cap_net_raw,cap_net_admin,cap_net_bind_service=+eip" /usr/sbin/dnsmasq

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -98,3 +98,20 @@ configure_client_basic_auth ironic-rpc
 
 # Make sure ironic traffic bypasses any proxies
 export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"
+
+PROBE_CURL_ARGS=
+if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "true" ]]; then
+    if [[ "${IRONIC_PRIVATE_PORT}" == "unix" ]]; then
+        PROBE_URL="http://127.0.0.1:6385"
+        PROBE_CURL_ARGS="--unix-socket /shared/ironic.sock"
+    else
+        PROBE_URL="http://127.0.0.1:${IRONIC_PRIVATE_PORT}"
+    fi
+else
+        PROBE_URL="${IRONIC_BASE_URL}"
+fi
+export PROBE_CURL_ARGS
+export PROBE_URL
+
+PROBE_KIND=readiness render_j2_config /bin/ironic-probe.j2 /bin/ironic-readiness
+PROBE_KIND=liveness render_j2_config /bin/ironic-probe.j2 /bin/ironic-liveness

--- a/scripts/ironic-probe.j2
+++ b/scripts/ironic-probe.j2
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+curl -sSf {{ env.PROBE_CURL_ARGS }} "{{ env.PROBE_URL }}"
+
+# TODO(dtantsur): when PROBE_KIND==readiness, try the conductor and driver API
+# to make sure the conductor is ready. This requires having access to secrets
+# since these endpoints are authenticated.


### PR DESCRIPTION
This change is the first step towards https://github.com/metal3-io/baremetal-operator/issues/1528.
Through these scripts, we can decouple the validation logic from
the pod definition and provide more sophisticated tests in the future.

Right now, the same curl command is used (modulo supporting all variants
of deploying Ironic).

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>