### PR TITLE
:seedling: Expose cipher suite configuration for vmedia

### DIFF
--- a/ironic-config/apache2-vmedia.conf.j2
+++ b/ironic-config/apache2-vmedia.conf.j2
@@ -10,6 +10,19 @@ Listen {{ env.VMEDIA_TLS_PORT }}
     SSLCertificateFile {{ env.IRONIC_VMEDIA_CERT_FILE }}
     SSLCertificateKeyFile {{ env.IRONIC_VMEDIA_KEY_FILE }}
 
+    {% if "IRONIC_VMEDIA_TLS_12_CIPHERS" in env and env.IRONIC_VMEDIA_TLS_12_CIPHERS | length %}
+    SSLCipherSuite {{ env.IRONIC_VMEDIA_TLS_12_CIPHERS }}
+    {% endif %}
+    {% if "IRONIC_VMEDIA_TLS_13_CIPHERS" in env and env.IRONIC_VMEDIA_TLS_13_CIPHERS | length %}
+    SSLCipherSuite TLSv1.3 {{ env.IRONIC_VMEDIA_TLS_13_CIPHERS }}
+    {% endif %}
+    {% if "IRONIC_VMEDIA_CURVES" in env and env.IRONIC_VMEDIA_CURVES | length %}
+    SSLOpenSSLConfCmd Curves {{ env.IRONIC_VMEDIA_CURVES }}
+    {% endif %}
+    {% if env.IRONIC_VMEDIA_TLS_ENFORCE_SERVER_CIPHER_ORDER | lower == "true" %}
+    SSLHonorCipherOrder on
+    {% endif %}
+
     <Directory ~ "/shared/html">
          Order deny,allow
          deny from all


### PR DESCRIPTION
**What this PR does / why we need it**:
Some BMC implementations are advertising ciphers they do not correctly support, leading to errors or extremely bad performance when using virtual media.

Workaround is to disable those not well supported ciphers on the server side.
This commit exposes the necessary configuration options to do so through environment variables.