### PR TITLE
:seedling: add Renovate config to update release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "onboarding": false,
+  "requireConfig": "ignored",
+  "baseBranchPatterns": ["release-30.0", "release-31.0", "release-32.0"],
+  "enabledManagers": ["custom.regex"],
+  "schedule": ["after 12am and before 2am"],
+  "prCreation": "immediate",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "automerge": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "ARG IRONIC_SOURCE=(?<currentDigest>[a-f0-9]{40})\\s+#\\s*(?<currentValue>[^\\n]+)"
+      ],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "openstack-ironic",
+      "packageNameTemplate": "https://opendev.org/openstack/ironic.git",
+      "autoReplaceStringTemplate": "ARG IRONIC_SOURCE={{#if newDigest}}{{{newDigest}}}{{else}}{{{newValue}}}{{/if}} # {{{currentValue}}}"
+    }
+  ]
+}


### PR DESCRIPTION
Add renovate.json to add Renovate bot config that would follow upstream Ironic branches and update IRONIC_SOURCE when the bugfix/stable branches get updates.

This will allow us to get a PR to update the pinned SHA in case there is upstream bugfix. Merging that pin bump PR will then build us new image of that release branch, which in turn will be used in testing.

NOTE: This PR requires release branches to have
`ARG IRONIC_SOURCE=sha # branch name`
before it works, Renovate cannot deal with converting branch name into SHA on its own. I will push those PRs to release branches separately.

We also need to enable Renovate app for this repo.