### PR TITLE
WIP: 🐛 Fix permissions for /certs/ca directory

### DIFF
--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -23,7 +23,7 @@ chown "${IRONIC_USER}":"${IRONIC_GROUP}" /shared
 # that need to have correct ownership as the entire ironic in BMO
 # deployment shares a single fsGroup in manifest's securityContext
 mkdir -p /certs/ca
-chown "${IRONIC_USER}":"${IRONIC_GROUP}" /certs{,/ca}
+chown -R "${IRONIC_USER}":"${IRONIC_GROUP}" /certs{,/ca}
 chmod 2775 /certs{,/ca}
 
 # ironic and httpd related changes


### PR DESCRIPTION
The metal3-ironic-inspector pod is not able to create the /certs/ca directory and fails with the following error while executing /bin/tls-common.sh. This PR fixes this issue.
```
++ mkdir -p /certs/ca/ironic
mkdir: cannot create directory '/certs/ca/ironic': Permission denied
```