### PR TITLE
✨ Support for mounting an auth config for OCI registries

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -245,3 +245,8 @@ endpoint_override = {{ env.IRONIC_BASE_URL }}
 cert_file = {{ env.IRONIC_CERT_FILE }}
 key_file = {{ env.IRONIC_KEY_FILE }}
 {% endif %}
+
+[oci]
+{% if env.IRONIC_OCI_AUTH_CONFIG is defined %}
+authentication_config = {{ env.IRONIC_OCI_AUTH_CONFIG }}
+{% endif %}

--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -40,6 +40,10 @@ fi
 
 IRONIC_CONFIG="${IRONIC_CONF_DIR}/ironic.conf"
 
+if [[ -z "${IRONIC_OCI_AUTH_CONFIG:-}" ]] && [[ -f "/auth/oci.json" ]]; then
+    export IRONIC_OCI_AUTH_CONFIG="/auth/oci.json"
+fi
+
 configure_json_rpc_auth()
 {
     if [[ "${IRONIC_EXPOSE_JSON_RPC}" != "true" ]]; then


### PR DESCRIPTION
As part of its support for oci:// URLs, Ironic can accept an
authentication file (aka pull secret). Automate settings the right
variable of /auth/oci.json is mounted.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
