### PR TITLE
🌱 Read Ironic htpasswd from file or environment variable

### DIFF
--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -11,21 +11,11 @@ else
     export IRONIC_EXPOSE_JSON_RPC="${IRONIC_EXPOSE_JSON_RPC:-false}"
 fi
 
-set +x
 IRONIC_HTPASSWD_FILE=/etc/ironic/htpasswd
-if [[ -f "/auth/ironic/username" ]]; then
-    IRONIC_HTPASSWD_USERNAME=$(</auth/ironic/username)
-fi
-IRONIC_HTPASSWD_USERNAME=${IRONIC_HTPASSWD_USERNAME:-}
-if [[ -f "/auth/ironic/password" ]]; then
-    IRONIC_HTPASSWD_PASSWORD=$(</auth/ironic/password)
-fi
-IRONIC_HTPASSWD_PASSWORD=${IRONIC_HTPASSWD_PASSWORD:-}
-if [[ -n "${IRONIC_HTPASSWD_USERNAME}" ]]; then
-    IRONIC_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_HTPASSWD_USERNAME}" "${IRONIC_HTPASSWD_PASSWORD}")"
+if [[ -f "/auth/ironic/htpasswd" ]]; then
+    IRONIC_HTPASSWD=$(</auth/ironic/htpasswd)
 fi
 export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
-set -x
 
 configure_client_basic_auth()
 {


### PR DESCRIPTION
This PR reverts #482 and #498, because it is not secure to mount the ironic username and password as plain text files into
ironic-image. The PR adds the ability to mount the ironic htpasswd as a file (to introduce a better way than just using environment variable for this purpose). 

