### PR TITLE
🌱 Use bootloader through a local file link

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -81,7 +81,7 @@ send_sensor_data = {{ env.SEND_SENSOR_DATA }}
 # Power state is checked every 60 seconds and BMC activity should
 # be avoided more often than once every sixty seconds.
 send_sensor_data_interval = 160
-bootloader = {{ env.IRONIC_HTTP_URL }}/uefi_esp.img
+bootloader = file:///templates/uefi_esp.img
 verify_step_priority_override = management.clear_job_queue:90
 # We don't use this feature, and it creates an additional load on the database
 node_history = False

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -37,7 +37,6 @@ export INSPECTOR_EXTRA_ARGS
 
 # Copy files to shared mount
 render_j2_config /templates/inspector.ipxe.j2 /shared/html/inspector.ipxe
-cp /templates/uefi_esp.img /shared/html/uefi_esp.img
 # cp -r /etc/httpd/* "${HTTPD_DIR}"
 if [[ -f "${HTTPD_CONF_DIR}/httpd.conf" ]]; then
     mv "${HTTPD_CONF_DIR}/httpd.conf" "${HTTPD_CONF_DIR}/httpd.conf.example"


### PR DESCRIPTION
There is no need to go through the HTTP server for it: it is only used
locally by Ironic itself.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
