### PR TITLE
:seedling: Move Image build to GH runner

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -1,5 +1,8 @@
 name: build-images-action
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -8,61 +11,35 @@ on:
     tags:
     - 'v*'
 
-permissions: {}
-
-jobs:
-  build:
-    name: Build container images
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    if: github.repository == 'metal3-io/ironic-image'
-    steps:
-    - name: build ironic image
-      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-      with:
-        jenkins_url: "https://jenkins.nordix.org/"
-        jenkins_user: "metal3.bot@gmail.com"
-        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-        job_name: "metal3_ironic_container_image_building"
-        job_params: |
-          {
-            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-          }
-        job_timeout: "3600"
-    - name: build sushy-tools image
-      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-      with:
-        jenkins_url: "https://jenkins.nordix.org/"
-        jenkins_user: "metal3.bot@gmail.com"
-        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-        job_name: "metal3_sushy-tools_container_image_building"
-        job_params: |
-          {
-            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-          }
-        job_timeout: "1000"
-    - name: build vbmc image
-      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-      with:
-        jenkins_url: "https://jenkins.nordix.org/"
-        jenkins_user: "metal3.bot@gmail.com"
-        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-        job_name: "metal3_vbmc_container_image_building"
-        job_params: |
-          {
-            "BUILD_CONTAINER_IMAGE_GIT_REFERENCE": "${{ github.ref }}"
-          }
-        job_timeout: "1000"
-    - name: Slack Notification on Failure
-      if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907 # 2.3.0
-      env:
-        SLACK_TITLE: 'GitHub Action Failed in ${{ github.repository }}'
-        SLACK_COLOR: '#FF0000'
-        SLACK_MESSAGE: 'The GitHub Action workflow failed for ironic image build.'
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_CHANNEL: metal3-github-actions-notify
-        SLACK_USERNAME: metal3-github-actions-notify
+  build_ironic:
+    name: Build Ironic container image
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: "ironic"
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  build_sushy-tools:
+    name: Build sushy-tools image
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: "sushy-tools"
+      dockerfile-directory: resources/sushy-tools
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  build_vbmc:
+    name: build vbmc image
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: "vbmc"
+      dockerfile-directory: resources/vbmc
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Move container image builds to GH runners, using common image build workflow from project-infra, making workflow much cleaner and maintainable. 

This solves many GH workflow<->Jenkins related issues, like false timeouts due scheduling and GH workers do not suffer from random network issues as often. 