### PR TITLE
:seedling: group all dependabot github action updates into one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     interval: "monthly"
     day: "friday"
   target-branch: main
+  ## group all action bumps into single PR
+  groups:
+    all-github-actions:
+      patterns: ["*"]
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
Group all dependabot github action updates into one PR.

I forgot to do this change for ironic-image, when applied it to all repos we have.
