### PR TITLE
:warning: Do not install separate sushy-oem-idrac

### DIFF
--- a/ironic-packages-list
+++ b/ironic-packages-list
@@ -22,4 +22,3 @@ sushy @ git+https://opendev.org/openstack/sushy@{{ env.SUSHY_SOURCE }}
 {% else %}
 sushy
 {% endif %}
-sushy-oem-idrac


### PR DESCRIPTION
The sushy-oem-idrac code is now included in sushy
