### PR TITLE
🐛 Remove extra slash from deploy kernel/ramdisk paths

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -66,8 +66,8 @@ fi
 IMAGE_CACHE_PREFIX=/shared/html/images/ironic-python-agent
 if [[ -z "${DEPLOY_KERNEL_URL:-}" ]] && [[ -z "${DEPLOY_RAMDISK_URL:-}" ]] && \
        [[ -f "${IMAGE_CACHE_PREFIX}.kernel" ]] && [[ -f "${IMAGE_CACHE_PREFIX}.initramfs" ]]; then
-    export DEPLOY_KERNEL_URL="file:///${IMAGE_CACHE_PREFIX}.kernel"
-    export DEPLOY_RAMDISK_URL="file:///${IMAGE_CACHE_PREFIX}.initramfs"
+    export DEPLOY_KERNEL_URL="file://${IMAGE_CACHE_PREFIX}.kernel"
+    export DEPLOY_RAMDISK_URL="file://${IMAGE_CACHE_PREFIX}.initramfs"
 fi
 
 if [[ -f "${IRONIC_CONF_DIR}/ironic.conf" ]]; then


### PR DESCRIPTION
Ironic's security checks don't recognize //shared as a valid prefix.

Follow-up to 315acdab32f296f850cd3961a5e0fde095567659.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>