### PR TITLE
⚠️ Deprecate passing MARIADB_PASSWORD in favour of mounting a secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ functionality:
 - `DHCP_IGNORE` - a set of tags on hosts that should be ignored and not allocate
    DHCP leases for, e.g. `tag:!known` to ignore any unknown hosts (empty by
    default)
-- `MARIADB_PASSWORD` - The database password
+- `MARIADB_PASSWORD` - The database password.
+   Deprecated. Instead, mount a secret with `password` (optionally with a
+   `username`) at `/auth/mariadb` mount point.
 - `OS_<section>_\_<name>=<value>` - This format can be used to set arbitary
    Ironic config options
 - `IRONIC_RAMDISK_SSH_KEY` - A public key to allow ssh access to nodes running

--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -21,6 +21,16 @@ fi
 export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
 export IRONIC_RPC_HTPASSWD=${IRONIC_RPC_HTPASSWD:-${IRONIC_HTPASSWD}}
 
+if [[ -n "${MARIADB_PASSWORD:-}" ]]; then
+    echo "WARNING: passing MARIADB_PASSWORD is deprecated, mount a secret under /auth/mariadb instead"
+elif [[ -f /auth/mariadb/password ]]; then
+    MARIADB_PASSWORD=$(</auth/mariadb/password)
+fi
+
+if [[ -z "${MARIADB_USER:-}" ]] && [[ -f /auth/mariadb/username ]]; then
+    MARIADB_USER=$(</auth/mariadb/username)
+fi
+
 IRONIC_CONFIG=/etc/ironic/ironic.conf
 
 

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -19,13 +19,19 @@ export IRONIC_ENABLE_VLAN_INTERFACES=${IRONIC_ENABLE_VLAN_INTERFACES:-${IRONIC_I
 
 export HTTP_PORT=${HTTP_PORT:-80}
 
-MARIADB_PASSWORD=${MARIADB_PASSWORD:-change_me}
-MARIADB_DATABASE=${MARIADB_DATABASE:-ironic}
-MARIADB_USER=${MARIADB_USER:-ironic}
-MARIADB_HOST=${MARIADB_HOST:-127.0.0.1}
-export MARIADB_CONNECTION="mysql+pymysql://${MARIADB_USER}:${MARIADB_PASSWORD}@${MARIADB_HOST}/${MARIADB_DATABASE}?charset=utf8"
-if [[ "$MARIADB_TLS_ENABLED" == "true" ]]; then
-    export MARIADB_CONNECTION="${MARIADB_CONNECTION}&ssl=on&ssl_ca=${MARIADB_CACERT_FILE}"
+export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-true}
+if [[ "${IRONIC_USE_MARIADB}" == true ]]; then
+    if [[ -z "${MARIADB_PASSWORD:-}" ]]; then
+        echo "FATAL: IRONIC_USE_MARIADB requires password, mount a secret under /auth/mariadb"
+        exit 1
+    fi
+    MARIADB_DATABASE=${MARIADB_DATABASE:-ironic}
+    MARIADB_USER=${MARIADB_USER:-ironic}
+    MARIADB_HOST=${MARIADB_HOST:-127.0.0.1}
+    export MARIADB_CONNECTION="mysql+pymysql://${MARIADB_USER}:${MARIADB_PASSWORD}@${MARIADB_HOST}/${MARIADB_DATABASE}?charset=utf8"
+    if [[ "$MARIADB_TLS_ENABLED" == "true" ]]; then
+        export MARIADB_CONNECTION="${MARIADB_CONNECTION}&ssl=on&ssl_ca=${MARIADB_CACERT_FILE}"
+    fi
 fi
 
 # TODO(dtantsur): remove the explicit default once we get
@@ -36,7 +42,6 @@ if [[ "$NUMPROC" -lt 4 ]]; then
 fi
 export NUMWORKERS=${NUMWORKERS:-$NUMPROC}
 
-export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-true}
 
 # Whether to enable fast_track provisioning or not
 export IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}


### PR DESCRIPTION
Passing a password in clear text is an obviously bad idea. Add support
for mounting a secret and deprecate the clear text approach.

This change also makes it a fatal error to not pass the password.
Our mariadb-image does not support empty passwords anyway, and we should
not rely on anyone actually using "change_me" without realizing it.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>