### PR TITLE
🌱 increase ironic-image build timeout to 3600s

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -31,7 +31,7 @@ jobs:
           {
             "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
           }
-        job_timeout: "1000"
+        job_timeout: "3600"
     - name: build sushy-tools image
       uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
       with:


### PR DESCRIPTION
Ironic-image build locally, with a fast disk, fast CPU, and fast net takes 500-600s, depending on pre-pulls, repository speeds etc. New cloud has none of those reliably, so it times out at 1000s far too often. Also scheduling time is considered when images are built in Jenkins, and often scheduling takes a long time. Thanks to #505  we get notifications of these failures now.

- Ironic image: 1000s -> 3600s (build time 500-600s, less than 2x safety)
- Sushy-tools: keep 1000s (build time 150s, 6x safety)
- VMBC: keep 1000s (build time 100s, 10x safety)

I will cherry-pick this to release branches as well.