### PR TITLE
:warning: Update ipxe version to May 2024

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM $BASE_IMAGE AS ironic-builder
 
-ARG IPXE_COMMIT_HASH=119c415ee47aaef2717104fea493377aa9a65874
+ARG IPXE_COMMIT_HASH=e965f179e1654103eca33feed7a9cc4c51d91be6
 
 RUN dnf install -y gcc git make xz-devel
 


### PR DESCRIPTION
This is yet another tentative to make ipxe more close to the current version and include some improvements and bug fixes.

We point the ipxe commit hash to [1] from May 2024, so roughly 6 months of changes are included.
To see the complete list of changes run:
`git log --pretty=oneline 119c41..e965f17`
from a local clone of the ipxe repository.

In general the changes included between the old hash and the current chosen hash improve compatibility
with recent gcc and build libraries, while fixing
numerous bugs.

On a side note, this is the minimum commit required to build ipxe on CentOS Stream 10.

This is a follow up to https://github.com/metal3-io/ironic-image/commit/4955fbbbb3283f9a12e8e63d1326d666fdda79b1

[1] https://github.com/ipxe/ipxe/commit/e965f179e1654103eca33feed7a9cc4c51d91be6

