### PR TITLE
🌱  Update sushy-tools to 2.0.0

### DIFF
--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=docker.io/library/python:3.9.18-slim-bookworm
 
 FROM $BASE_IMAGE
 
-ARG SUSHY_TOOLS_VERSION="1.3.0"
+ARG SUSHY_TOOLS_VERSION="2.0.0"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \


### PR DESCRIPTION
We release sushy-tools 2.0.0 last week, let's update the version we use in Metal3

https://review.opendev.org/c/openstack/releases/+/943234
