### PR TITLE
✨ Add scripts to run database upgrades and online migrations

### DIFF
--- a/scripts/rundatabase-upgrade
+++ b/scripts/rundatabase-upgrade
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+# shellcheck disable=SC1091
+. /bin/configure-ironic.sh
+
+# NOTE(dtantsur): no retries here: this script is supposed to be run as a Job
+# that is retried on failure.
+exec ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -9,7 +9,10 @@ export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-false}
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
-run_ironic_dbsync
+# Allows skipping dbsync if it's done by an external job
+if [[ "${IRONIC_SKIP_DBSYNC:-false}" != true ]]; then
+    run_ironic_dbsync
+fi
 
 if [[ "$IRONIC_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
     python3 -m pyinotify -e IN_DELETE_SELF -v "${IRONIC_CERT_FILE}" |

--- a/scripts/runonline-data-migrations
+++ b/scripts/runonline-data-migrations
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+# shellcheck disable=SC1091
+. /bin/configure-ironic.sh
+
+# NOTE(dtantsur): no retries here: this script is supposed to be run as a Job
+# that is retried on failure.
+exec ironic-dbsync --config-file /etc/ironic/ironic.conf online_data_migrations


### PR DESCRIPTION
The new entrypoints rundatabase-upgrade and runonline-data-migrations are
designed to be run as a Job every time Ironic is upgraded. See also:
https://docs.openstack.org/ironic/latest/admin/upgrade-guide.html

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>