### PR TITLE
⚠️ Drop the non-Redfish iLO 4 and iLO 5 drivers

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -4,19 +4,19 @@ debug = true
 default_deploy_interface = direct
 default_inspect_interface = agent
 default_network_interface = noop
-enabled_bios_interfaces = no-bios,redfish,idrac-redfish,irmc,ilo
-enabled_boot_interfaces = ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media,redfish-https
+enabled_bios_interfaces = no-bios,redfish,idrac-redfish,irmc
+enabled_boot_interfaces = ipxe,pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,redfish-https
 enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent
 enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
-enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
-enabled_inspect_interfaces = agent,irmc,fake,redfish,ilo
-enabled_management_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,manual-management
+enabled_inspect_interfaces = agent,irmc,fake,redfish
+enabled_management_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,noop
 enabled_network_interfaces = noop
-enabled_power_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo
-enabled_raid_interfaces = no-raid,irmc,agent,fake,redfish,idrac-redfish,ilo5
-enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
+enabled_power_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish
+enabled_raid_interfaces = no-raid,irmc,agent,fake,redfish,idrac-redfish
+enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,fake
 {% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}
 rpc_transport = json-rpc
 {% else %}
@@ -238,13 +238,6 @@ use_swift = false
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console=yes
 {% if env.BMC_TLS_ENABLED == "true" %}
 # idrac uses the same options as the redfish driver
-verify_ca = {{ env.BMC_CACERT_FILE }}
-{% endif %}
-
-[ilo]
-kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console=yes
-use_web_server_for_images = true
-{% if env.BMC_TLS_ENABLED == "true" %}
 verify_ca = {{ env.BMC_CACERT_FILE }}
 {% endif %}
 

--- a/ironic-packages-list
+++ b/ironic-packages-list
@@ -10,7 +10,6 @@ ironic @ git+https://opendev.org/openstack/ironic@{{ env.IRONIC_SOURCE }}
 ironic @ git+https://opendev.org/openstack/ironic
 {% endif %}
 ironic-prometheus-exporter
-proliantutils
 PyMySQL>=0.8.0
 python-scciclient
 {% if env.SUSHY_SOURCE %}


### PR DESCRIPTION
Ironic will stop supporting them very soon because neither them nor
proliantutils is no longer maintained. iLO 5 users should use Redfish.
Unfortunately, IPMI is the only option for iLO 4 users now.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
