### PR TITLE
:seedling: pin upstream ironic bugfix/30.0 to a SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG PATCH_LIST
 
 # build arguments for source build customization
 ARG UPPER_CONSTRAINTS_FILE=upper-constraints.txt
-ARG IRONIC_SOURCE=bugfix/30.0
+ARG IRONIC_SOURCE=cb887d429552a9ed82f6d8da728a3f4da5095db4 # bugfix/30.0
 ARG SUSHY_SOURCE
 
 COPY sources /sources/


### PR DESCRIPTION
Pin upstream Ironic from bugfix/30.0 branch, so we can activate Renovate bot config to make PRs when the upstream branch changes.

Ref: https://github.com/metal3-io/ironic-image/pull/768