### PR TITLE
:warning: Remove ironic-lib dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ARG PATCH_LIST
 # build arguments for source build customization
 ARG UPPER_CONSTRAINTS_FILE=upper-constraints.txt
 ARG IRONIC_SOURCE
-ARG IRONIC_LIB_SOURCE
 ARG SUSHY_SOURCE
 
 COPY sources /sources/

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ The following can serve as an example:
 ## Custom source for ironic software
 
 When building the ironic image, it is also possible to specify a
-different source for ironic, ironic-lib or the sushy library using the build
-arguments **IRONIC_SOURCE**, **IRONIC_LIB_SOURCE**, and **SUSHY_SOURCE**.
+different source for ironic or the sushy library using the build
+arguments **IRONIC_SOURCE** and **SUSHY_SOURCE**.
 The accepted formats are gerrit refs, like _refs/changes/89/860689/2_,
 commit hashes, like _a1fe6cb41e6f0a1ed0a43ba5e17745714f206f1f_,
 repo tags or branches, or a local directory that needs to be under the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,7 @@ Things you should check before making a release:
   for high-level process and possible follow-up actions
 - Verify the latest bugfix or stable branches (which is the most recent) in ironic
   upstream repository;
-- Verify compatibility with latest sushy and ironic-lib upstream releases or master
+- Verify compatibility with latest sushy upstream releases or master
   branches based on ironic bugfix or stable requirements and constraints
 - Verify openstack upper-constraints compatibility with ironic bugfix or stable branches
 - Verify any other direct or indirect dependency is uplifted to close any public

--- a/ironic-packages-list
+++ b/ironic-packages-list
@@ -9,15 +9,6 @@ ironic @ git+https://opendev.org/openstack/ironic@{{ env.IRONIC_SOURCE }}
 {% else %}
 ironic @ git+https://opendev.org/openstack/ironic
 {% endif %}
-{% if env.IRONIC_LIB_SOURCE %}
-    {% if path.isdir('/sources/' + env.IRONIC_LIB_SOURCE) %}
-git+file:///sources/{{ env.IRONIC_LIB_SOURCE }}
-    {% else %}
-ironic-lib @ git+https://opendev.org/openstack/ironic-lib@{{ env.IRONIC_LIB_SOURCE }}
-    {% endif %}
-{% else %}
-ironic-lib
-{% endif %}
 ironic-prometheus-exporter
 proliantutils
 PyMySQL>=0.8.0

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -49,10 +49,6 @@ if [[ -n ${SUSHY_SOURCE:-} ]]; then
     sed -i '/^sushy===/d' "${UPPER_CONSTRAINTS_PATH}"
 fi
 
-if [[ -n ${IRONIC_LIB_SOURCE:-} ]]; then
-    sed -i '/^ironic-lib===/d' "${UPPER_CONSTRAINTS_PATH}"
-fi
-
 python3 -m pip install --no-cache-dir --ignore-installed --prefix /usr -r "${IRONIC_PKG_LIST_FINAL}" -c "${UPPER_CONSTRAINTS_PATH}"
 
 # ironic system configuration


### PR DESCRIPTION
The ironic source code does not depend from ironic-lib anymore.
For more info please check [1]

[1] https://opendev.org/openstack/ironic/commit/74d239d4ebfde3e66d838c0cb74992bae0f7c00c

