### PR TITLE
:sparkles: Make deep image inspection configurable

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -92,6 +92,9 @@ deploy_kernel = file://{{ env.IRONIC_DEFAULT_KERNEL }}
 {% if env.IRONIC_DEFAULT_RAMDISK is defined %}
 deploy_ramdisk = file://{{ env.IRONIC_DEFAULT_RAMDISK }}
 {% endif %}
+{% if env.DISABLE_DEEP_IMAGE_INSPECTION | lower == "true" %}
+disable_deep_image_inspection = True
+{% endif %}
 
 [database]
 {% if env.IRONIC_USE_MARIADB | lower == "false" %}


### PR DESCRIPTION
This PR:

  - Implements the support for disabling the deep_image_inspection via environment variable.

This new functionality is needed because e.g right now the Ironic&IPA has issues running deep image inspection on e.g. live-iso images.

