### PR TITLE
:seedling: Revert "Use the shared directory to store master iso images on ironic-conductor node"

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -119,7 +119,6 @@ erase_devices_priority = 0
 http_root = /shared/html/
 http_url = {{ env.IRONIC_HTTP_URL }}
 fast_track = {{ env.IRONIC_FAST_TRACK }}
-iso_master_path = /shared/html/master_iso_images
 {% if env.IRONIC_BOOT_ISO_SOURCE %}
 ramdisk_image_download_source = {{ env.IRONIC_BOOT_ISO_SOURCE }}
 {% endif %}


### PR DESCRIPTION
Reverts metal3-io/ironic-image#756

This is breaking live-ISO tests in BMO e2e