### PR TITLE
:bug: harmonize custom config/data paths and db data migration

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -27,7 +27,7 @@ use_stderr = true
 hash_ring_algorithm = sha256
 my_ip = {{ env.IRONIC_IP }}
 host = {{ env.IRONIC_CONDUCTOR_HOST }}
-tempdir = /data/tmp
+tempdir = {{ env.IRONIC_TMP_DATA_DIR }}
 
 # If a path to a certificate is defined, use that first for webserver
 {% if env.WEBSERVER_CACERT_FILE %}

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -17,7 +17,6 @@ export DNSMASQ_TEMP_DIR="${CUSTOM_CONFIG_DIR}/dnsmasq"
 export HTTPD_DIR="${CUSTOM_CONFIG_DIR}/httpd"
 export HTTPD_CONF_DIR="${HTTPD_DIR}/conf"
 export HTTPD_CONF_DIR_D="${HTTPD_DIR}/conf.d"
-export IPXE_CONF_DIR="${CUSTOM_CONFIG_DIR}/ipxe"
 export IRONIC_CONF_DIR="${CUSTOM_CONFIG_DIR}/ironic"
 export IRONIC_DB_DIR="${CUSTOM_DATA_DIR}/db"
 export IRONIC_GEN_CERT_DIR="${CUSTOM_DATA_DIR}/auto_gen_certs"
@@ -26,8 +25,8 @@ export PROBE_CONF_DIR="${CUSTOM_CONFIG_DIR}/probes"
 
 mkdir -p "${IRONIC_CONF_DIR}" "${PROBE_CONF_DIR}" "${HTTPD_CONF_DIR}" \
     "${HTTPD_CONF_DIR_D}" "${DNSMASQ_CONF_DIR}" "${DNSMASQ_TEMP_DIR}" \
-    "${IRONIC_DB_DIR}" "${IRONIC_GEN_CERT_DIR}" "${IPXE_CONF_DIR}" \
-    "${DNSMASQ_DATA_DIR}" "${IRONIC_TMP_DATA_DIR}"
+    "${IRONIC_DB_DIR}" "${IRONIC_GEN_CERT_DIR}" "${DNSMASQ_DATA_DIR}" \
+    "${IRONIC_TMP_DATA_DIR}"
 
 export HTPASSWD_FILE="${IRONIC_CONF_DIR}/htpasswd"
 export LOCAL_DB_URI="sqlite:///${IRONIC_DB_DIR}/ironic.sqlite"

--- a/scripts/rundatabase-upgrade
+++ b/scripts/rundatabase-upgrade
@@ -7,4 +7,4 @@ set -euxo pipefail
 
 # NOTE(dtantsur): no retries here: this script is supposed to be run as a Job
 # that is retried on failure.
-exec ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
+exec ironic-dbsync --config-file "${IRONIC_CONF_DIR}/ironic.conf" upgrade

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -80,5 +80,4 @@ configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" httpd "${IRONIC_CE
 # Set up inotify to kill the container (restart) whenever cert of httpd for /shared/html/<redifsh;ilo> path change
 configure_restart_on_certificate_update "${IRONIC_VMEDIA_TLS_SETUP}" httpd "${IRONIC_VMEDIA_CERT_FILE}"
 
-exec /usr/sbin/httpd -DFOREGROUND \
-     -f "${HTTPD_CONF_DIR}/httpd.conf"
+exec /usr/sbin/httpd -DFOREGROUND -f "${HTTPD_CONF_DIR}/httpd.conf"

--- a/scripts/runonline-data-migrations
+++ b/scripts/runonline-data-migrations
@@ -7,4 +7,4 @@ set -euxo pipefail
 
 # NOTE(dtantsur): no retries here: this script is supposed to be run as a Job
 # that is retried on failure.
-exec ironic-dbsync --config-file /etc/ironic/ironic.conf online_data_migrations
+exec ironic-dbsync --config-file "${IRONIC_CONF_DIR}/ironic.conf" online_data_migrations


### PR DESCRIPTION
This PR:
 - Removes unused IPXE_CONF_DIR variable
 - Removes unjustified line break
 - Configures the ironic temp_dir to use env var instead of hard coded value
 - Make the recently added online data migration feature compatible with custom config paths
 - Make the recently added rundatabase-upgrade compatible with custom config paths
 
 This PR is a followup to https://github.com/metal3-io/ironic-image/pull/634 and https://github.com/metal3-io/ironic-image/pull/623 with the aim to harmonize the the new feature sets and fix a few nits.