### PR TITLE
✨ Add configurable max_pool_size and max_overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ functionality:
 - `IRONIC_ENABLE_VLAN_INTERFACES` - Which VLAN interfaces to enable on the
   agent start-up. Can be a list of interfaces or a special value `all`.
   Defaults to `all`.
+- `OS_DATABASE__MAX_POOL_SIZE` - Maximum number of SQL connections to
+  keep open in a pool.
+- `OS_DATABASE__MAX_OVERFLOW` - If set, use this value for max_overflow with SQLAlchemy.
 
 MariaDB configuration:
 

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -106,6 +106,8 @@ connection = sqlite:////var/lib/ironic/ironic.sqlite
 # IO by not doing syncs all the time.
 sqlite_synchronous = False
 {% endif %}
+max_pool_size = {{ env.OS_DATABASE__MAX_POOL_SIZE | default(5) }}
+max_overflow = {{ env.OS_DATABASE__MAX_OVERFLOW | default(50) }}
 
 [deploy]
 default_boot_option = local


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Added support for configuring `max_pool_size` and `max_overflow` in the database section of the Jinja template. These values are now derived from environment variables `IRONIC_MAX_POOL_SIZE` and `IRONIC_MAX_OVERFLOW`, with default values set to 5 and 50, respectively.

This change allows for better control over database connection pooling, improving scalability and performance.

Considering our environment with approximately 3,028 Ironic nodes, adjusting these values may be necessary to handle concurrent operations efficiently.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
