### PR TITLE
:bug: Pin setuptools during image build

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -33,7 +33,11 @@ if [[ "$INSTALL_TYPE" == "source" ]]; then
     # NOTE(dtantsur): pip is a requirement of python3 in CentOS
     # shellcheck disable=SC2086
     dnf install -y python3-pip $BUILD_DEPS
-    python3 -m pip install pip==21.3.1
+    # NOTE(elfosardo): pinning pip and setuptools version to avoid
+    # incompatibilities and errors during packages installation;
+    # versions should be updated regularly, for example
+    # after cutting a release branch.
+    python3 -m pip install pip==21.3.1 setuptools==74.1.2
 
     IRONIC_PKG_LIST_FINAL="/tmp/ironic-${INSTALL_TYPE}-list-final"
 


### PR DESCRIPTION
Usually the setuptools installed by the system is stable but a bit too old compared to the packages we use for ironic, so pinning a more recent version helps avoiding errors and incompatibilities.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>
(cherry picked from commit 82692ba7683ec1d48a67aaaaf6d8bf5496177c1d)

