### PR TITLE
🐛 Update httpd.conf.j2 

### DIFF
--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -1,6 +1,6 @@
 ServerRoot "/etc/httpd"
 {%- if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen [::]:{{ env.HTTP_PORT }}
+Listen {{ env.HTTP_PORT }}
 {% else %}
 Listen {{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}
 {% endif %}


### PR DESCRIPTION
**What this PR does / why we need it**:
The current `Listen` directive does not work on systems that have ipv6 disabled. The Apache Listen directive supports `Listen <port>` syntax at which point it seems to be able to listen correctly on both dual stack and ipv4 only systems. See https://httpd.apache.org/docs/2.4/bind.html for more details.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #531 