### PR TITLE
🌱 add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - derekhiggins
- - dtantsur
- - elfosardo
- - iurygregory
+- ironic-image-maintainers
 
 reviewers:
- - lentzi90
- - Rozzii
- - tuminoid
- - zaneb
+- ironic-image-maintainers
+- ironic-image-reviewers
 
 emeritus_reviewers:
- - maelk
- - namnx228
- - stbenjam
+- maelk
+- namnx228
+- stbenjam
 
 emeritus_approvers:
- - bfournie
- - hardys
+- bfournie
+- hardys

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,14 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  ironic-image-maintainers:
+  - derekhiggins
+  - dtantsur
+  - elfosardo
+  - iurygregory
+
+  ironic-image-reviewers:
+  - lentzi90
+  - Rozzii
+  - tuminoid
+  - zaneb


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.
