### PR TITLE
:sparkles: Support both IPv4 and IPv6 addresses in startup scripts and configuration files

### DIFF
--- a/ironic-config/apache2-ipxe.conf.j2
+++ b/ironic-config/apache2-ipxe.conf.j2
@@ -1,4 +1,5 @@
-Listen {{ env.IPXE_TLS_PORT }}
+Listen 0.0.0.0:{{ env.IPXE_TLS_PORT }}
+Listen [::]:{{ env.IPXE_TLS_PORT }}
 
 <VirtualHost *:{{ env.IPXE_TLS_PORT }}>
     ErrorLog /dev/stderr

--- a/ironic-config/apache2-vmedia.conf.j2
+++ b/ironic-config/apache2-vmedia.conf.j2
@@ -1,4 +1,5 @@
-Listen {{ env.VMEDIA_TLS_PORT }}
+Listen 0.0.0.0:{{ env.VMEDIA_TLS_PORT }}
+Listen [::]:{{ env.VMEDIA_TLS_PORT }}
 
 <VirtualHost *:{{ env.VMEDIA_TLS_PORT }}>
     ErrorLog /dev/stderr

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -15,8 +15,14 @@
 Listen {{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
- <VirtualHost {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}>
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
+{% endif %}
 {% endif %}
 
     DocumentRoot "/shared/html"

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -12,7 +12,8 @@
 
 
 {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.IRONIC_LISTEN_PORT }}
+Listen 0.0.0.0:{{ env.IRONIC_LISTEN_PORT }}
+Listen [::]:{{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
 {% if env.ENABLE_IPV4 %}

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -2,7 +2,12 @@ ServerRoot {{ env.HTTPD_DIR }}
 {%- if env.LISTEN_ALL_INTERFACES | lower == "true" %}
 Listen {{ env.HTTP_PORT }}
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.HTTP_PORT }}
+{% endif %}
 {% endif %}
 Include /etc/httpd/conf.modules.d/*.conf
 User apache

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -1,6 +1,7 @@
 ServerRoot {{ env.HTTPD_DIR }}
 {%- if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.HTTP_PORT }}
+Listen 0.0.0.0:{{ env.HTTP_PORT }}
+Listen [::]:{{ env.HTTP_PORT }}
 {% else %}
 {% if env.ENABLE_IPV4 %}
 Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -68,7 +68,7 @@ port = {{ env.IRONIC_PRIVATE_PORT }}
 {% endif %}
 public_endpoint = {{ env.IRONIC_BASE_URL }}
 {% else %}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_HOST_IP }}
 port = {{ env.IRONIC_LISTEN_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 enable_ssl_api = true
@@ -186,7 +186,7 @@ cipher_suite_versions = 3,17
 # containers are in host networking.
 auth_strategy = http_basic
 http_basic_auth_user_file = {{ env.IRONIC_RPC_HTPASSWD_FILE }}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_HOST_IP }}
 port = {{ env.IRONIC_JSON_RPC_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 use_ssl = true

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -25,7 +25,13 @@ rpc_transport = none
 use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
+{% if env.ENABLE_IPV4 %}
 my_ip = {{ env.IRONIC_IP }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+my_ipv6 = {{ env.IRONIC_IPV6 }}
+{% endif %}
+
 host = {{ env.IRONIC_CONDUCTOR_HOST }}
 
 # If a path to a certificate is defined, use that first for webserver

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -136,4 +136,11 @@ render_j2_config "/etc/ironic/ironic.conf.j2" \
 configure_json_rpc_auth
 
 # Make sure ironic traffic bypasses any proxies
-export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"
+export NO_PROXY="${NO_PROXY:-}"
+
+if [[ -n "${IRONIC_IPV6}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
+fi
+if [[ -n "${IRONIC_IP}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+fi

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -49,6 +49,12 @@ export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
 
 wait_for_interface_or_ip
 
+if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+    export IRONIC_HOST_IP="::"
+else
+    export IRONIC_HOST_IP="${IRONIC_IP}"
+fi
+
 # Hostname to use for the current conductor instance.
 export IRONIC_CONDUCTOR_HOST=${IRONIC_CONDUCTOR_HOST:-${IRONIC_URL_HOST}}
 

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -51,6 +51,8 @@ wait_for_interface_or_ip
 
 if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
     export IRONIC_HOST_IP="::"
+elif [[ -n "${ENABLE_IPV6}" ]]; then
+    export IRONIC_HOST_IP="${IRONIC_IPV6}"
 else
     export IRONIC_HOST_IP="${IRONIC_IP}"
 fi

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -114,10 +114,20 @@ parse_ip_address()
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 wait_for_interface_or_ip()
 {
-    # If $PROVISIONING_IP is specified, then we wait for that to become
-    # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
-    # for an IP
-    if [[ -n "${PROVISIONING_IP}" ]]; then
+    # IRONIC_IP already defined overrides everything else
+    if [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_IP}" ]]; then
+        # If $PROVISIONING_IP is specified, then we wait for that to become
+        # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
+        # for an IP
         local PARSED_IP
         PARSED_IP="$(parse_ip_address "${PROVISIONING_IP}")"
         if [[ -z "${PARSED_IP}" ]]; then
@@ -135,15 +145,6 @@ wait_for_interface_or_ip()
         echo "Found ${PROVISIONING_IP} on interface \"${IFACE_OF_IP}\"!"
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
-        export IRONIC_IP="${PARSED_IP}"
-    elif [[ -n "${IRONIC_IP}" ]]; then
-        local PARSED_IP
-        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
-        if [[ -z "${PARSED_IP}" ]]; then
-            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
-            exit 1
-        fi
-
         export IRONIC_IP="${PARSED_IP}"
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -48,12 +48,6 @@ get_provisioning_interface()
 
     local interface="provisioning"
 
-    if [[ -n "${PROVISIONING_IP}" ]]; then
-        if ip -br addr show | grep -i " ${PROVISIONING_IP}/" &>/dev/null; then
-            interface="$(ip -br addr show | grep -i " ${PROVISIONING_IP}/" | cut -f 1 -d ' ' | cut -f 1 -d '@')"
-        fi
-    fi
-
     for mac in ${PROVISIONING_MACS//,/ }; do
         if ip -br link show up | grep -i "$mac" &>/dev/null; then
             interface="$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ' | cut -f 1 -d '@')"

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -46,7 +46,7 @@ get_provisioning_interface()
         return
     fi
 
-    local interface="provisioning"
+    local interface=""
 
     for mac in ${PROVISIONING_MACS//,/ }; do
         if ip -br link show up | grep -i "$mac" &>/dev/null; then
@@ -136,13 +136,25 @@ wait_for_interface_or_ip()
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
         export IRONIC_IP="${PARSED_IP}"
-    else
+    elif [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             IRONIC_IP="$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)"
             export IRONIC_IP
             sleep 1
         done
+    else
+        echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
+        return 1
     fi
 
     # If the IP contains a colon, then it's an IPv6 address, and the HTTP


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the configuration and startup scripts rely on the assumption that all the services should either be exposed on an IPv4 or an IPv6 address. Dual-stack support is somewhat provided by leveraging IPv4-mapped IPv6 addresses, that is, only an IPv6 socket is allocated (which is a discouraged practice). Enable true dual-stack support, both in ironic.conf and all the Apache instances, by introducing IRONIC_IPV6 alongside the existing IRONIC_IP, so that either or both IPs can be leverage when defined or detected.
To avoid breaking changes and keep the PR simple, externally provided IRONIC_IP and PROVISIONING_IP values will result in either an IPv4 or an IPv6 socket allocated and not both. However, when PROVISIONING_INTERFACE must be used, the new code will attempt to detect both IP versions, potentially resulting in a proper dual-stack configuration on a dual-stack system. In this case, IPv6 will however take precedence for URL generation.

This PR paves the way to a future PR, where a hostname, resolving to both IPv4 and IPv6 addresses, can be leveraged for "dual-stack URLs" and, potentially, in a dual socket configuration. Besides this possibility, an initial conversation on other approaches or improvements can also get started here.

NOTE: based on PR #788

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
