### PR TITLE
🐛 Stop defaulting WEBSERVER_VERIFY_CA to IRONIC_CACERT_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,7 @@ functionality:
 - `IRONIC_JSON_RPC_PORT` - port used by the ironic json-rpc service (default to
   6189).
 - `WEBSERVER_CACERT_FILE` - Specifies the CA or CA bundle that will be used
-  by Ironic to verify disk and IPA images and also by IPA to download the
-  disk images, by default this will  point to Ironic's CA, if empty string
-  is passed then the system default CA bundle will be used
+  by Ironic to verify disk and IPA images.
 
 The following environment variables can be passed to customize the virtual
 media HTTP server configuration:

--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -26,11 +26,6 @@ export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
 
 export IPXE_TLS_PORT="${IPXE_TLS_PORT:-8084}"
 
-# Used directly in the ironic.conf
-# Configures what CA or CA bundle is used for verifying
-# Node and IPA image urls
-export WEBSERVER_CACERT_FILE="${WEBSERVER_CACERT_FILE-${IRONIC_CACERT_FILE}}"
-
 if [[ -f "$IRONIC_CERT_FILE" ]] && [[ ! -f "$IRONIC_KEY_FILE" ]]; then
     echo "Missing TLS Certificate key file $IRONIC_KEY_FILE"
     exit 1


### PR DESCRIPTION
These two have completely different roles: WEBSERVER_VERIFY_CA is used
by Ironic to check user images.  Unless your image happens to be on a
server that uses the same CA, this is not a valid default.

Also fix README: WEBSERVER_VERIFY_CA is not used by IPA.

Fixes: #777
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
