### PR TITLE
✨ Allow independent credentials for JSON RPC

### DIFF
--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -15,38 +15,60 @@ IRONIC_HTPASSWD_FILE=/etc/ironic/htpasswd
 if [[ -f "/auth/ironic/htpasswd" ]]; then
     IRONIC_HTPASSWD=$(</auth/ironic/htpasswd)
 fi
+if [[ -f "/auth/ironic-rpc/htpasswd" ]]; then
+    IRONIC_RPC_HTPASSWD=$(</auth/ironic-rpc/htpasswd)
+fi
 export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+export IRONIC_RPC_HTPASSWD=${IRONIC_RPC_HTPASSWD:-${IRONIC_HTPASSWD}}
 
-configure_client_basic_auth()
-{
-    local auth_config_file="/auth/$1/auth-config"
-    local dest="${2:-/etc/ironic/ironic.conf}"
-    if [[ -f "${auth_config_file}" ]]; then
-        # Merge configurations in the "auth" directory into the default ironic configuration file
-        crudini --merge "${dest}" < "${auth_config_file}"
-    fi
-}
+IRONIC_CONFIG=/etc/ironic/ironic.conf
+
 
 configure_json_rpc_auth()
 {
-    if [[ "${IRONIC_EXPOSE_JSON_RPC}" == "true" ]]; then
-        if [[ -z "${IRONIC_HTPASSWD}" ]]; then
+    if [[ "${IRONIC_EXPOSE_JSON_RPC}" != "true" ]]; then
+        return
+    fi
+
+    local auth_config_file="/auth/ironic-rpc/auth-config"
+    local username_file="/auth/ironic-rpc/username"
+    local password_file="/auth/ironic-rpc/password"
+    if [[ -f "${username_file}" ]] && [[ -f "${password_file}" ]]; then
+        crudini --set "${IRONIC_CONFIG}" json_rpc username "$(<${username_file})"
+        set +x
+        crudini --set "${IRONIC_CONFIG}" json_rpc password "$(<${password_file})"
+        set -x
+    elif [[ -f "${auth_config_file}" ]]; then
+        echo "WARNING: using auth-config is deprecated, mount a secret directly"
+        # Merge configurations in the "auth" directory into the default ironic configuration file
+        crudini --merge "${IRONIC_CONFIG}" < "${auth_config_file}"
+    else
+        echo "FATAL: no client-side credentials provided for JSON RPC"
+        echo "HINT: mount a secret with username and password fields under /auth/ironic-rpc"
+        exit 1
+    fi
+
+    if [[ -z "${IRONIC_RPC_HTPASSWD}" ]]; then
+        if [[ -f "${username_file}" ]] && [[ -f "${password_file}" ]]; then
+            htpasswd -c -i -B "${IRONIC_HTPASSWD_FILE}-rpc" "$(<${username_file})" <"${password_file}"
+        else
             echo "FATAL: enabling JSON RPC requires authentication"
+            echo "HINT: mount a secret with either username and password or htpasswd under /auth/ironic-rpc"
             exit 1
         fi
-        printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}-rpc"
+    else
+        printf "%s\n" "${IRONIC_RPC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}-rpc"
     fi
 }
 
 configure_ironic_auth()
 {
-    local config=/etc/ironic/ironic.conf
     # Configure HTTP basic auth for API server
     if [[ -n "${IRONIC_HTPASSWD}" ]]; then
         printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}"
         if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "false" ]]; then
-            crudini --set "${config}" DEFAULT auth_strategy http_basic
-            crudini --set "${config}" DEFAULT http_basic_auth_user_file "${IRONIC_HTPASSWD_FILE}"
+            crudini --set "${IRONIC_CONFIG}" DEFAULT auth_strategy http_basic
+            crudini --set "${IRONIC_CONFIG}" DEFAULT http_basic_auth_user_file "${IRONIC_HTPASSWD_FILE}"
         fi
     fi
 }

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -84,8 +84,6 @@ env | grep "^OS_" || true
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter
 
-configure_json_rpc_auth
-
 if [[ -f /proc/sys/crypto/fips_enabled ]]; then
     ENABLE_FIPS_IPA=$(cat /proc/sys/crypto/fips_enabled)
     export ENABLE_FIPS_IPA
@@ -94,7 +92,7 @@ fi
 # The original ironic.conf is empty, and can be found in ironic.conf_orig
 render_j2_config /etc/ironic/ironic.conf.j2 /etc/ironic/ironic.conf
 
-configure_client_basic_auth ironic-rpc
+configure_json_rpc_auth
 
 # Make sure ironic traffic bypasses any proxies
 export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"


### PR DESCRIPTION
It's probably not a great idea to allow users to easily access JSON RPC,
so a different set of credentials is useful.

Also allow the secret to be mounted directly without the convoluted
auth-config format (which is an ini file in reality). Deprecate
the auth-config approach (JSON RPC is the last instance where it's
used).