### PR TITLE
:bug: Use custom data directory to store the master iso images on ironic-conductor node

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -41,6 +41,10 @@ isolinux_bin = /usr/share/syslinux/isolinux.bin
 # the ESP provided in [conductor]bootloader.
 grub_config_path = EFI/centos/grub.cfg
 
+# NOTE(hroyrh): updating the default temp directory to fix device cross links
+# errors when hard linking
+tempdir = /shared/tmp
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -115,6 +115,7 @@ echo 'Options set from Environment variables'
 env | grep "^OS_" || true
 
 mkdir -p /shared/html
+mkdir -p /shared/tmp
 mkdir -p /shared/ironic_prometheus_exporter
 
 if [[ -f /proc/sys/crypto/fips_enabled ]]; then


### PR DESCRIPTION
When read-only root filesystem is enabled for ironic-image based containers, the path /var/lib/ironic/master_iso_images becomes read-only. We need to change the path to custom data directory so that changes can be made to this path for updating image cache.

This pr is duplicate of  #756 , which was reverted in #757 .

