### PR TITLE
WIP :sparkles: support default BMC verify ca

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -216,13 +216,27 @@ ipxe_config_template = /templates/ipxe_config.template
 [redfish]
 use_swift = false
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console=yes
+{% if env.BMC_TLS_ENABLED == "true" %}
+verify_ca = /tmp/bmc-tls.pem
+{% endif %}
 
 [ilo]
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console=yes
 use_web_server_for_images = true
+{% if env.BMC_TLS_ENABLED == "true" %}
+verify_ca = /tmp/bmc-tls.pem
+{% endif %}
 
 [irmc]
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console=yes
+{% if env.BMC_TLS_ENABLED == "true" %}
+verify_ca = /tmp/bmc-tls.pem
+{% endif %}
+
+[drac]
+{% if env.BMC_TLS_ENABLED == "true" %}
+verify_ca = /tmp/bmc-tls.pem
+{% endif %}
 
 [service_catalog]
 endpoint_override = {{ env.IRONIC_BASE_URL }}

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -15,4 +15,11 @@ configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" ironic "${IRONIC_C
 
 configure_ironic_auth
 
+if [[ -d "$BMC_CACERT_PATH" ]]; then
+    # shellcheck disable=SC2034
+    inotifywait -m -e create,modify,delete "${BMC_CACERT_PATH}" | while read -r file event; do
+        cat "$BMC_CACERT_PATH"/* > /tmp/bmc-tls.pem
+    done &
+fi
+
 exec /usr/bin/ironic --config-dir "${IRONIC_CONF_DIR}"

--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -17,6 +17,7 @@ export IPXE_KEY_FILE=/certs/ipxe/tls.key
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 
 export MARIADB_CACERT_FILE=/certs/ca/mariadb/tls.crt
+export BMC_CACERT_PATH=/certs/ca/bmc
 
 export IPXE_TLS_PORT="${IPXE_TLS_PORT:-8084}"
 
@@ -109,3 +110,10 @@ configure_restart_on_certificate_update()
             done &
     fi
 }
+
+if [ -d "$BMC_CACERT_PATH" ]; then
+    export BMC_TLS_ENABLED="true"
+    cat "$BMC_CACERT_PATH"/* > /tmp/bmc-tls.pem
+else
+    export BMC_TLS_ENABLED="false"
+fi


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Add support for default verify ca, to implement the [bmc-ca-certificate-support](https://github.com/openshift/enhancements/blob/995b620cb04c030bf62c908e188472fe7031a704/enhancements/security/bmc-ca-certificate-support.md?plain=1#L94-L96) proposal.

This PR needs to wait for the implementation of [add-default-verify-ca](https://opendev.org/openstack/ironic-specs/src/branch/master/specs/approved/add-default-verify-ca.rst) on the Ironic.
The following is the implementation on the Ironic (currently in the WIP stage):
- https://review.opendev.org/c/openstack/ironic/+/947544/3
- https://review.opendev.org/c/openstack/ironic/+/947545/3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
