### PR TITLE
Improve httpd TLS configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ COPY ironic-config/httpd.conf.j2 /etc/httpd/conf/
 COPY ironic-config/httpd-modules.conf /etc/httpd/conf.modules.d/
 COPY ironic-config/apache2-vmedia.conf.j2 /templates/httpd-vmedia.conf.j2
 COPY ironic-config/apache2-ipxe.conf.j2 /templates/httpd-ipxe.conf.j2
+COPY ironic-config/apache2-image.conf.j2 /templates/httpd-image.conf.j2
 
 # DATABASE
 RUN mkdir -p /var/lib/ironic && \

--- a/ironic-config/apache2-image.conf.j2
+++ b/ironic-config/apache2-image.conf.j2
@@ -1,0 +1,25 @@
+Listen {{ env.HTTPD_TLS_PORT }}
+
+<VirtualHost *:{{ env.HTTPD_TLS_PORT }}>
+    ErrorLog /dev/stderr
+    LogLevel debug
+    CustomLog /dev/stdout combined
+
+    SSLEngine on
+    SSLProtocol {{ env.HTTPD_SSL_PROTOCOL }}
+    SSLCertificateFile {{ env.HTTPD_CERT_FILE }}
+    SSLCertificateKeyFile {{ env.HTTPD_KEY_FILE }}
+
+    <Directory "/shared/html">
+        Require all denied
+    </Directory>
+    <Directory "/shared/html/images">
+        Require all granted
+    </Directory>
+
+    <Location ~ "^/.*">
+        SSLRequireSSL
+    </Location>
+
+</VirtualHost>
+

--- a/ironic-config/apache2-ipxe.conf.j2
+++ b/ironic-config/apache2-ipxe.conf.j2
@@ -10,26 +10,17 @@ Listen {{ env.IPXE_TLS_PORT }}
     SSLCertificateFile {{ env.IPXE_CERT_FILE }}
     SSLCertificateKeyFile {{ env.IPXE_KEY_FILE }}
 
+    DocumentRoot "/shared/html"
     <Directory "/shared/html">
-        Order Allow,Deny
-        Allow from all
+        Options Indexes FollowSymLinks
+        Require all granted
     </Directory>
-    <Directory "/shared/html/(redfish|ilo|images)/">
-        Order Deny,Allow
-        Deny from all
+    <Directory ~ "/shared/html/(redfish|ilo|images)/">
+        Require all denied
     </Directory>
+
+    <Location ~ "^/.*">
+        SSLRequireSSL
+    </Location>
+
 </VirtualHost>
-
-<Location ~ "^/grub.*/">
-    SSLRequireSSL
-</Location>
-<Location ~ "^/pxelinux.cfg/">
-    SSLRequireSSL
-</Location>
-<Location ~ "^/.*\.conf/">
-    SSLRequireSSL
-</Location>
-<Location ~ "^/(([0-9]|[a-z]).*-){4}([0-9]|[a-z]).*/">
-    SSLRequireSSL
-</Location>
-

--- a/ironic-config/apache2-vmedia.conf.j2
+++ b/ironic-config/apache2-vmedia.conf.j2
@@ -11,15 +11,17 @@ Listen {{ env.VMEDIA_TLS_PORT }}
     SSLCertificateKeyFile {{ env.IRONIC_VMEDIA_KEY_FILE }}
 
     <Directory ~ "/shared/html">
-         Order deny,allow
-         deny from all
+        Order deny,allow
+        deny from all
     </Directory>
     <Directory ~ "/shared/html/(redfish|ilo)/">
-         Order allow,deny
-         allow from all
+        Order allow,deny
+        allow from all
     </Directory>
+
+    <Location ~ "^/.*">
+        SSLRequireSSL
+    </Location>
+
 </VirtualHost>
 
-<Location ~ "^/(redfish|ilo)/">
-    SSLRequireSSL
-</Location>

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -29,28 +29,15 @@ dhcp-option=option{% if ":" in env["DNS_IP"] %}6{% endif %}:dns-server,{{ env["D
 {%- if env.IPV == "4" or env.IPV is undefined %}
 # IPv4 Configuration:
 dhcp-match=ipxe,175
-# Client is already running iPXE; move to next stage of chainloading
-{%- if env.IPXE_TLS_SETUP == "true"  %}
-# iPXE with (U)EFI
-dhcp-boot=tag:efi,tag:ipxe,{{ env.IRONIC_HTTP_URL }}/custom-ipxe/snponly.efi
-# iPXE with BIOS
-dhcp-boot=tag:ipxe,{{ env.IRONIC_HTTP_URL }}/custom-ipxe/undionly.kpxe
-{% else %}
-dhcp-boot=tag:ipxe,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
-{% endif %}
 
 # Note: Need to test EFI booting
 dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9
 dhcp-match=set:efi,option:client-arch,11
-# Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader do the same also if iPXE ROM boots but TLS is enabled
-{%- if env.IPXE_TLS_SETUP == "true"  %}
-dhcp-boot=tag:efi,tag:ipxe,snponly.efi
-{% endif %}
-dhcp-boot=tag:efi,tag:!ipxe,snponly.efi
-
-# Client is running PXE over BIOS; send BIOS version of iPXE chainloader
-dhcp-boot=/undionly.kpxe,{{ env.IRONIC_IP }}
+# Client is (i)PXE booting on EFI machine
+dhcp-boot=tag:efi,/snponly.efi,{{ env.IRONIC_IP }}
+# Client is running (i)PXE on BIOS machine
+dhcp-boot=tag:!efi,/undionly.kpxe,{{ env.IRONIC_IP }}
 {% endif %}
 
 {% if env.IPV == "6" %}
@@ -60,8 +47,10 @@ ra-param={{ env.PROVISIONING_INTERFACE }},0,0
 
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE
-dhcp-option=tag:pxe6,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/snponly.efi
-dhcp-option=tag:ipxe6,option6:bootfile-url,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
+# Client is (i)PXE booting on EFI machine
+dhcp-option=tag:efi,option6:bootfile-url,{{ env.IRONIC_URL_HOST }}/snponly.efi
+# Client is running (i)PXE on BIOS machine
+dhcp-option=tag:!efi,option6:bootfile-url,{{ env.IRONIC_URL_HOST }}/undionly.kpxe
 
 # It can be used when setting DNS or GW variables.
 {%- if env["GATEWAY_IP"] is undefined %}

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -8,6 +8,13 @@ Include /etc/httpd/conf.modules.d/*.conf
 User apache
 Group apache
 
+{% if env.HTTPD_TLS_SETUP == "true" %}
+SSLEngine on
+SSLProtocol {{ env.HTTPD_SSL_PROTOCOL }}
+SSLCertificateFile {{ env.HTTPD_CERT_FILE }}
+SSLCertificateKeyFile {{ env.HTTPD_KEY_FILE }}
+{% endif %}
+
 <Directory />
     AllowOverride none
     Require all denied
@@ -16,18 +23,34 @@ Group apache
 DocumentRoot "/shared/html"
 
 <Directory "/shared/html">
+{%- if env.IPXE_TLS_SETUP | lower == "true" %}
     Options Indexes FollowSymLinks
-    AllowOverride None
+    Require all denied
+{%- else %}
+    Options Indexes FollowSymLinks
     Require all granted
+{%- endif %}
 </Directory>
 
-{%- if env.HTTPD_SERVE_NODE_IMAGES | lower == "true" %}
+<Directory ~ "/shared/html/(redfish|ilo)/">
+{%- if env.IRONIC_VMEDIA_TLS_SETUP | lower == "true" %}
+    Require all denied
+{%- else %}
+    Require all granted
+{%- endif %}
+</Directory>
+
 <Directory "/shared/html/images">
     Options Indexes FollowSymLinks
     AllowOverride None
+{%- set serve_img = env.HTTPD_SERVE_NODE_IMAGES | lower %}
+{%- set httpd_tls = env.HTTPD_TLS_SETUP | lower %}
+{%- if serve_img == "true" and httpd_tls != "true" %}
     Require all granted
+{%- else %}
+    Require all denied
+{%- endif %}
 </Directory>
-{% endif %}
 
 <IfModule dir_module>
     DirectoryIndex index.html

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -101,7 +101,11 @@ wait_for_interface_or_ip()
     # Avoid having to construct full URL multiple times while allowing
     # the override of IRONIC_HTTP_URL for environments in which IRONIC_IP
     # is unreachable from hosts being provisioned.
-    export IRONIC_HTTP_URL="${IRONIC_HTTP_URL:-http://${IRONIC_URL_HOST}:${HTTP_PORT}}"
+    if [[ "${HTTPD_TLS_SETUP}" = "true" ]]; then
+        export IRONIC_HTTP_URL="${IRONIC_HTTP_URL:-https://${IRONIC_URL_HOST}:${HTTPD_TLS_PORT}}"
+    else
+        export IRONIC_HTTP_URL="${IRONIC_HTTP_URL:-http://${IRONIC_URL_HOST}:${HTTP_PORT}}"
+    fi
     export IRONIC_TFTP_URL="${IRONIC_TFTP_URL:-tftp://${IRONIC_URL_HOST}}"
     export IRONIC_BASE_URL=${IRONIC_BASE_URL:-"${IRONIC_SCHEME}://${IRONIC_URL_HOST}:${IRONIC_ACCESS_PORT}"}
 }

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -63,6 +63,12 @@ if [[ "$IRONIC_VMEDIA_TLS_SETUP" == "true" ]]; then
         "${HTTPD_CONF_DIR_D}/vmedia.conf"
 fi
 
+# Render httpd TLS configuration for /shared/html/images
+if [[ "${HTTPD_TLS_SETUP}" == "true" ]]; then
+    render_j2_config "/templates/httpd-image.conf.j2" \
+        "${HTTPD_CONF_DIR_D}/image.conf"
+fi
+
 # Render httpd TLS configuration for /shared/html
 if [[ "$IPXE_TLS_SETUP" == "true" ]]; then
     mkdir -p /shared/html/custom-ipxe

--- a/scripts/runironic-exporter
+++ b/scripts/runironic-exporter
@@ -2,8 +2,6 @@
 
 # shellcheck disable=SC1091
 . /bin/configure-ironic.sh
-# shellcheck disable=SC1091
-. /bin/ironic-common.sh
 
 FLASK_RUN_HOST=${FLASK_RUN_HOST:-0.0.0.0}
 FLASK_RUN_PORT=${FLASK_RUN_PORT:-9608}

--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -2,14 +2,17 @@
 
 export IRONIC_CERT_FILE=/certs/ironic/tls.crt
 export IRONIC_KEY_FILE=/certs/ironic/tls.key
-export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
 export IRONIC_INSECURE=${IRONIC_INSECURE:-false}
 export IRONIC_SSL_PROTOCOL=${IRONIC_SSL_PROTOCOL:-"-ALL +TLSv1.2 +TLSv1.3"}
 export IPXE_SSL_PROTOCOL=${IPXE_SSL_PROTOCOL:-"-ALL +TLSv1.2 +TLSv1.3"}
+export HTTPD_SSL_PROTOCOL=${HTTPD_SSL_PROTOCOL:-"-ALL +TLSv1.2 +TLSv1.3"}
 export IRONIC_VMEDIA_SSL_PROTOCOL=${IRONIC_VMEDIA_SSL_PROTOCOL:-"ALL"}
 
 export IRONIC_VMEDIA_CERT_FILE=/certs/vmedia/tls.crt
 export IRONIC_VMEDIA_KEY_FILE=/certs/vmedia/tls.key
+
+export HTTPD_CERT_FILE=/certs/httpd/tls.crt
+export HTTPD_KEY_FILE=/certs/httpd/tls.key
 
 export IPXE_CERT_FILE=/certs/ipxe/tls.crt
 export IPXE_KEY_FILE=/certs/ipxe/tls.key
@@ -17,8 +20,11 @@ export IPXE_KEY_FILE=/certs/ipxe/tls.key
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 
 export MARIADB_CACERT_FILE=/certs/ca/mariadb/tls.crt
+export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
+export HTTPD_CACERT_FILE=/certs/ca/httpd/tls.crt
 
 export IPXE_TLS_PORT="${IPXE_TLS_PORT:-8084}"
+export HTTPD_TLS_PORT="${HTTPD_TLS_PORT:-8085}"
 
 if [[ -f "$IRONIC_CERT_FILE" ]] && [[ ! -f "$IRONIC_KEY_FILE" ]]; then
     echo "Missing TLS Certificate key file $IRONIC_KEY_FILE"
@@ -44,6 +50,15 @@ if [[ -f "$IPXE_CERT_FILE" ]] && [[ ! -f "$IPXE_KEY_FILE" ]]; then
 fi
 if [[ ! -f "$IPXE_CERT_FILE" ]] && [[ -f "$IPXE_KEY_FILE" ]]; then
     echo "Missing TLS Certificate file $IPXE_CERT_FILE"
+    exit 1
+fi
+
+if [[ -f "$HTTPD_CERT_FILE" ]] && [[ ! -f "$HTTPD_KEY_FILE" ]]; then
+    echo "Missing TLS Certificate key file $HTTPD_KEY_FILE"
+    exit 1
+fi
+if [[ ! -f "$HTTPD_CERT_FILE" ]] && [[ -f "$HTTPD_KEY_FILE" ]]; then
+    echo "Missing TLS Certificate file $HTTPD_CERT_FILE"
     exit 1
 fi
 
@@ -90,6 +105,13 @@ if [[ -f "$MARIADB_CACERT_FILE" ]]; then
     export MARIADB_TLS_ENABLED="true"
 else
     export MARIADB_TLS_ENABLED="false"
+fi
+
+if [[ -f "${HTTPD_CACERT_FILE}" ]]; then
+    export HTTPD_TLS_SETUP="true"
+    export WEBSERVER_CACERT_FILE="/certs/ca/httpd/tls.crt"
+else
+    export HTTPD_TLS_SETUP="false"
 fi
 
 configure_restart_on_certificate_update()


### PR DESCRIPTION
This commit:

- Introduces a separate port for TLS enabled HTTPD server used for image hosting
- Introduces the management of TLS resources (cert, key) for the new port
- Makes sure that if iPXE, virtual media or httpd image server is using TLS the related resources are only available via the TLS enabled port.
- Removes plain http support from the dnsmasq ipxe config, only FTP addresses are advertised for both ipxe and pxe clients for the purpose of chainloading the ipxe firmware.
- Simplifies and unifies the way the TLS requirement is specified for URL paths.
- Makes the apache access control use the newer syntax for all the artifact hosting configs (ipxe, vmdedia, images, httpd default config)

Main motivation was that even when ipxe was configured to use TLS the ipxe artifacts were available via http on the 6180 port.

