### PR TITLE
:sparkles: add new release automation and documentation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,127 @@
+# This code is borrowed from https://github.com/kubernetes-sigs/cluster-api/blob/main/.github/workflows/release.yaml
+name: Create Release
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'releasenotes/*.md'
+
+permissions: {}
+
+jobs:
+  push_release_tags:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release-version.outputs.release_version }}
+    if: github.repository == 'metal3-io/ironic-image'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+    - name: Get release version
+      id: release-version
+      run: |
+        if [[ ${{ steps.changed-files.outputs.all_changed_files_count }} != 1 ]]; then
+          echo "1 release notes file should be changed to create a release tag, found ${{ steps.changed-files.outputs.all_changed_files_count }}"
+          exit 1
+        fi
+        for changed_file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          export RELEASE_VERSION=$(echo "${changed_file}" | grep -oP '(?<=/)[^/]+(?=\.md)')
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_ENV}
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_OUTPUT}
+          if [[ "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Valid semver: ${RELEASE_VERSION}"
+          else
+            echo "Invalid semver: ${RELEASE_VERSION}"
+            exit 1
+          fi
+        done
+    - name: Determine the release branch to use
+      run: |
+        if [[ ${RELEASE_VERSION} =~ beta ]] || [[ ${RELEASE_VERSION} =~ alpha ]]; then
+          export RELEASE_BRANCH=main
+          echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> ${GITHUB_ENV}
+          echo "This is a beta or alpha release, will use release branch ${RELEASE_BRANCH}"
+        else
+          export RELEASE_BRANCH=release-$(echo ${RELEASE_VERSION} | sed -E 's/^v([0-9]+)\.([0-9]+)\..*$/\1.\2/')
+          echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> ${GITHUB_ENV}
+          echo "This is not a beta or alpha release, will use release branch ${RELEASE_BRANCH}"
+        fi
+    - name: Create or checkout release branch
+      run: |
+        if git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+          echo "Branch ${RELEASE_BRANCH} already exists"
+          git checkout "${RELEASE_BRANCH}"
+        else
+          git checkout -b "${RELEASE_BRANCH}"
+          git push origin "${RELEASE_BRANCH}"
+          echo "Created branch ${RELEASE_BRANCH}"
+        fi
+    - name: Validate tag does not already exist
+      run: |
+        if [[ -n "$(git tag -l "${RELEASE_VERSION}")" ]]; then
+          echo "Tag ${RELEASE_VERSION} already exists, exiting"
+          exit 1
+        fi
+    - name: Create Release Tag
+      run: |
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git tag -a ${RELEASE_VERSION} -m ${RELEASE_VERSION}
+        git push origin ${RELEASE_VERSION}
+        echo "Created tag ${RELEASE_VERSION}"
+  release:
+    name: create draft release
+    runs-on: ubuntu-latest
+    needs: push_release_tags
+    permissions:
+      contents: write
+    steps:
+    - name: Set env
+      run: echo "RELEASE_TAG=${RELEASE_TAG}" >> ${GITHUB_ENV}
+      env:
+        RELEASE_TAG: ${{needs.push_release_tags.outputs.release_tag}}
+    - name: checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.RELEASE_TAG }}
+    - name: Calculate go version
+      run: echo "go_version=$(make go-version)" >> ${GITHUB_ENV}
+    - name: Set up Go
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        go-version: ${{ env.go_version }}
+    - name: get release notes
+      run: |
+        curl -L "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${{ env.RELEASE_TAG }}.md" \
+        -o "${{ env.RELEASE_TAG }}.md"
+    - name: Release
+      uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+      with:
+        draft: true
+        body_path: ${{ env.RELEASE_TAG }}.md
+        tag_name: ${{ env.RELEASE_TAG }}
+  build_ironic_image:
+    permissions:
+      contents: read
+    needs: push_release_tags
+    name: Build Ironic-image container image
+    if: github.repository == 'metal3-io/ironic-image'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: 'ironic-image'
+      pushImage: true
+      ref: ${{ needs.push_release_tags.outputs.release_tag }}
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,23 @@ help:
 build:
 	$(CONTAINER_ENGINE) build . -f Dockerfile
 
+## --------------------------------------
+## Release
+## --------------------------------------
+GO := $(shell type -P go)
+# Use GOPROXY environment variable if set
+GOPROXY := $(shell $(GO) env GOPROXY)
+ifeq ($(GOPROXY),)
+GOPROXY := https://proxy.golang.org
+endif
+export GOPROXY
+
+RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
+RELEASE_NOTES_DIR := releasenotes
+
+$(RELEASE_NOTES_DIR):
+	mkdir -p $(RELEASE_NOTES_DIR)/
+
+.PHONY: release-notes
+release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
+	cd hack/tools && $(GO) run release/notes.go  --releaseTag=$(RELEASE_TAG) > $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,0 +1,14 @@
+module github.com/metal3-io/ironic-standalone-operator/hack/tools
+
+go 1.23.7
+
+require (
+	github.com/blang/semver v3.5.1+incompatible
+	github.com/google/go-github v17.0.0+incompatible
+	golang.org/x/oauth2 v0.30.0
+)
+
+require (
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+)

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -1,0 +1,12 @@
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -1,0 +1,351 @@
+//go:build tools
+// +build tools
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"errors"
+
+	"github.com/blang/semver"
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+/*
+This tool prints all the titles of all PRs from previous release to HEAD.
+This needs to be run *before* a tag is created.
+
+Use these as the base of your release notes.
+*/
+
+const (
+	features        = ":sparkles: New Features"
+	bugs            = ":bug: Bug Fixes"
+	documentation   = ":book: Documentation"
+	warning         = ":warning: Breaking Changes"
+	other           = ":seedling: Others"
+	unknown         = ":question: Sort these by hand"
+	superseded      = ":recycle: Superseded or Reverted"
+	repoOwner       = "metal3-io"
+	repoName        = "ironic-image"
+	warningTemplate = ":rotating_light: This is a %s. Use it only for testing purposes.\nIf you find any bugs, file an [issue](https://github.com/metal3-io/ironic-image/issues/new/).\n\n"
+)
+
+var (
+	outputOrder = []string{
+		warning,
+		features,
+		bugs,
+		documentation,
+		other,
+		unknown,
+		superseded,
+	}
+	toTag = flag.String("releaseTag", "", "The tag or commit to end to.")
+)
+
+func main() {
+	flag.Parse()
+	os.Exit(run())
+}
+
+// In ironic-image here, we also need to filter out the legacy capm3- tags.
+func latestTag() (string, error) {
+	if toTag != nil && *toTag != "" {
+		if strings.Contains(*toTag, "capm3-") {
+			return "", errors.New("legacy capm3- prefixed RELEASE_TAG set")
+		}
+		return *toTag, nil
+	}
+
+	return "", errors.New("RELEASE_TAG is not set")
+}
+
+// lastTag returns the tag to start collecting commits from based on the latestTag.
+// For pre-releases and minor releases, it returns the latest minor release tag
+// (e.g., for v1.9.0, v1.9.0-beta.0, or v1.9.0-rc.0, it returns v1.8.0).
+// For patch releases, it returns the latest patch release tag (e.g., for v1.9.1 it returns v1.9.0).
+// In this repo, it also needs to handle majors as most of the versions are major bumps
+func lastTag(latestTag string) (string, error) {
+	if isBeta(latestTag) || isRC(latestTag) || isMinor(latestTag) {
+		if index := strings.LastIndex(latestTag, "-"); index != -1 {
+			latestTag = latestTag[:index]
+		}
+		latestTag = strings.TrimPrefix(latestTag, "v")
+
+		semVersion, err := semver.New(latestTag)
+		if err != nil {
+			return "", fmt.Errorf("parsing semver for %s: %w", latestTag, err)
+		}
+		if semVersion.Minor == 0 {
+			semVersion.Major--
+		} else {
+			semVersion.Minor--
+		}
+		lastReleaseTag := fmt.Sprintf("v%s", semVersion.String())
+		return lastReleaseTag, nil
+	}
+
+	latestTag = strings.TrimPrefix(latestTag, "v")
+
+	semVersion, err := semver.New(latestTag)
+	if err != nil {
+		return "", fmt.Errorf("parsing semver for %s: %w", latestTag, err)
+	}
+	semVersion.Patch--
+	lastReleaseTag := fmt.Sprintf("v%s", semVersion.String())
+	return lastReleaseTag, nil
+}
+
+func isBeta(tag string) bool {
+	return strings.Contains(tag, "-beta.")
+}
+
+func isRC(tag string) bool {
+	return strings.Contains(tag, "-rc.")
+}
+
+func isMinor(tag string) bool {
+	return strings.HasSuffix(tag, ".0")
+}
+
+func run() int {
+	latestTag, err := latestTag()
+	if err != nil {
+		log.Fatalf("Failed to get latestTag: %v", err)
+	}
+	lastTag, err := lastTag(latestTag)
+	if err != nil {
+		log.Fatalf("Failed to get lastTag: %v", err)
+	}
+
+	commitHash, err := getCommitHashFromNewTag(latestTag)
+	if err != nil {
+		log.Fatalf("Failed to get commit hash from latestTag %s: %v", latestTag, err)
+	}
+
+	cmd := exec.Command("git", "rev-list", lastTag+".."+commitHash, "--merges", "--pretty=format:%B") // #nosec G204:gosec
+
+	merges := map[string][]string{
+		features:      {},
+		bugs:          {},
+		documentation: {},
+		warning:       {},
+		other:         {},
+		unknown:       {},
+		superseded:    {},
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("Error")
+		fmt.Println(string(out))
+		return 1
+	}
+
+	commits := []*commit{}
+	outLines := strings.Split(string(out), "\n")
+	for _, line := range outLines {
+		line = strings.TrimSpace(line)
+		last := len(commits) - 1
+		switch {
+		case strings.HasPrefix(line, "commit"):
+			commits = append(commits, &commit{})
+		case strings.HasPrefix(line, "Merge"):
+			commits[last].merge = line
+			continue
+		case line == "":
+		default:
+			commits[last].body = line
+		}
+	}
+
+	for _, c := range commits {
+		body := strings.TrimSpace(c.body)
+		var key, prNumber, fork string
+		switch {
+		case strings.HasPrefix(body, ":sparkles:"), strings.HasPrefix(body, "✨"):
+			key = features
+			body = strings.TrimPrefix(body, ":sparkles:")
+			body = strings.TrimPrefix(body, "✨")
+		case strings.HasPrefix(body, ":bug:"), strings.HasPrefix(body, "🐛"):
+			key = bugs
+			body = strings.TrimPrefix(body, ":bug:")
+			body = strings.TrimPrefix(body, "🐛")
+		case strings.HasPrefix(body, ":book:"), strings.HasPrefix(body, "📖"):
+			key = documentation
+			body = strings.TrimPrefix(body, ":book:")
+			body = strings.TrimPrefix(body, "📖")
+		case strings.HasPrefix(body, ":seedling:"), strings.HasPrefix(body, "🌱"):
+			key = other
+			body = strings.TrimPrefix(body, ":seedling:")
+			body = strings.TrimPrefix(body, "🌱")
+		case strings.HasPrefix(body, ":running:"), strings.HasPrefix(body, "🏃"):
+			// This has been deprecated in favor of :seedling:
+			key = other
+			body = strings.TrimPrefix(body, ":running:")
+			body = strings.TrimPrefix(body, "🏃")
+		case strings.HasPrefix(body, ":warning:"), strings.HasPrefix(body, "⚠️"):
+			key = warning
+			body = strings.TrimPrefix(body, ":warning:")
+			body = strings.TrimPrefix(body, "⚠️")
+		case strings.HasPrefix(body, ":rocket:"), strings.HasPrefix(body, "🚀"):
+			continue
+		default:
+			key = unknown
+		}
+
+		body = strings.TrimSpace(body)
+		if body == "" {
+			continue
+		}
+		body = fmt.Sprintf("- %s", body)
+
+		if strings.HasPrefix(c.merge, "Merge pull request") {
+			_, err = fmt.Sscanf(c.merge, "Merge pull request %s from %s", &prNumber, &fork)
+			if err != nil {
+				log.Fatalf("Error parsing merge commit message: %v", err)
+			}
+		} else if strings.HasPrefix(c.merge, "Merge commit from fork") {
+			_, err = fmt.Sscanf(c.merge, "Merge commit from fork")
+			if err != nil {
+				log.Fatalf("Error parsing merge commit message: %v", err)
+			}
+		} else {
+			log.Fatalf("Unexpected merge commit message format: %s", c.merge)
+		}
+
+		merges[key] = append(merges[key], formatMerge(body, prNumber))
+	}
+
+	// Add empty superseded section, if not beta/rc, we don't cleanup those notes
+	if !isBeta(latestTag) && !isRC(latestTag) {
+		merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
+	}
+
+	fmt.Println("<!-- markdownlint-disable no-inline-html line-length -->")
+	if isBeta(latestTag) {
+		fmt.Printf(warningTemplate, "BETA RELEASE")
+	}
+	if isRC(latestTag) {
+		fmt.Printf(warningTemplate, "RELEASE CANDIDATE")
+	}
+	// TODO Turn this into a link (requires knowing the project name + organization)
+	fmt.Printf("# Changes since %v\n\n", lastTag)
+
+	// print the changes by category
+	for _, key := range outputOrder {
+		mergeslice := merges[key]
+		if len(mergeslice) > 0 {
+			fmt.Printf("## %v\n\n", key)
+			for _, merge := range mergeslice {
+				fmt.Println(merge)
+			}
+			fmt.Println()
+		}
+
+		// if we're doing beta/rc, print breaking changes and hide the rest of the changes
+		if key == warning {
+			if isBeta(latestTag) || isRC(latestTag) {
+				fmt.Printf("<details>\n")
+				fmt.Printf("<summary>More details about the release</summary>\n\n")
+			}
+		}
+	}
+
+	// then close the details if we had it open
+	if isBeta(latestTag) || isRC(latestTag) {
+		fmt.Printf("</details>\n\n")
+	}
+
+	fmt.Printf("The image for this release is: %v\n", latestTag)
+	fmt.Println("\n_Thanks to all our contributors!_ 😊")
+
+	return 0
+}
+
+type commit struct {
+	merge string
+	body  string
+}
+
+func formatMerge(line, prNumber string) string {
+	if prNumber == "" {
+		return line
+	}
+	return fmt.Sprintf("%s (%s)", line, prNumber)
+}
+
+// getCommitHashFromNewTag returns the latest commit hash for the specified tag.
+// For minor and pre releases, it returns the main branch's latest commit.
+// For patch releases, it returns the latest commit on the corresponding release branch.
+func getCommitHashFromNewTag(newTag string) (string, error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return "", errors.New("GITHUB_TOKEN is required")
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	branch := "main"
+	if !isBeta(newTag) {
+		branch = getReleaseBranchFromTag(newTag)
+		// Check if branch exist in upstream or not
+		_, _, err := client.Repositories.GetBranch(ctx, repoOwner, repoName, branch)
+		if err != nil {
+			// If branch does not exist, defaults to main
+			branch = "main"
+		}
+	}
+
+	ref, _, err := client.Git.GetRef(ctx, repoOwner, repoName, "refs/heads/"+branch)
+	if err != nil {
+		log.Fatalf("Error fetching ref: %v", err)
+	}
+	commitHash := ref.GetObject().GetSHA()
+	return commitHash, nil
+}
+
+func trimPrereleasePrefix(version string) string {
+	if idx := strings.Index(version, "-"); idx != -1 {
+		return version[:idx]
+	}
+	return version
+}
+
+func getReleaseBranchFromTag(tag string) string {
+	tag = strings.TrimPrefix(tag, "v")
+	tag = trimPrereleasePrefix(tag)
+	if index := strings.LastIndex(tag, "."); index != -1 {
+		tag = tag[:index]
+	}
+	return fmt.Sprintf("release-%s", tag)
+}


### PR DESCRIPTION
Add new changelog based release creation automation and update release documentation.

Note: ironic-image is not Go-centric repo, so let's not add all the bells and whistles related to the release note generator Go code (linters etc) as we plan to make it reusable from project-infra to avoid having 10 copies of the code for ever to maintain.