### PR TITLE
🌱 Enables sushy-tool image multiarch builds

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -31,6 +31,8 @@ jobs:
       image-name: 'sushy-tools'
       dockerfile-directory: resources/sushy-tools
       pushImage: true
+      multiPlatform: true
+      platform: "linux/amd64,linux/arm64,linux/arm/v8"
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This repo contains the files needed to build the Ironic images used by Metal3.
 When updated, builds are automatically triggered on
 <https://quay.io/repository/metal3-io/ironic/>
 
+> [!NOTE]
+> ARM images are experimental and not tested.
+
 This repo supports the creation of multiple containers needed when provisioning
 baremetal nodes with Ironic. Eventually there will be separate images for each
 container, but currently separate containers can share this same image with


### PR DESCRIPTION
**What this PR does / why we need it**:
This (hopefully) enables multiarch builds on the sushy-tools container image.

**Which issue(s) this PR fixes**:
Fixes #615 

Also, see https://github.com/metal3-io/project-infra/pull/960 as required for this to work.
