### PR TITLE
🐛 Drop quiet option of grep to avoid race condition with pipefail

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -19,13 +19,13 @@ get_provisioning_interface()
     local interface="provisioning"
 
     if [[ -n "${PROVISIONING_IP}" ]]; then
-        if ip -br addr show | grep -qi " ${PROVISIONING_IP}/"; then
+        if ip -br addr show | grep -i " ${PROVISIONING_IP}/" &>/dev/null; then
             interface="$(ip -br addr show | grep -i " ${PROVISIONING_IP}/" | cut -f 1 -d ' ' | cut -f 1 -d '@')"
         fi
     fi
 
     for mac in ${PROVISIONING_MACS//,/ }; do
-        if ip -br link show up | grep -qi "$mac"; then
+        if ip -br link show up | grep -i "$mac" &>/dev/null; then
             interface="$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ' | cut -f 1 -d '@')"
             break
         fi


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The grep -q closes input pipe immediately if any match is found, while the command on the left side will exit with SIGPIPE when it tries to write to a closed pipe, causing the Metal3 Pod to get stuck in CrashLoopBackOff sometimes.

**Which issue(s) this PR fixes**:
Fixes #611 
