### PR TITLE
:bug: Fix dnsmasq config ipv6 issues

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -12,20 +12,29 @@ port={{ env.DNS_PORT }}
 log-dhcp
 dhcp-range={{ env.DHCP_RANGE }}
 
-# It can be used when setting DNS or GW variables.
 {%- if env["GATEWAY_IP"] is undefined %}
 # Disable default router(s)
 dhcp-option=3
 {% else %}
-dhcp-option=option{% if ":" in env["GATEWAY_IP"] %}6{% endif %}:router,{{ env["GATEWAY_IP"] }}
+# Setting default router is not supported in v6, there are router advertisements
+# for that. In v4 we set the router option.
+{% if ":" in env["GATEWAY_IP"] %}
+enable-ra
+ra-param={{ env.PROVISIONING_INTERFACE }},0,0
+{% else %}
+dhcp-option=option:router,{{ env["GATEWAY_IP"] }}
 {% endif %}
+{% endif %}
+
 {%- if env["DNS_IP"] is undefined %}
 # Disable DNS over provisioning network
 dhcp-option=6
 {% else %}
+# dns-server is a valid option for both v4 and v6
 dhcp-option=option{% if ":" in env["DNS_IP"] %}6{% endif %}:dns-server,{{ env["DNS_IP"] }}
 {% endif %}
 
+{# Network boot options for IPv4 and IPv6 #}
 {%- if env.IPV == "4" or env.IPV is undefined %}
 # IPv4 Configuration:
 dhcp-match=ipxe,175
@@ -55,27 +64,10 @@ dhcp-boot=/undionly.kpxe,{{ env.IRONIC_IP }}
 
 {% if env.IPV == "6" %}
 # IPv6 Configuration:
-enable-ra
-ra-param={{ env.PROVISIONING_INTERFACE }},0,0
-
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE
 dhcp-option=tag:pxe6,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/snponly.efi
 dhcp-option=tag:ipxe6,option6:bootfile-url,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
-
-# It can be used when setting DNS or GW variables.
-{%- if env["GATEWAY_IP"] is undefined %}
-# Disable default router(s)
-dhcp-option=3
-{% else %}
-dhcp-option=3,{{ env["GATEWAY_IP"] }}
-{% endif %}
-{%- if env["DNS_IP"] is undefined %}
-# Disable DNS over provisioning network
-dhcp-option=6
-{% else %}
-dhcp-option=6,{{ env["DNS_IP"] }}
-{% endif %}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The current dnsmasq configuration caused dnsmasq container to stop due to wrong configuration in IPv6 only environment. This PR fixes that issue and also removes duplicate block from the configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #614 
