### PR TITLE
:seedling: add dependabot configuration for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+## main branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+    day: "friday"
+  target-branch: main
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+
+## main branch config ends here


### PR DESCRIPTION
Now that we have workflows in this repository, let's add Dependabot config to keep them up to date. Assigning an individual weekday for this repo, and interval of one month.
