### PR TITLE
🐛 Extract files one-by-one in logwatch

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -12,6 +12,10 @@ python3 -m pyinotify --raw-format -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
         # <Event dir=False mask=0x8 maskname=IN_CLOSE_WRITE name=mylogs.gzip path=/shared/log/ironic/deploy pathname=/shared/log/ironic/deploy/mylogs.gzip wd=1 >
         FILENAME=$(echo "${filename}" | cut -d'=' -f2-)
         echo "************ Contents of ${LOG_DIR}/${FILENAME} ramdisk log file bundle **************"
-        tar -xOzvvf "${LOG_DIR}/${FILENAME}" | sed -e "s/^/${FILENAME}: /"
+        tar -tzf "${LOG_DIR}/${FILENAME}" | while read -r entry; do
+            echo "${FILENAME}: **** Entry: ${entry} ****"
+            tar -xOzf "${LOG_DIR}/${FILENAME}" "${entry}" | sed -e "s/^/${FILENAME}: /"
+            echo
+        done
         rm -f "${LOG_DIR}/${FILENAME}"
     done


### PR DESCRIPTION
Currently, the file listing is sent to stderr, while files themselves
are sent to stdout. Then the two streams are merged in the resulting
CI report. However, they are not guaranteed to be 100% synchronized,
which results in file names appearing in the middle of log lines.
They are also neither human- nor machine-friendly.

Here I'm switching from extracting all files using -Ov to listing files
first and extracting them one by one.

I'm also adding extra new lines before each file to make the output more
readable.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
