### PR TITLE
🌱 Bump default sushy-tools version to 1.3.0

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/library/python:3.9.18-slim-bookworm
 
 FROM $BASE_IMAGE
 
-ARG SUSHY_TOOLS_VERSION="1.2.0"
+ARG SUSHY_TOOLS_VERSION="1.3.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \


### PR DESCRIPTION
Bump sushy-tools version to the latest v1.3.0
https://opendev.org/openstack/sushy-tools/releases/tag/1.3.0