### PR TITLE
🐛runlogwatch.sh fix CPU usage and partial files

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -4,15 +4,14 @@
 LOG_DIR="/shared/log/ironic/deploy"
 
 while :; do
-    if ! ls "${LOG_DIR}"/*.tar.gz 1> /dev/null 2>&1; then
-        continue
-    fi
+    sleep 5
 
-    for fn in "${LOG_DIR}"/*.tar.gz; do
+    while read -r fn; do
+        echo
         echo "************ Contents of $fn ramdisk log file bundle **************"
         tar -xOzvvf "$fn" | sed -e "s/^/$(basename "$fn"): /"
         rm -f "$fn"
-    done
+    # find all *.tar.gz files which are older than six seconds
+    done < <(find "${LOG_DIR}" -mmin +0.1 -type f -name "*.tar.gz")
 
-    sleep 5
 done


### PR DESCRIPTION
Currently runlogwatch.sh runs in a tight loop when there are no files,
consuming CPU. Also there have been reports of truncated logs being
outputted which would be explained by ironic not writing these files
atomically [1]. This change improves this script by:
- moving the sleep to the top of the loop so it is called on every
  iteration
- change the file glob to a `find` command which includes `-mmin +0.1`
  so the file is only processed when it is at least 6 seconds old