### PR TITLE
🌱 Approvers: remove Derek, add Adam

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,4 +14,5 @@ emeritus_reviewers:
 
 emeritus_approvers:
 - bfournie
+- derekhiggins
 - hardys

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,12 @@
 
 aliases:
   ironic-image-maintainers:
-  - derekhiggins
   - dtantsur
   - elfosardo
   - iurygregory
+  - Rozzii
 
   ironic-image-reviewers:
   - lentzi90
-  - Rozzii
   - tuminoid
   - zaneb


### PR DESCRIPTION
Derek is no longer working in our team, so removing him.

Adam has contributed significant features to ironic-image, and has been
reviewing both it and IrSO consistently.

We should probably consider more promotions, but at least the gap is
covered.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
