### PR TITLE
:seedling: Use pynotify instead of inotify-tools

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -7,6 +7,7 @@ ipmitool
 iproute
 mod_ssl
 procps
+python3-inotify
 python3-jinja2
 qemu-img
 sqlite

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -71,10 +71,6 @@ if [[ -n "${EXTRA_PKGS_LIST:-}" ]]; then
     fi
 fi
 
-dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-dnf config-manager --set-disabled epel
-dnf install -y --enablerepo=epel inotify-tools
-
 dnf remove -y --noautoremove 'dnf-command(config-manager)'
 
 # NOTE(elfosardo): we need to reinstall tzdata as the base CS9 container removes

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -72,18 +72,18 @@ fi
 
 # Set up inotify to kill the container (restart) whenever cert files for ironic api change
 if [[ "$IRONIC_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
-    # shellcheck disable=SC2034
-    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read -r file event; do
-        kill -WINCH $(pgrep httpd)
-    done &
+    python3 -m pyinotify -e IN_DELETE_SELF -v "${IRONIC_CERT_FILE}" |
+        while read -r file event; do
+            kill -WINCH $(pgrep httpd)
+        done &
 fi
 
 # Set up inotify to kill the container (restart) whenever cert of httpd for /shared/html/<redifsh;ilo> path change
 if [[ "$IRONIC_VMEDIA_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
-    # shellcheck disable=SC2034
-    inotifywait -m -e delete_self "${IRONIC_VMEDIA_CERT_FILE}" | while read -r file event; do
-        kill -WINCH $(pgrep httpd)
-    done &
+    python3 -m pyinotify -e IN_DELETE_SELF -v "${IRONIC_VMEDIA_CERT_FILE}" |
+        while read -r file event; do
+            kill -WINCH $(pgrep httpd)
+        done &
 fi
 
 exec /usr/sbin/httpd -DFOREGROUND

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -12,10 +12,10 @@ mkdir -p /shared/log/ironic/deploy
 run_ironic_dbsync
 
 if [[ "$IRONIC_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
-    # shellcheck disable=SC2034
-    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read -r file event; do
-        kill $(pgrep ironic)
-    done &
+    python3 -m pyinotify -e IN_DELETE_SELF -v "${IRONIC_CERT_FILE}" |
+        while read -r file event; do
+            kill $(pgrep ironic)
+        done &
 fi
 
 configure_ironic_auth

--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -3,7 +3,7 @@
 # Ramdisk logs path
 LOG_DIR="/shared/log/ironic/deploy"
 
-inotifywait -m "${LOG_DIR}" -e close_write |
+python3 -m pyinotify -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
     while read -r path _action file; do
         echo "************ Contents of ${path}/${file} ramdisk log file bundle **************"
         tar -xOzvvf "${path}/${file}" | sed -e "s/^/${file}: /"


### PR DESCRIPTION
The inotify-tools last release is from september 2023
and last update in the repo is 7 months old (May 2024).
The inotify-tools package is not present in the EPEL10 repo
anymore while python3-inotify is in a native repository.
This change allows us to remove dependency from EPEL entirely.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>

Closes https://github.com/metal3-io/ironic-image/issues/605


