### PR TITLE
🌱 Synchronize the functional job with IrSO

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -11,6 +11,8 @@ jobs:
       CLUSTER_TYPE: minikube
       LOGDIR: /tmp/logs
       JUNIT_OUTPUT: /tmp/logs/report.xml
+      IRONIC_CUSTOM_IMAGE: localhost/ironic:test
+      IRONIC_CUSTOM_VERSION: latest
     steps:
     - name: Update repositories
       run: sudo apt-get update
@@ -35,11 +37,11 @@ jobs:
       with:
         start-args: "--ha"
     - name: Prepare tests
-      run: cd ironic-standalone-operator && ./test/prepare.sh
+      run: ironic-standalone-operator/test/prepare.sh
+    - name: Build and local the image
+      run: ironic-image/hack/prepare-irso-tests.sh
     - name: Run tests
-      run: ironic-image/hack/ci-e2e.sh
-      env:
-        IRSO_PATH: "${{ github.workspace }}/ironic-standalone-operator"
+      run: ironic-standalone-operator/test/run.sh
     - name: Collect logs
       run: ironic-standalone-operator/test/collect-logs.sh
       if: always()

--- a/hack/prepare-irso-tests.sh
+++ b/hack/prepare-irso-tests.sh
@@ -7,14 +7,7 @@ cd "${REPO_ROOT}" || exit 1
 
 CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-
-IRSO_REPO="${IRSO_REPO:-https://github.com/metal3-io/ironic-standalone-operator}"
-IRSO_BRANCH="${IRSO_BRANCH:-main}"
-if [[ -z "${IRSO_PATH:-}" ]]; then
-    IRSO_PATH="$(mktemp -td irso-XXXXXXXX)"
-    git clone "${IRSO_REPO}" -b "${IRSO_BRANCH}" "${IRSO_PATH}"
-fi
-export IRONIC_CUSTOM_IMAGE=localhost/ironic:test
+IRONIC_CUSTOM_IMAGE=${IRONIC_CUSTOM_IMAGE:-localhost/ironic:test}
 
 "${CONTAINER_RUNTIME}" build -t "${IRONIC_CUSTOM_IMAGE}" .
 IMAGE_ARCHIVE="$(mktemp --suffix=.tar)"
@@ -25,10 +18,3 @@ else
     minikube image load --logtostderr "${IMAGE_ARCHIVE}"
 fi
 rm -f "${IMAGE_ARCHIVE}"
-
-cd "${IRSO_PATH}/test"
-# shellcheck disable=SC1091
-. testing.env
-export IRONIC_CUSTOM_VERSION=latest
-
-exec go test -timeout 90m


### PR DESCRIPTION
Use the IrSO's run.sh instead of the local version. This fixes a few
issues, such as missing verbosity or lack of filtering.

Rename the setup script to something more suitable and split it into
a separate workflow step.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
