### PR TITLE
🐛 Do not use /tmp as a source directory for the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,10 @@ ARG SUSHY_SOURCE
 COPY sources /sources/
 COPY ${UPPER_CONSTRAINTS_FILE} ironic-packages-list ${PKGS_LIST} \
      ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} \
-     ironic-config/inspector.ipxe.j2 ironic-config/httpd-ironic-api.conf.j2 \
+     /tmp/
+COPY ironic-config/inspector.ipxe.j2 ironic-config/httpd-ironic-api.conf.j2 \
      ironic-config/ipxe_config.template ironic-config/dnsmasq.conf.j2 \
-    /tmp/
+     /templates/
 COPY prepare-image.sh patch-image.sh configure-nonroot.sh /bin/
 COPY scripts/ /bin/
 
@@ -47,15 +48,15 @@ RUN prepare-image.sh && rm -f /bin/prepare-image.sh
 
 # IRONIC #
 COPY --from=ironic-builder /tmp/ipxe/src/bin/undionly.kpxe /tmp/ipxe/src/bin-x86_64-efi/snponly.efi /tftpboot/
-COPY --from=ironic-builder /tmp/esp.img /tmp/uefi_esp.img
+COPY --from=ironic-builder /tmp/esp.img /templates/uefi_esp.img
 
 COPY ironic-config/ironic.conf.j2 /etc/ironic/
 
 # Custom httpd config, removes all but the bare minimum needed modules
 COPY ironic-config/httpd.conf.j2 /etc/httpd/conf/
 COPY ironic-config/httpd-modules.conf /etc/httpd/conf.modules.d/
-COPY ironic-config/apache2-vmedia.conf.j2 /tmp/httpd-vmedia.conf.j2
-COPY ironic-config/apache2-ipxe.conf.j2 /tmp/httpd-ipxe.conf.j2
+COPY ironic-config/apache2-vmedia.conf.j2 /templates/httpd-vmedia.conf.j2
+COPY ironic-config/apache2-ipxe.conf.j2 /templates/httpd-ipxe.conf.j2
 
 # DATABASE
 RUN mkdir -p /var/lib/ironic && \

--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ The following can serve as an example:
    callback from the ramdisk doing the cleaning
 - `OS_PXE__BOOT_RETRY_TIMEOUT=1200` - timeout (seconds) to enable boot retries.
 
+## Using a read-only root filesystem
+
+The ironic-image can operate with a read-only root filesystem. However,
+it needs a few directories to be mounted as writable `emptyDir` volumes:
+
+- `/conf` - location for rendered configuration files
+- `/data` - writable runtime data such as the database
+- `/tmp` - temporary directory
+
+This is in addition to the always required `/shared` volume that is used to
+share runtime data between Ironic and HTTPD.
+
 ## Custom source for ironic software
 
 When building the ironic image, it is also possible to specify a

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -64,7 +64,7 @@ AddDefaultCharset UTF-8
     MIMEMagicFile conf/magic
 </IfModule>
 
-PidFile /var/tmp/httpd.pid
+PidFile {{ env.IRONIC_TMP_DATA_DIR }}/httpd.pid
 
 # EnableSendfile directive could speed up deployments but it could also cause
 # issues depending on the underlying file system, to learn more:

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -27,7 +27,6 @@ use_stderr = true
 hash_ring_algorithm = sha256
 my_ip = {{ env.IRONIC_IP }}
 host = {{ env.IRONIC_CONDUCTOR_HOST }}
-tempdir = {{ env.IRONIC_TMP_DATA_DIR }}
 
 # If a path to a certificate is defined, use that first for webserver
 {% if env.WEBSERVER_CACERT_FILE %}
@@ -211,7 +210,7 @@ enable_netboot_fallback = true
 # Enable the fallback path to in-band inspection
 ipxe_fallback_script = inspector.ipxe
 {% if env.IPXE_TLS_SETUP | lower == "true" %}
-ipxe_config_template = /tmp/ipxe_config.template
+ipxe_config_template = /templates/ipxe_config.template
 {% endif %}
 
 [redfish]

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -36,7 +36,7 @@ fi
 # Template and write dnsmasq.conf
 # we template via /tmp as sed otherwise creates temp files in /etc directory
 # where we can't write
-python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' <"/tmp/dnsmasq.conf.j2" >"${DNSMASQ_TEMP_DIR}/dnsmasq_temp.conf"
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' <"/templates/dnsmasq.conf.j2" >"${DNSMASQ_TEMP_DIR}/dnsmasq_temp.conf"
 
 for iface in $(echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=${iface}" "${DNSMASQ_TEMP_DIR}/dnsmasq_temp.conf"

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -36,8 +36,8 @@ fi
 export INSPECTOR_EXTRA_ARGS
 
 # Copy files to shared mount
-render_j2_config /tmp/inspector.ipxe.j2 /shared/html/inspector.ipxe
-cp /tmp/uefi_esp.img /shared/html/uefi_esp.img
+render_j2_config /templates/inspector.ipxe.j2 /shared/html/inspector.ipxe
+cp /templates/uefi_esp.img /shared/html/uefi_esp.img
 # cp -r /etc/httpd/* "${HTTPD_DIR}"
 if [[ -f "${HTTPD_CONF_DIR}/httpd.conf" ]]; then
     mv "${HTTPD_CONF_DIR}/httpd.conf" "${HTTPD_CONF_DIR}/httpd.conf.example"
@@ -49,7 +49,7 @@ render_j2_config "/etc/httpd/conf/httpd.conf.j2" \
 
 if [[ "$IRONIC_TLS_SETUP" == "true" ]]; then
     if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "true" ]]; then
-        render_j2_config "/tmp/httpd-ironic-api.conf.j2" \
+        render_j2_config "/templates/httpd-ironic-api.conf.j2" \
             "${HTTPD_CONF_DIR_D}/ironic.conf"
     fi
 else
@@ -60,7 +60,7 @@ write_htpasswd_files
 
 # Render httpd TLS configuration for /shared/html/<redifsh;ilo>
 if [[ "$IRONIC_VMEDIA_TLS_SETUP" == "true" ]]; then
-    render_j2_config "/tmp/httpd-vmedia.conf.j2" \
+    render_j2_config "/templates/httpd-vmedia.conf.j2" \
         "${HTTPD_CONF_DIR_D}/vmedia.conf"
 fi
 
@@ -68,7 +68,7 @@ fi
 if [[ "$IPXE_TLS_SETUP" == "true" ]]; then
     mkdir -p /shared/html/custom-ipxe
     chmod 0777 /shared/html/custom-ipxe
-    render_j2_config "/tmp/httpd-ipxe.conf.j2" "${HTTPD_CONF_DIR_D}/ipxe.conf"
+    render_j2_config "/templates/httpd-ipxe.conf.j2" "${HTTPD_CONF_DIR_D}/ipxe.conf"
     cp "${IPXE_CUSTOM_FIRMWARE_DIR}/undionly.kpxe" \
        "${IPXE_CUSTOM_FIRMWARE_DIR}/snponly.efi" \
        "/shared/html/custom-ipxe"


### PR DESCRIPTION
Unfortunately, a lot of code in Ironic ignores the tempdir
configuration. Even worse, the default value for this option relies on
having a writable /tmp, which makes the current approach not functional
without mounting an emptyDir to /tmp. But if an emptyDir is mounted to
/tmp, we lose access to all the template files stored there.

This change uses a new directory /templates as a source for files that
needs copying/templating in runtime.

Also fix usage of /var/tmp in httpd.conf.

Document the requirements.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
