### PR TITLE
:bug: remove faulty NUMPROC logic

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -28,13 +28,8 @@ if [[ "$MARIADB_TLS_ENABLED" == "true" ]]; then
     export MARIADB_CONNECTION="${MARIADB_CONNECTION}&ssl=on&ssl_ca=${MARIADB_CACERT_FILE}"
 fi
 
-# TODO(dtantsur): remove the explicit default once we get
-# https://review.opendev.org/761185 in the repositories
-NUMPROC="$(grep -c "^processor" /proc/cpuinfo)"
-if [[ "$NUMPROC" -lt 4 ]]; then
-    NUMPROC=4
-fi
-export NUMWORKERS=${NUMWORKERS:-$NUMPROC}
+# zero makes it do cpu number detection on Ironic side
+export NUMWORKERS=${NUMWORKERS:-0}
 
 export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-true}
 


### PR DESCRIPTION
This removes the faulty NUMPROC processor count detection logic from the configure-ironic.sh. It used to limit CPU count to 4, but the "fixed" version made it a MINIMUM of 4.

This detection has now been merged on the ironic api side, so we can remote the note + the faulty logic, and just leave the minimal env var there. 0 means ironic will run its autodetection logic and set maximum of 4 cores.

This fix has been merged on the Ironic side already in 2020, so we can backport this to all branches we have.

Fixes: #635 