### PR TITLE
🐛 Disable unused httpd mod_proxy extensions

### DIFF
--- a/ironic-config/httpd-modules.conf
+++ b/ironic-config/httpd-modules.conf
@@ -8,8 +8,6 @@ LoadModule mpm_event_module /etc/httpd/modules/mod_mpm_event.so
 LoadModule ssl_module /etc/httpd/modules/mod_ssl.so
 LoadModule env_module /etc/httpd/modules/mod_env.so
 LoadModule proxy_module /etc/httpd/modules/mod_proxy.so
-LoadModule proxy_ajp_module /etc/httpd/modules/mod_proxy_ajp.so
-LoadModule proxy_balancer_module /etc/httpd/modules/mod_proxy_balancer.so
 LoadModule proxy_http_module /etc/httpd/modules/mod_proxy_http.so
 LoadModule slotmem_shm_module /etc/httpd/modules/mod_slotmem_shm.so
 LoadModule headers_module /etc/httpd/modules/mod_headers.so


### PR DESCRIPTION
mod_proxy_ajp is only necessary for some Java applications.

mod_proxy_balancer is for connecting to several backends.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
