### PR TITLE
✨ Support DEPLOY_KERNEL_URL and DEPLOY_RAMDISK_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ functionality:
 - `IRONIC_ENABLE_VLAN_INTERFACES` - Which VLAN interfaces to enable on the
   agent start-up. Can be a list of interfaces or a special value `all`.
   Defaults to `all`.
+- `DEPLOY_KERNEL_URL` and `DEPLOY_RAMDISK_URL` provide the default IPA kernel
+  and initramfs images. If they're not set, the images from IPA downloader are
+  used (if present).
 
 MariaDB configuration:
 

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -87,11 +87,11 @@ verify_step_priority_override = management.clear_job_queue:90
 node_history = False
 # Provide for a timeout longer than 60 seconds for certain vendor's hardware
 power_state_change_timeout = 120
-{% if env.IRONIC_DEFAULT_KERNEL is defined %}
-deploy_kernel = file://{{ env.IRONIC_DEFAULT_KERNEL }}
+{% if env.DEPLOY_KERNEL_URL is defined %}
+deploy_kernel = {{ env.DEPLOY_KERNEL_URL }}
 {% endif %}
-{% if env.IRONIC_DEFAULT_RAMDISK is defined %}
-deploy_ramdisk = file://{{ env.IRONIC_DEFAULT_RAMDISK }}
+{% if env.DEPLOY_RAMDISK_URL is defined %}
+deploy_ramdisk = {{ env.DEPLOY_RAMDISK_URL }}
 {% endif %}
 {% if env.DISABLE_DEEP_IMAGE_INSPECTION | lower == "true" %}
 disable_deep_image_inspection = True

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -64,9 +64,10 @@ if [[ -n "$IRONIC_EXTERNAL_IP" ]]; then
 fi
 
 IMAGE_CACHE_PREFIX=/shared/html/images/ironic-python-agent
-if [[ -f "${IMAGE_CACHE_PREFIX}.kernel" ]] && [[ -f "${IMAGE_CACHE_PREFIX}.initramfs" ]]; then
-    export IRONIC_DEFAULT_KERNEL="${IMAGE_CACHE_PREFIX}.kernel"
-    export IRONIC_DEFAULT_RAMDISK="${IMAGE_CACHE_PREFIX}.initramfs"
+if [[ -z "${DEPLOY_KERNEL_URL:-}" ]] && [[ -z "${DEPLOY_RAMDISK_URL:-}" ]] && \
+       [[ -f "${IMAGE_CACHE_PREFIX}.kernel" ]] && [[ -f "${IMAGE_CACHE_PREFIX}.initramfs" ]]; then
+    export DEPLOY_KERNEL_URL="file:///${IMAGE_CACHE_PREFIX}.kernel"
+    export DEPLOY_RAMDISK_URL="file:///${IMAGE_CACHE_PREFIX}.initramfs"
 fi
 
 if [[ -f "${IRONIC_CONF_DIR}/ironic.conf" ]]; then


### PR DESCRIPTION
These variables have the same meaning as on BMO and configure the
default URL's for IPA.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
