### PR TITLE
:bug: Revert "Fix dnsmasq config ipv6 issues"

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -12,29 +12,20 @@ port={{ env.DNS_PORT }}
 log-dhcp
 dhcp-range={{ env.DHCP_RANGE }}
 
+# It can be used when setting DNS or GW variables.
 {%- if env["GATEWAY_IP"] is undefined %}
 # Disable default router(s)
 dhcp-option=3
 {% else %}
-# Setting default router is not supported in v6, there are router advertisements
-# for that. In v4 we set the router option.
-{% if ":" in env["GATEWAY_IP"] %}
-enable-ra
-ra-param={{ env.PROVISIONING_INTERFACE }},0,0
-{% else %}
-dhcp-option=option:router,{{ env["GATEWAY_IP"] }}
+dhcp-option=option{% if ":" in env["GATEWAY_IP"] %}6{% endif %}:router,{{ env["GATEWAY_IP"] }}
 {% endif %}
-{% endif %}
-
 {%- if env["DNS_IP"] is undefined %}
 # Disable DNS over provisioning network
 dhcp-option=6
 {% else %}
-# dns-server is a valid option for both v4 and v6
 dhcp-option=option{% if ":" in env["DNS_IP"] %}6{% endif %}:dns-server,{{ env["DNS_IP"] }}
 {% endif %}
 
-{# Network boot options for IPv4 and IPv6 #}
 {%- if env.IPV == "4" or env.IPV is undefined %}
 # IPv4 Configuration:
 dhcp-match=ipxe,175
@@ -64,10 +55,27 @@ dhcp-boot=/undionly.kpxe,{{ env.IRONIC_IP }}
 
 {% if env.IPV == "6" %}
 # IPv6 Configuration:
+enable-ra
+ra-param={{ env.PROVISIONING_INTERFACE }},0,0
+
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE
 dhcp-option=tag:pxe6,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/snponly.efi
 dhcp-option=tag:ipxe6,option6:bootfile-url,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
+
+# It can be used when setting DNS or GW variables.
+{%- if env["GATEWAY_IP"] is undefined %}
+# Disable default router(s)
+dhcp-option=3
+{% else %}
+dhcp-option=3,{{ env["GATEWAY_IP"] }}
+{% endif %}
+{%- if env["DNS_IP"] is undefined %}
+# Disable DNS over provisioning network
+dhcp-option=6
+{% else %}
+dhcp-option=6,{{ env["DNS_IP"] }}
+{% endif %}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Reverts metal3-io/ironic-image#708

After testing this patch on an actual ipv6 deployment, we've verified that this change breaks dnsmasq and ip assignment
The router option does work as expected instead
```
dnsmasq: started, version 2.85 DNS disabled
dnsmasq: compile time options: IPv6 GNU-getopt DBus no-UBus no-i18n IDN2 DHCP DHCPv6 no-Lua TFTP no-conntrack ipset auth cryptohash DNSSEC loop-detect inotify dumpfile
dnsmasq-dhcp: DHCPv6, IP range fd00:1101::a -- fd00:1101::ffff:ffff:ffff:fffe, lease time 1d
dnsmasq-dhcp: router advertisement on fd00:1101::
dnsmasq-dhcp: RTR-ADVERT(enp1s0) fd00:1101::
dnsmasq-dhcp: IPv6 router advertisement enabled
dnsmasq-dhcp: DHCP, sockets bound exclusively to interface enp1s0
```

