### PR TITLE
🌱 Fix syntax in build images github workflow

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -11,6 +11,7 @@ on:
     tags:
     - 'v*'
 
+jobs:
   build_ironic:
     name: Build Ironic container image
     if: github.repository == 'metal3-io/ironic-image'


### PR DESCRIPTION
The syntax error in build images workflow caused all jobs to fail. These could probably be automatically caught in the future