### PR TITLE
fix(dnsmasq): add missing set

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -49,6 +49,7 @@ dhcp-boot=tag:ipxe,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
 {% endif %}
 
 # Note: Need to test EFI booting
+dhcp-match=set:bios,option:client-arch,0
 dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9
 dhcp-match=set:efi,option:client-arch,11
@@ -59,7 +60,7 @@ dhcp-boot=tag:efi,tag:ipxe,snponly.efi
 dhcp-boot=tag:efi,tag:!ipxe,snponly.efi
 
 # Client is running PXE over BIOS; send BIOS version of iPXE chainloader
-dhcp-boot=/undionly.kpxe,{{ env.IRONIC_IP }}
+dhcp-boot=tag:bios,/undionly.kpxe,{{ env.IRONIC_IP }}
 {% endif %}
 
 {% if env.IPV == "6" %}


### PR DESCRIPTION
# DHCP configuration

- **fix(dnsmasq): add missing set**
- **feat(dnsmasq): tag bios machine**
