### PR TITLE
🌱 Use a multi-node cluster in functional tests 

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -32,6 +32,8 @@ jobs:
         go-version: ${{ steps.vars.outputs.go_version }}
     - name: Setup a minikube cluster
       uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # v0.0.19
+      with:
+        start-args: "--ha"
     - name: Prepare tests
       run: cd ironic-standalone-operator && ./test/prepare.sh
     - name: Run tests

--- a/hack/ci-e2e.sh
+++ b/hack/ci-e2e.sh
@@ -31,4 +31,4 @@ cd "${IRSO_PATH}/test"
 . testing.env
 export IRONIC_CUSTOM_VERSION=latest
 
-exec go test -timeout 60m
+exec go test -timeout 90m


### PR DESCRIPTION
This change largely mirrors the changes to IrSO CI.

Go back to using `minikube image load` with a tarball.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
