### PR TITLE
:warning: Use watchdog to monitor logs and certificate changes

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -40,8 +40,7 @@ if [[ ! -s "${UPPER_CONSTRAINTS_PATH}" ]]; then
 fi
 
 # NOTE(elfosardo): install dependencies constrained
-# also install pyasyncore to allow asyncore in Python 3.12
-python3.12 -m pip install jinja2 pyinotify pyasyncore -c "${UPPER_CONSTRAINTS_PATH}"
+python3.12 -m pip install jinja2 watchdog -c "${UPPER_CONSTRAINTS_PATH}"
 
 IRONIC_PKG_LIST="/tmp/ironic-packages-list"
 IRONIC_PKG_LIST_FINAL="/tmp/ironic-packages-list-final"

--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -1,21 +1,32 @@
 #!/usr/bin/bash
 
 # Ramdisk logs path
-LOG_DIR="/shared/log/ironic/deploy"
+export LOG_DIR="/shared/log/ironic/deploy"
 
 mkdir -p "${LOG_DIR}"
 
-# shellcheck disable=SC2034
-python3.12 -m pyinotify --raw-format -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
-    while read -r event dir mask maskname filename filepath pathname wd; do
-        #NOTE(elfosardo): a pyinotify event looks like this:
-        # <Event dir=False mask=0x8 maskname=IN_CLOSE_WRITE name=mylogs.gzip path=/shared/log/ironic/deploy pathname=/shared/log/ironic/deploy/mylogs.gzip wd=1 >
-        FILENAME=$(echo "${filename}" | cut -d'=' -f2-)
-        echo "************ Contents of ${LOG_DIR}/${FILENAME} ramdisk log file bundle **************"
-        tar -tzf "${LOG_DIR}/${FILENAME}" | while read -r entry; do
-            echo "${FILENAME}: **** Entry: ${entry} ****"
-            tar -xOzf "${LOG_DIR}/${FILENAME}" "${entry}" | sed -e "s/^/${FILENAME}: /"
-            echo
-        done
-        rm -f "${LOG_DIR}/${FILENAME}"
+# Function to process log files
+process_log_file() {
+    local FILEPATH="$1"
+    # shellcheck disable=SC2155
+    local FILENAME=$(basename "${FILEPATH}")
+
+    echo "************ Contents of ${LOG_DIR}/${FILENAME} ramdisk log file bundle **************"
+    tar -tzf "${FILEPATH}" | while read -r entry; do
+        echo "${FILENAME}: **** Entry: ${entry} ****"
+        tar -xOzf "${FILEPATH}" "${entry}" | sed -e "s/^/${FILENAME}: /"
+        echo
     done
+    rm -f "${FILEPATH}"
+}
+
+# Export the function so watchmedo can use it
+export -f process_log_file
+
+# Use watchmedo to monitor for file close events
+# shellcheck disable=SC2016
+watchmedo shell-command \
+    --patterns="*" \
+    --ignore-directories \
+    --command='if [[ "${watch_event_type}" == "closed" ]]; then process_log_file "${watch_src_path}"; fi' \
+    "${LOG_DIR}"


### PR DESCRIPTION
Watchdog comes with a shell utility script, watchmedo, that can perfectly replace pyinotify, and it works natively with Python 3.12
We drop pyinotify in favor of watchdog and convert the scripts to use watchmedo.

Fixes #715
