### PR TITLE
:seedling: use new cncf oracle gh runners

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: oracle-vm-4cpu-16gb-x86-64
     env:
       CLUSTER_TYPE: minikube
       LOGDIR: /tmp/logs


### PR DESCRIPTION
See [BMO 2599](https://github.com/metal3-io/baremetal-operator/pull/2599) for reference.
 
/hold
To be merged when all repos show green with new workers.