### PR TITLE
:sparkles: relocate ironic-client to this repository

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -47,3 +47,15 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  build_client:
+    name: build ironic-client image
+    if: github.repository == 'metal3-io/ironic-image'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: 'ironic-client'
+      dockerfile-directory: resources/ironic-client
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -137,7 +137,9 @@ For that, please continue following the instructions provided in
 
 ## Keeping sync with other images and tools
 
-- The [sushy-tools and vbmc](https://github.com/metal3-io/ironic-image/tree/main/resources)
+- The [sushy-tools](<https://github.com/metal3-io/ironic-image/tree/main/resources/sushy-tools>),
+  [vbmc](https://github.com/metal3-io/ironic-image/tree/main/resources/vbmc)
+  and [ironic-client](https://github.com/metal3-io/ironic-image/tree/main/resources/ironic-client)
   images won't be versioned, we expect them to work with any version.
 - The [ipa-downloader](https://github.com/metal3-io/ironic-ipa-downloader)
   image uses the [ironic-python-agent](https://opendev.org/openstack/ironic-python-agent)

--- a/resources/ironic-client/Dockerfile
+++ b/resources/ironic-client/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/centos/centos:stream9
+
+# Help people find the actual baremetal command
+COPY scripts/openstack /usr/bin/openstack
+
+RUN dnf install -y python3 python3-pip genisoimage && \
+    pip install python-ironicclient --prefix /usr --no-cache-dir && \
+    chmod +x /usr/bin/openstack && \
+    dnf update -y && \
+    dnf clean all && \
+    rm -rf /var/cache/{yum,dnf}/*
+
+ENTRYPOINT ["/usr/bin/baremetal"]

--- a/resources/ironic-client/README.md
+++ b/resources/ironic-client/README.md
@@ -1,0 +1,9 @@
+# Metal3 Ironic Client Container
+
+This repo contains the files needed to build a container image with the Ironic
+CLI utilities, which are useful for debugging via Ironic APIs.
+
+## Description
+
+When updated, builds are automatically triggered on
+[Quay](https://quay.io/repository/metal3-io/ironic-client).

--- a/resources/ironic-client/scripts/openstack
+++ b/resources/ironic-client/scripts/openstack
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Please use /usr/bin/baremetal instead"
+exit 1


### PR DESCRIPTION
Relocate ironic-client image from ironic-client repo, which will be archived.

Ref: https://github.com/metal3-io/ironic-client/issues/30 