### PR TITLE
:seedling: pin upstream ironic stable/2025.2 to a SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG PATCH_LIST
 
 # build arguments for source build customization
 ARG UPPER_CONSTRAINTS_FILE=upper-constraints.txt
-ARG IRONIC_SOURCE=stable/2025.2
+ARG IRONIC_SOURCE=98c5fc671714c30c796c5a1b1fe92b7542df5818 # stable/2025.2
 ARG SUSHY_SOURCE
 
 # dummy variable: put the current date to trigger a rebuild


### PR DESCRIPTION
Pin upstream Ironic from stable/2025.2 branch, so we can activate Renovate bot config to make PRs when the upstream branch changes.

Ref: #768 