### PR TITLE
:warning: Improve priority and validation of input variables consumed in wait_for_interface_or_ip

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -122,13 +122,25 @@ wait_for_interface_or_ip()
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
         export IRONIC_IP="${PARSED_IP}"
-    else
+    elif [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             IRONIC_IP="$(ip -br addr show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)"
             export IRONIC_IP
             sleep 1
         done
+    else
+        echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
+        return 1
     fi
 
     # If the IP contains a colon, then it's an IPv6 address, and the HTTP

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -100,10 +100,20 @@ parse_ip_address()
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 wait_for_interface_or_ip()
 {
-    # If $PROVISIONING_IP is specified, then we wait for that to become
-    # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
-    # for an IP
-    if [[ -n "${PROVISIONING_IP}" ]]; then
+    # IRONIC_IP already defined overrides everything else
+    if [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_IP}" ]]; then
+        # If $PROVISIONING_IP is specified, then we wait for that to become
+        # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
+        # for an IP
         local PARSED_IP
         PARSED_IP="$(parse_ip_address "${PROVISIONING_IP}")"
         if [[ -z "${PARSED_IP}" ]]; then
@@ -121,15 +131,6 @@ wait_for_interface_or_ip()
         echo "Found ${PROVISIONING_IP} on interface \"${IFACE_OF_IP}\"!"
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
-        export IRONIC_IP="${PARSED_IP}"
-    elif [[ -n "${IRONIC_IP}" ]]; then
-        local PARSED_IP
-        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
-        if [[ -z "${PARSED_IP}" ]]; then
-            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
-            exit 1
-        fi
-
         export IRONIC_IP="${PARSED_IP}"
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do


### PR DESCRIPTION
**What this PR does / why we need it**:
The current logic in wait_for_interface_or_ip deals with the input IP addresses or interfaces, according to the following order: PROVISIONING_IP, IRONIC_IP, PROVISIONING_INTERFACE. The improvements this PR introduces are:
- make the test case for IRONIC_IP explicit rather than implicit, improving code readability before the following change
- "group" PROVISIONING_IP and PROVISIONING_INTERFACE in terms of priority by prioritizing IRONIC_IP instead, resulting in the following order: IRONIC_IP, PROVISIONING_IP, PROVISIONING_INTERFACE
- include input validation for the externally provided IRONIC_IP

What the PR does not address is logging a warning in case of multiple input variables set and one taking inevitably precedence over the another(s).

NOTE: based on PR #787

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
