### PR TITLE
📖 Releasing: set IRONIC_CUSTOM_IMAGE in the IrSO job

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -12,6 +12,8 @@ jobs:
       LOGDIR: /tmp/logs
       JUNIT_OUTPUT: /tmp/logs/report.xml
       IRONIC_CUSTOM_IMAGE: localhost/ironic:test
+      # NOTE(dtantsur): change this on stable branches to make sure the correct
+      # logic is used in IrSO, and also that the tests are skipped properly.
       IRONIC_CUSTOM_VERSION: latest
     steps:
     - name: Update repositories

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -265,6 +265,11 @@ operator code as well. After that, an
 [IrSO release](https://github.com/metal3-io/ironic-standalone-operator/blob/main/docs/releasing.md)
 will be prepared.
 
+Finally, return to the release branch in this repository and update
+`IRONIC_CUSTOM_VERSION` in the IrSO workflow
+(`.github/workflows/irso-functional.yml`) to match the correct version (e.g.
+`32.0` on `release-32.0`).
+
 ## Additional actions outside this repository
 
 Further additional actions may be required in the Metal3 project after


### PR DESCRIPTION
Setting this value is important for stable branches, both for the
version-specific logic in IrSO itself and for skipping tests that cannot
run on this branch.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
