### PR TITLE
:seedling: build ironic-image on both centos:stream versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@ SHELL=/usr/bin/env bash -o errexit
 
 .PHONY: help build
 
-export CONTAINER_ENGINE ?= podman
+export CONTAINER_RUNTIME ?= podman
 
 help:
 	@echo "Targets:"
 	@echo "  build -- build the docker image"
 
 build:
-	$(CONTAINER_ENGINE) build . -f Dockerfile
+	$(CONTAINER_RUNTIME) build . -f Dockerfile --build-arg BASE_IMAGE=quay.io/centos/centos:stream9
+	$(CONTAINER_RUNTIME) build . -f Dockerfile --build-arg BASE_IMAGE=quay.io/centos/centos:stream10
 
 ## --------------------------------------
 ## Release


### PR DESCRIPTION
Build ironic-image on both centos:stream versions. We build both in our post merge step, but we don't build cs10 version anywhere else. This leads to situations where we merge stuff that breaks the build.

This will be accompanied by project-infra PR that will run "make build" to run the test.

Also, rename the Makefile variable CONTAINER_ENGINE to CONTAINER_RUNTIME as we use CONTAINER_RUNTIME everywhere else as the engine selector.
