### PR TITLE
:warning: Use Python 3.12 for resources images

### DIFF
--- a/resources/ironic-client/Dockerfile
+++ b/resources/ironic-client/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=docker.io/library/python:3.9-slim-bookworm
+ARG BASE_IMAGE=docker.io/library/python:3.12-slim-bookworm
 
 FROM $BASE_IMAGE
 

--- a/resources/sushy-tools/Dockerfile
+++ b/resources/sushy-tools/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=docker.io/library/python:3.9.18-slim-bookworm
+ARG BASE_IMAGE=docker.io/library/python:3.12-slim-bookworm
 
 FROM $BASE_IMAGE
 

--- a/resources/vbmc/Dockerfile
+++ b/resources/vbmc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=docker.io/library/python:3.9.18-slim-bookworm
+ARG BASE_IMAGE=docker.io/library/python:3.12-slim-bookworm
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
Moving ironicclient, sushy-tools and vbmc to Python 3.12

