### PR TITLE
:warning: Update ipxe version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,16 @@ ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM $BASE_IMAGE AS ironic-builder
 
+ARG IPXE_COMMIT_HASH=9062544f6a0c69c249b90d21a08d05518aafc2ec
+
 RUN dnf install -y gcc git make xz-devel
 
 WORKDIR /tmp
 
-RUN git clone --depth 1 --branch v1.21.1 https://github.com/ipxe/ipxe.git && \
-      cd ipxe/src && \
+RUN git clone https://github.com/ipxe/ipxe.git && \
+      cd ipxe && \
+      git reset --hard $IPXE_COMMIT_HASH && \
+      cd src && \
       ARCH=$(uname -m | sed 's/aarch/arm/') && \
       # NOTE(elfosardo): warning should not be treated as errors by default
       NO_WERROR=1 make bin/undionly.kpxe "bin-$ARCH-efi/snponly.efi"


### PR DESCRIPTION
This is a tentative to make ipxe more close to the current version
and include some improvements and bug fixes.
As a first step we build and install ipxe using a commit hash,
as no stable versions have been released since December 2020.

We point the ipxe commit hash to [1] from November 2021, so
roughly a year of changes is included.
To see the complete list of changes run:
`git log --pretty=oneline 988d2c1..9062544`
from a local clone of the ipxe repository.

In general the changes included between the stable 1.21.1
version and the current chosen hash improve compatibility
with recent gcc and build libraries, while fixing
numerous bugs.

This change also introduce a build arg to allow choosing
the ipxe commit hash at container build time.

[1] https://github.com/ipxe/ipxe/commit/9062544f6a0c69c249b90d21a08d05518aafc2ec
