### PR TITLE
🐛 Disable unused network interfaces

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -7,15 +7,16 @@ default_network_interface = noop
 enabled_bios_interfaces = no-bios,redfish,idrac-redfish,irmc,ilo
 enabled_boot_interfaces = ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
 enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent
+enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
 enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
 enabled_inspect_interfaces = agent,irmc,fake,redfish,ilo
 enabled_management_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_network_interfaces = noop
 enabled_power_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo
 enabled_raid_interfaces = no-raid,irmc,agent,fake,redfish,idrac-redfish,ilo5
 enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
-enabled_firmware_interfaces = no-firmware,fake,redfish
 {% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}
 rpc_transport = json-rpc
 {% else %}


### PR DESCRIPTION
Loading the "flat" network interfaces causes a confusing warnings about
unset cleaning_network parameter. Just disable it.

Sort the options in the configuration.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>