### PR TITLE
:sparkles: Install shim-pkg explicitly and add support for CentOS Stream 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repo contains the files needed to build the Ironic images used by Metal3.
 
+Supported base images are CentOS Stream 9 and CentOS Stream 10.
+
 ## Build Status
 
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/metal3-io/badge)](https://clomonitor.io/projects/cncf/metal3-io)

--- a/prepare-efi.sh
+++ b/prepare-efi.sh
@@ -10,10 +10,12 @@ if [[ "$ARCH" == "x86_64" ]]; then
     PACKAGES=grub2-efi-x64
     BOOTEFI=BOOTX64.EFI
     GRUBEFI=grubx64.efi
+    SHIM_PKG=shim-x64
 elif [[ "$ARCH" == "aarch64" ]]; then
     PACKAGES=grub2-efi-aa64
     BOOTEFI=BOOTAA64.EFI
     GRUBEFI=grubaa64.efi
+    SHIM_PKG=shim-aa64
 else
     echo "WARNING: don't know how to build an EFI image on $ARCH"
     touch "$DEST"
@@ -29,7 +31,7 @@ fi
 # ``Cannot initialize '::'``
 # This is due to the conversion table missing codepage 850, included in glibc-gconv-extra
 # shellcheck disable=SC2086
-dnf install -y grub2 shim dosfstools mtools glibc-gconv-extra $PACKAGES
+dnf install -y grub2 shim dosfstools mtools glibc-gconv-extra $PACKAGES $SHIM_PKG
 
 ## TODO(TheJulia): At some point we may want to try and make the size
 ## of the ESP image file to be sized smaller for the files that need to


### PR DESCRIPTION
This simple change allows us to build ironic containers using
CS10 base images, adding that as supported OS.
This has been tested locally and in CI.

related issue https://github.com/metal3-io/ironic-image/issues/529
