### PR TITLE
🐛 OSSA-2025-001: set file_url_allowed_paths to what Metal3 uses

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -96,6 +96,9 @@ deploy_ramdisk = file://{{ env.IRONIC_DEFAULT_RAMDISK }}
 {% if env.DISABLE_DEEP_IMAGE_INSPECTION | lower == "true" %}
 disable_deep_image_inspection = True
 {% endif %}
+# Allowed path for file:// links: ipa-downloader uses /shared/html/images,
+# while the bootloader configuration above refers to /templates.
+file_url_allowed_paths = /shared/html/images,/templates
 
 [database]
 {% if env.IRONIC_USE_MARIADB | lower == "true" %}


### PR DESCRIPTION
The fix for OSSA-2025-001 introduces a new option that limits which
paths are allowed for file:// URLs. The default value already contains
the paths that Metal3 uses, but it will change in the future.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
