### PR TITLE
⚠️ Set IRONIC_USE_MARIADB to false by default in all cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ functionality:
 - `DHCP_IGNORE` - a set of tags on hosts that should be ignored and not allocate
    DHCP leases for, e.g. `tag:!known` to ignore any unknown hosts (empty by
    default)
-- `MARIADB_PASSWORD` - The database password.
-   Deprecated. Instead, mount a secret with `password` (optionally with a
-   `username`) at `/auth/mariadb` mount point.
 - `OS_<section>_\_<name>=<value>` - This format can be used to set arbitary
    Ironic config options
 - `IRONIC_RAMDISK_SSH_KEY` - A public key to allow ssh access to nodes running
@@ -97,6 +94,20 @@ functionality:
 - `IRONIC_ENABLE_VLAN_INTERFACES` - Which VLAN interfaces to enable on the
   agent start-up. Can be a list of interfaces or a special value `all`.
   Defaults to `all`.
+
+MariaDB configuration:
+
+- `IRONIC_USE_MARIADB` - Whether to use an external MariaDB database instead of
+  a local SQLite file (default `false`)
+- `MARIADB_HOST` - Host name with an optional port of the MariaDB database
+  instance (must be provided if `IRONIC_USE_MARIADB` is `true`)
+- `MARIADB_DATABASE` - Database name to use (default `ironic`)
+- `MARIADB_USER` - User name to use when connecting to the database (default
+  `ironic`). The user must have privileges to create and update tables.
+  Can be provided via a secret mounted under `/auth/mariadb`.
+- `MARIADB_PASSWORD` - The database password.
+   Deprecated. Instead, mount a secret with `password` (optionally with a
+   `username`) under `/auth/mariadb` mount point.
 
 The ironic configuration can be overridden by various environment variables.
 The following can serve as an example:

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -97,14 +97,14 @@ disable_deep_image_inspection = True
 {% endif %}
 
 [database]
-{% if env.IRONIC_USE_MARIADB | lower == "false" %}
+{% if env.IRONIC_USE_MARIADB | lower == "true" %}
+connection = {{ env.MARIADB_CONNECTION }}
+{% else %}
 connection = sqlite:////var/lib/ironic/ironic.sqlite
 # Synchronous mode is required for data integrity in case of operating system
 # crash. In our case we restart the container from scratch, so we can save some
 # IO by not doing syncs all the time.
 sqlite_synchronous = False
-{% else %}
-connection = {{ env.MARIADB_CONNECTION }}
 {% endif %}
 
 [deploy]

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -19,7 +19,6 @@ export IRONIC_ENABLE_VLAN_INTERFACES=${IRONIC_ENABLE_VLAN_INTERFACES:-${IRONIC_I
 
 export HTTP_PORT=${HTTP_PORT:-80}
 
-export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-true}
 if [[ "${IRONIC_USE_MARIADB}" == true ]]; then
     if [[ -z "${MARIADB_PASSWORD:-}" ]]; then
         echo "FATAL: IRONIC_USE_MARIADB requires password, mount a secret under /auth/mariadb"

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -8,6 +8,8 @@ PROVISIONING_IP="${PROVISIONING_IP:-}"
 PROVISIONING_MACS="${PROVISIONING_MACS:-}"
 IPXE_CUSTOM_FIRMWARE_DIR="${IPXE_CUSTOM_FIRMWARE_DIR:-/shared/custom_ipxe_firmware}"
 
+export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-false}
+
 get_provisioning_interface()
 {
     if [[ -n "$PROVISIONING_INTERFACE" ]]; then
@@ -78,7 +80,7 @@ render_j2_config()
 
 run_ironic_dbsync()
 {
-    if [[ "${IRONIC_USE_MARIADB:-true}" == "true" ]]; then
+    if [[ "${IRONIC_USE_MARIADB}" == "true" ]]; then
         # It's possible for the dbsync to fail if mariadb is not up yet, so
         # retry until success
         until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -1,8 +1,5 @@
 #!/usr/bin/bash
 
-# This setting must go before configure-ironic since it has different defaults.
-export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-false}
-
 # shellcheck disable=SC1091
 . /bin/configure-ironic.sh
 


### PR DESCRIPTION
Previously, it defaulted to true for a split API/conductor deployment,
but this mode is no longer supported. Most deployments use a single
Ironic process and SQLite as a backend.

Update README with the relevant parameters.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
