### PR TITLE
🌱 enable https download in ipxe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /tmp
 
 RUN git clone --depth 1 --branch v1.21.1 https://github.com/ipxe/ipxe.git && \
       cd ipxe/src && \
+      # Enable HTTPS support
+      sed -i 's/#undef\tDOWNLOAD_PROTO_HTTPS/#define\tDOWNLOAD_PROTO_HTTPS/' config/general.h && \
       ARCH=$(uname -m | sed 's/aarch/arm/') && \
       # NOTE(elfosardo): warning should not be treated as errors by default
       NO_WERROR=1 make bin/undionly.kpxe "bin-$ARCH-efi/snponly.efi"


### PR DESCRIPTION
**What this PR does / why we need it**:
I am trying to use TLS in every part of the deployment chain and it seems that by default [HTTPS is disabled](https://github.com/ipxe/ipxe/blob/master/src/config/general.h#L59) in iPXE image.

![image](https://github.com/metal3-io/ironic-image/assets/13087245/02d93f48-7dd2-460e-a6b7-3cf516768412)

As per https://ipxe.org/buildcfg/download_proto_https this commit would enable support (tested this in our environment).
