### PR TITLE
:bug: fix release image building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,8 +118,24 @@ jobs:
     if: github.repository == 'metal3-io/ironic-image'
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
-      image-name: 'ironic-image'
+      image-name: 'ironic'
       pushImage: true
+      ref: ${{ needs.push_release_tags.outputs.release_tag }}
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  build_ironic_image_cs10:
+    permissions:
+      contents: read
+    needs: push_release_tags
+    name: Build Ironic-image container image
+    if: github.repository == 'metal3-io/ironic-image'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: 'ironic_cs10'
+      pushImage: true
+      image-build-args: 'BASE_IMAGE=quay.io/centos/centos:stream10'
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -133,10 +133,11 @@ Once PR is merged following GitHub actions are triggered:
     or a new patch release from the latest release branch, uncheck the box for
     latest release. If it is a release candidate (RC) or a beta release,
     tick pre-release box.
-   - GitHub job `build_ironic_image` build release images with the
-    release tag, and push them to Quay. Make sure the release tags are visible in
-    Quay tags pages:
-      - [Ironic Image](https://quay.io/repository/metal3-io/ironic-image?tab=tags)
+   - GitHub jobs `build_ironic_image` and `build_ironic_image_cs10` build release
+    images with the release tag, and push them to Quay. Make sure the release
+    tags are visible in Quay tags pages:
+      - [Ironic CS9](https://quay.io/repository/metal3-io/ironic?tab=tags)
+      - [Ironic CS10](https://quay.io/repository/metal3-io/ironic_cs10?tab=tags)
     If the new release tag is not available for any of the images, check if the
     action has failed and retrigger as necessary.
 
@@ -153,7 +154,8 @@ Git tags pushed:
 
 Container images built and tagged at Quay registry:
 
-- [ironic-image:vx.y.z](https://quay.io/repository/metal3-io/ironic-image?tab=tags)
+- [ironic:vx.y.z](https://quay.io/repository/metal3-io/ironic?tab=tags)
+- [ironic_cs10:vx.y.z](https://quay.io/repository/metal3-io/ironic_cs10?tab=tags)
 
 You can also check the draft release and its tags in the Github UI.
 


### PR DESCRIPTION
Account for ironic_cs10 image in release job and use the correct image names as well.

Fix the documentation related to this too.
