### PR TITLE
:seedling: pin upstream ironic bugfix/31.0 to a SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG PATCH_LIST
 
 # build arguments for source build customization
 ARG UPPER_CONSTRAINTS_FILE=upper-constraints.txt
-ARG IRONIC_SOURCE=bugfix/31.0
+ARG IRONIC_SOURCE=b65af82e24f9a98730586544b5906c1b5644ab76 # bugfix/31.0
 ARG SUSHY_SOURCE
 
 COPY sources /sources/


### PR DESCRIPTION
Pin upstream Ironic from bugfix/31.0 branch, so we can activate Renovate bot config to make PRs when the upstream branch changes.

Ref: #768 