### PR TITLE
:seedling: Add build ironic-image workflow on PRs

### DIFF
--- a/.github/workflows/ironic-image-build-pr.yml
+++ b/.github/workflows/ironic-image-build-pr.yml
@@ -1,0 +1,40 @@
+name: Build Ironic Image on PRs
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        centos_version:
+        - stream9
+        - stream10
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+    - name: Set base image
+      id: base-image
+      run: |
+        if [[ "${{ matrix.centos_version }}" == "stream9" ]]; then
+          echo "base_image=quay.io/centos/centos:stream9" >> "${GITHUB_OUTPUT}"
+        elif [[ "${{ matrix.centos_version }}" == "stream10" ]]; then
+          echo "base_image=quay.io/centos/centos:stream10" >> "${GITHUB_OUTPUT}"
+        fi
+    - name: Build Docker image
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: .
+        file: ./Dockerfile
+        push: false
+        tags: ironic:${{ matrix.centos_version }}
+        build-args: |
+          BASE_IMAGE=${{ steps.base-image.outputs.base_image }}
+        cache-from: type=gha,scope=${{ matrix.centos_version }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.centos_version }}


### PR DESCRIPTION
Test if ironic-image can be built using both CS9 and CS10 before running e2e tests.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>

