### PR TITLE
🐛 improve upper constraints handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ ARG PATCH_LIST
 ARG INSTALL_TYPE=source
 
 # build arguments for source build customization
-ARG UPPER_CONSTRAINTS_FILE
 ARG IRONIC_SOURCE=bugfix/25.0
+ARG UPPER_CONSTRAINTS_FILE=upper-constraints.txt
 ARG IRONIC_LIB_SOURCE
 ARG SUSHY_SOURCE
 

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -47,7 +47,7 @@ if [[ "$INSTALL_TYPE" == "source" ]]; then
 
     # NOTE(elfosardo): if the content of the upper-constraints file is empty,
     # we give as assumed that we're on the master branch
-    if [[ ! -f "${UPPER_CONSTRAINTS_PATH}" ]]; then
+    if [[ ! -s "${UPPER_CONSTRAINTS_PATH}" ]]; then
         UPPER_CONSTRAINTS_PATH="/tmp/upper-constraints.txt"
         curl -L https://releases.openstack.org/constraints/upper/master -o "${UPPER_CONSTRAINTS_PATH}"
     fi


### PR DESCRIPTION
This commit:
 - Provides a default value for the UPPER_CONSTRAINT docker file argument
 - Changes the prepare-image.sh logic to check the actual size of the upper constraint file and not the presence of it.

Background of this change is that it has been noticed that on release branches during image building the "pinned" upper constraint file is not picked up rather pulled from upstream OpenStack because of a lack of default argument value during image building.
