### PR TITLE
🌱 Fix error in reading ironic htpasswd from file

### DIFF
--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -14,11 +14,11 @@ fi
 set +x
 IRONIC_HTPASSWD_FILE=/etc/ironic/htpasswd
 if [[ -f "/auth/ironic/username" ]]; then
-    read -r IRONIC_HTPASSWD_USERNAME<"/auth/ironic/username"
+    IRONIC_HTPASSWD_USERNAME=$(</auth/ironic/username)
 fi
 IRONIC_HTPASSWD_USERNAME=${IRONIC_HTPASSWD_USERNAME:-}
 if [[ -f "/auth/ironic/password" ]]; then
-    read -r IRONIC_HTPASSWD_PASSWORD<"/auth/ironic/password"
+    IRONIC_HTPASSWD_PASSWORD=$(</auth/ironic/password)
 fi
 IRONIC_HTPASSWD_PASSWORD=${IRONIC_HTPASSWD_PASSWORD:-}
 if [[ -n "${IRONIC_HTPASSWD_USERNAME}" ]]; then


### PR DESCRIPTION
Update the method of reading ironic htpasswd username and password from file, to make it less sensitive to error whether or not the file ends in newline.