### PR TITLE
:bug: Fix invalid and duplicate code in dnsmasq config

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -12,13 +12,6 @@ port={{ env.DNS_PORT }}
 log-dhcp
 dhcp-range={{ env.DHCP_RANGE }}
 
-# It can be used when setting DNS or GW variables.
-{%- if env["GATEWAY_IP"] is undefined %}
-# Disable default router(s)
-dhcp-option=3
-{% else %}
-dhcp-option=option{% if ":" in env["GATEWAY_IP"] %}6{% endif %}:router,{{ env["GATEWAY_IP"] }}
-{% endif %}
 {%- if env["DNS_IP"] is undefined %}
 # Disable DNS over provisioning network
 dhcp-option=6
@@ -26,9 +19,20 @@ dhcp-option=6
 dhcp-option=option{% if ":" in env["DNS_IP"] %}6{% endif %}:dns-server,{{ env["DNS_IP"] }}
 {% endif %}
 
+{# Network boot options for IPv4 and IPv6 #}
 {%- if env.IPV == "4" or env.IPV is undefined %}
 # IPv4 Configuration:
 dhcp-match=ipxe,175
+
+{# Set the router or disable it. Setting router is IPv4 specific, in v6 there #}
+{# are router advertisements that do the same thing. #}
+{%- if env["GATEWAY_IP"] is undefined %}
+# Disable default router(s)
+dhcp-option=3
+{% else %}
+dhcp-option=option:router,{{ env["GATEWAY_IP"] }}
+{% endif %}
+
 # Client is already running iPXE; move to next stage of chainloading
 {%- if env.IPXE_TLS_SETUP == "true"  %}
 # iPXE with (U)EFI
@@ -62,20 +66,6 @@ dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE
 dhcp-option=tag:pxe6,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/snponly.efi
 dhcp-option=tag:ipxe6,option6:bootfile-url,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
-
-# It can be used when setting DNS or GW variables.
-{%- if env["GATEWAY_IP"] is undefined %}
-# Disable default router(s)
-dhcp-option=3
-{% else %}
-dhcp-option=3,{{ env["GATEWAY_IP"] }}
-{% endif %}
-{%- if env["DNS_IP"] is undefined %}
-# Disable DNS over provisioning network
-dhcp-option=6
-{% else %}
-dhcp-option=6,{{ env["DNS_IP"] }}
-{% endif %}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The current dnsmasq config contains wrong configuration option `option6:router` and it also has duplicated code block.
