### PR TITLE
:bug: Pin ironic source

### DIFF
--- a/ironic-source-list
+++ b/ironic-source-list
@@ -7,7 +7,7 @@ git+file:///sources/{{ env.IRONIC_SOURCE }}
 ironic @ git+https://opendev.org/openstack/ironic@{{ env.IRONIC_SOURCE }}
     {% endif %}
 {% else %}
-ironic @ git+https://opendev.org/openstack/ironic
+ironic @ git+https://review.opendev.org/openstack/ironic@refs/changes/85/928885/1
 {% endif %}
 {% if env.IRONIC_LIB_SOURCE %}
     {% if path.isdir('/sources/' + env.IRONIC_LIB_SOURCE) %}


### PR DESCRIPTION
Workaround to unblock the CI.

This commit:
- Pins the Ironic source to a WIP upstream gerrit change that resolves a regression introduced by a recent change.