### PR TITLE
🐛 Revert "pin ironic source"

### DIFF
--- a/ironic-source-list
+++ b/ironic-source-list
@@ -7,7 +7,7 @@ git+file:///sources/{{ env.IRONIC_SOURCE }}
 ironic @ git+https://opendev.org/openstack/ironic@{{ env.IRONIC_SOURCE }}
     {% endif %}
 {% else %}
-ironic @ git+https://review.opendev.org/openstack/ironic@refs/changes/85/928885/1
+ironic @ git+https://opendev.org/openstack/ironic
 {% endif %}
 {% if env.IRONIC_LIB_SOURCE %}
     {% if path.isdir('/sources/' + env.IRONIC_LIB_SOURCE) %}


### PR DESCRIPTION
This reverts commit 9443d08bdda79ad3683fe887c1cc1dcd4e2efabc.

Revert temporary fix, when the [real bugfix](https://review.opendev.org/c/openstack/ironic/+/928885) has landed in Ironic's repository.

/hold