### PR TITLE
:seedling: add edited as irso functional trigger

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -2,7 +2,7 @@ name: IrSO Functional Tests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 jobs:
   test:


### PR DESCRIPTION
We are missing "edited" from IRSO functional job triggers.

This needs to be cherry-picked to 30.0 and 31.0 branches as well.

/cherry-pick release-30.0
/cherry-pick release-31.0