### PR TITLE
:warning: Update ipxe version to December 2022

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM $BASE_IMAGE AS ironic-builder
 
-ARG IPXE_COMMIT_HASH=9062544f6a0c69c249b90d21a08d05518aafc2ec
+ARG IPXE_COMMIT_HASH=7147532c3fbf9a7061e74549f6f920a91ca9a80d
 
 RUN dnf install -y gcc git make xz-devel
 


### PR DESCRIPTION
This is yet another tentative to make ipxe more close to the current version and include some improvements and bug fixes.

We point the ipxe commit hash to [1] from December 2022, so roughly a year of changes is included.
To see the complete list of changes run:
`git log --pretty=oneline 9062544..714753`
from a local clone of the ipxe repository.

In general the changes included between the old hash and and the current chosen hash improve compatibility
with recent gcc and build libraries, while fixing
numerous bugs.

This is a follow-up to https://github.com/metal3-io/ironic-image/commit/bd9319c91d75dd4e99efe6027de056d1187f9546

[1] https://github.com/ipxe/ipxe/commit/7147532c3fbf9a7061e74549f6f920a91ca9a80d

