### PR TITLE
:sparkles: Allow IRONIC_IPV4, IRONIC_IPV6 and URLs to be derived from a DNS record

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ functionality:
    `PROVISIONING_MACS` is provided)
 - `PROVISIONING_IP` - the specific IP to use (instead of calculating it based on
   the `PROVISIONING_INTERFACE`)
+- `IRONIC_URL_HOSTNAME` - a fully qualified name resolving to an IPv4 and/or IPv6
+  address, used for both binding and forming the required URLs; for the latter
+  purpose only, it can be used in combination with `PROVISIONING_INTERFACE`, which
+  would instead be used for the former. If the hostname has both IPv4 and IPv6
+  records, and both addresses are correctly assigned on the same network interface,
+  `IRONIC_URL_HOSTNAME` enables a dual-stack ironic image configuration.
 - `DNSMASQ_EXCEPT_INTERFACE` - interfaces to exclude when providing DHCP address
   (default `lo`)
 - `HTTP_PORT` - port used by http server (default `80`)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ functionality:
 - `DHCP_OPTIONS` - a `;` separated list of additional `dhcp-option` directives
    that allows passing specific network configuration parameters (like routers,
    DNS servers, and NTP) to DHCP clients (empty by default). Only applies to
-   IPv4 provisioning (`IPV=4` or unset). For more details on `dhcp-option` see
+   IPv4 provisioning, if enabled . For more details on `dhcp-option` see
    [the man page](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html).
 - `DHCP_IGNORE` - a set of tags on hosts that should be ignored and not allocate
    DHCP leases for, e.g. `tag:!known` to ignore any unknown hosts (empty by

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ functionality:
    `PROVISIONING_MACS` is provided)
 - `PROVISIONING_IP` - the specific IP to use (instead of calculating it based on
   the `PROVISIONING_INTERFACE`)
+- `IRONIC_URL_HOSTNAME` - a fully qualified name resolving to an IPv4 and/or IPv6
+  address, used for both binding and forming the required URLs; for the latter
+  purpose only, it can be used in combination with `PROVISIONING_INTERFACE`, which
+  would instead be used for the former. If the hostname has both IPv4 and IPv6
+  records, and both addresses are correctly assigned on the same network interface,
+  `IRONIC_URL_HOSTNAME` enables a dual-stack ironic image configuration.
 - `DNSMASQ_EXCEPT_INTERFACE` - interfaces to exclude when providing DHCP address
   (default `lo`)
 - `HTTP_PORT` - port used by http server (default `80`)

--- a/ironic-config/apache2-ipxe.conf.j2
+++ b/ironic-config/apache2-ipxe.conf.j2
@@ -1,4 +1,5 @@
-Listen {{ env.IPXE_TLS_PORT }}
+Listen 0.0.0.0:{{ env.IPXE_TLS_PORT }}
+Listen [::]:{{ env.IPXE_TLS_PORT }}
 
 <VirtualHost *:{{ env.IPXE_TLS_PORT }}>
     ErrorLog /dev/stderr

--- a/ironic-config/apache2-vmedia.conf.j2
+++ b/ironic-config/apache2-vmedia.conf.j2
@@ -1,4 +1,5 @@
-Listen {{ env.VMEDIA_TLS_PORT }}
+Listen 0.0.0.0:{{ env.VMEDIA_TLS_PORT }}
+Listen [::]:{{ env.VMEDIA_TLS_PORT }}
 
 <VirtualHost *:{{ env.VMEDIA_TLS_PORT }}>
     ErrorLog /dev/stderr

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -42,12 +42,12 @@ dhcp-option={{ opt }}
 dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9
 # Client is (i)PXE booting on EFI machine
-dhcp-boot=tag:efi,/{{ env.SNP_BASENAME }}-x86_64.efi,{{ env.IRONIC_IP }}
+dhcp-boot=tag:efi,/{{ env.SNP_BASENAME }}-x86_64.efi,{{ env.IRONIC_IPV4 }}
 # Client is (i)PXE booting on arm64 EFI machine
 dhcp-match=set:efi-arm64,option:client-arch,11
-dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IP }}
+dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IPV4 }}
 # Client is running (i)PXE on BIOS machine
-dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IP }}
+dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IPV4 }}
 {%- if env.IPXE_TLS_SETUP != "true" %}
 dhcp-boot=tag:ipxe,http://{{ env.IRONIC_IPV4 }}:{{ env.HTTP_PORT }}/boot.ipxe
 {% endif %}

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -15,17 +15,13 @@ dhcp-range={{ item }}
 {%- endfor %}
 {% endif %}
 
-{%- if env["DNS_IP"] is undefined %}
-# Disable DNS over provisioning network
-dhcp-option=6
-{% else %}
-dhcp-option=option{% if ":" in env["DNS_IP"] %}6{% endif %}:dns-server,{{ env["DNS_IP"] }}
-{% endif %}
-
 {# Network boot options for IPv4 and IPv6 #}
-{%- if env.IPV == "4" or env.IPV is undefined %}
+{%- if env.ENABLE_IPV4 %}
 # IPv4 Configuration:
 dhcp-match=ipxe,175
+
+# Either set the DNS option with DNS_IPV4 or disable the option
+dhcp-option=option:dns-server{% if env.DNS_IPV4 %},{{ env.DNS_IPV4 }}{% endif %}
 
 {# Set the router or disable it. Setting router is IPv4 specific, in v6 there #}
 {# are router advertisements that do the same thing. #}
@@ -53,14 +49,17 @@ dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IP }}
 # Client is running (i)PXE on BIOS machine
 dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IP }}
 {%- if env.IPXE_TLS_SETUP != "true" %}
-dhcp-boot=tag:ipxe,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
+dhcp-boot=tag:ipxe,http://{{ env.IRONIC_IPV4 }}:{{ env.HTTP_PORT }}/boot.ipxe
 {% endif %}
 {% endif %}
 
-{% if env.IPV == "6" %}
+{%- if env.ENABLE_IPV6 %}
 # IPv6 Configuration:
 enable-ra
 ra-param={{ env.PROVISIONING_INTERFACE }},0,0
+
+# Either set the DNS option with DNS_IPV6 or disable the option
+dhcp-option=option6:dns-server{% if env.DNS_IPV6 %},[{{ env.DNS_IPV6 }}]{% endif %}
 
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -49,7 +49,12 @@ dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IPV4 }}
 # Client is running (i)PXE on BIOS machine
 dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IPV4 }}
 {%- if env.IPXE_TLS_SETUP != "true" %}
+# Leverage hostname based URLs if available, use an IPv4 address otherwise
+{% if env.IRONIC_URL_HOSTNAME is defined and env.IRONIC_URL_HOSTNAME|length %}
+dhcp-boot=tag:ipxe,{{IRONIC_HTTP_URL}}/boot.ipxe
+{% else %}
 dhcp-boot=tag:ipxe,http://{{ env.IRONIC_IPV4 }}:{{ env.HTTP_PORT }}/boot.ipxe
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -15,8 +15,14 @@
 Listen {{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
- <VirtualHost {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}>
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
+{% endif %}
 {% endif %}
 
     DocumentRoot "/shared/html"

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -12,7 +12,8 @@
 
 
 {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.IRONIC_LISTEN_PORT }}
+Listen 0.0.0.0:{{ env.IRONIC_LISTEN_PORT }}
+Listen [::]:{{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
 {% if env.ENABLE_IPV4 %}

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -22,6 +22,9 @@ Listen {{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}
 {% if env.ENABLE_IPV6 %}
 Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
 {% endif %}
+{% if env.IRONIC_URL_HOSTNAME is defined and env.IRONIC_URL_HOSTNAME|length %}
+<VirtualHost {{ env.IRONIC_URL_HOSTNAME }}:{{ env.IRONIC_LISTEN_PORT }}>
+{% else %}
 <VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
 {% endif %}
 {% endif %}

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -17,12 +17,12 @@ Listen [::]:{{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
 {% if env.ENABLE_IPV4 %}
-Listen {{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}
+Listen {{ env.IRONIC_IPV4 }}:{{ env.IRONIC_LISTEN_PORT }}
 {% endif %}
 {% if env.ENABLE_IPV6 %}
 Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
 {% endif %}
-<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
+<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IPV4 }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
 {% endif %}
 
     DocumentRoot "/shared/html"

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -12,11 +12,17 @@
 
 
 {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.IRONIC_LISTEN_PORT }}
+Listen 0.0.0.0:{{ env.IRONIC_LISTEN_PORT }}
+Listen [::]:{{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
- <VirtualHost {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}>
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
 {% endif %}
 
     DocumentRoot "/shared/html"

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -22,6 +22,9 @@ Listen {{ env.IRONIC_IPV4 }}:{{ env.IRONIC_LISTEN_PORT }}
 {% if env.ENABLE_IPV6 %}
 Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
 {% endif %}
+{% if env.IRONIC_URL_HOSTNAME is defined and env.IRONIC_URL_HOSTNAME|length %}
+<VirtualHost {{ env.IRONIC_URL_HOSTNAME }}:{{ env.IRONIC_LISTEN_PORT }}>
+{% else %}
 <VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IPV4 }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
 {% endif %}
 

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -2,7 +2,12 @@ ServerRoot {{ env.HTTPD_DIR }}
 {%- if env.LISTEN_ALL_INTERFACES | lower == "true" %}
 Listen {{ env.HTTP_PORT }}
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.HTTP_PORT }}
+{% endif %}
 {% endif %}
 Include /etc/httpd/conf.modules.d/*.conf
 User apache

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -1,8 +1,14 @@
 ServerRoot {{ env.HTTPD_DIR }}
 {%- if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.HTTP_PORT }}
+Listen 0.0.0.0:{{ env.HTTP_PORT }}
+Listen [::]:{{ env.HTTP_PORT }}
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.HTTP_PORT }}
+{% endif %}
 {% endif %}
 Include /etc/httpd/conf.modules.d/*.conf
 User apache

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -1,6 +1,7 @@
 ServerRoot {{ env.HTTPD_DIR }}
 {%- if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.HTTP_PORT }}
+Listen 0.0.0.0:{{ env.HTTP_PORT }}
+Listen [::]:{{ env.HTTP_PORT }}
 {% else %}
 {% if env.ENABLE_IPV4 %}
 Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -4,7 +4,7 @@ Listen 0.0.0.0:{{ env.HTTP_PORT }}
 Listen [::]:{{ env.HTTP_PORT }}
 {% else %}
 {% if env.ENABLE_IPV4 %}
-Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}
+Listen {{ env.IRONIC_IPV4 }}:{{ env.HTTP_PORT }}
 {% endif %}
 {% if env.ENABLE_IPV6 %}
 Listen [{{ env.IRONIC_IPV6 }}]:{{ env.HTTP_PORT }}

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -68,7 +68,7 @@ port = {{ env.IRONIC_PRIVATE_PORT }}
 {% endif %}
 public_endpoint = {{ env.IRONIC_BASE_URL }}
 {% else %}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_HOST_IP }}
 port = {{ env.IRONIC_LISTEN_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 enable_ssl_api = true
@@ -186,7 +186,7 @@ cipher_suite_versions = 3,17
 # containers are in host networking.
 auth_strategy = http_basic
 http_basic_auth_user_file = {{ env.IRONIC_RPC_HTPASSWD_FILE }}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_HOST_IP }}
 port = {{ env.IRONIC_JSON_RPC_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 use_ssl = true

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -25,7 +25,13 @@ rpc_transport = none
 use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
+{% if env.ENABLE_IPV4 %}
 my_ip = {{ env.IRONIC_IP }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+my_ipv6 = {{ env.IRONIC_IPV6 }}
+{% endif %}
+
 host = {{ env.IRONIC_CONDUCTOR_HOST }}
 
 # If a path to a certificate is defined, use that first for webserver

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -33,7 +33,13 @@ rpc_transport = none
 use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
+{% if env.ENABLE_IPV4 %}
 my_ip = {{ env.IRONIC_IP }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+my_ipv6 = {{ env.IRONIC_IPV6 }}
+{% endif %}
+
 host = {{ env.IRONIC_CONDUCTOR_HOST }}
 
 # If a path to a certificate is defined, use that first for webserver
@@ -79,7 +85,7 @@ port = {{ env.IRONIC_PRIVATE_PORT }}
 {% endif %}
 public_endpoint = {{ env.IRONIC_BASE_URL }}
 {% else %}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_LISTEN_ADDRESS }}
 port = {{ env.IRONIC_LISTEN_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 enable_ssl_api = true
@@ -206,7 +212,7 @@ cipher_suite_versions = 3,17
 # containers are in host networking.
 auth_strategy = http_basic
 http_basic_auth_user_file = {{ env.IRONIC_RPC_HTPASSWD_FILE }}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_LISTEN_ADDRESS }}
 port = {{ env.IRONIC_JSON_RPC_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 use_ssl = true

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -34,7 +34,7 @@ use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
 {% if env.ENABLE_IPV4 %}
-my_ip = {{ env.IRONIC_IP }}
+my_ip = {{ env.IRONIC_IPV4 }}
 {% endif %}
 {% if env.ENABLE_IPV6 %}
 my_ipv6 = {{ env.IRONIC_IPV6 }}

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -12,3 +12,4 @@ sqlite
 syslinux-nonlinux
 util-linux
 xorriso
+bind-utils

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -13,3 +13,4 @@ sqlite
 tar
 util-linux
 xorriso
+bind-utils

--- a/scripts/configure-ironic-networking.sh
+++ b/scripts/configure-ironic-networking.sh
@@ -35,8 +35,8 @@ export NO_PROXY="${NO_PROXY:-}"
 if [[ -n "${IRONIC_IPV6}" ]]; then
     export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
 fi
-if [[ -n "${IRONIC_IP}" ]]; then
-    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+if [[ -n "${IRONIC_IPV4}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV4}"
 fi
 
 # Ensure driver config directory exists

--- a/scripts/configure-ironic-networking.sh
+++ b/scripts/configure-ironic-networking.sh
@@ -30,7 +30,14 @@ render_j2_config "/etc/ironic/ironic-networking.conf.j2" \
 configure_json_rpc_auth "ironic_networking_json_rpc"
 
 # Make sure ironic traffic bypasses any proxies
-export NO_PROXY="${NO_PROXY:-},${IRONIC_IP}"
+export NO_PROXY="${NO_PROXY:-}"
+
+if [[ -n "${IRONIC_IPV6}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
+fi
+if [[ -n "${IRONIC_IP}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+fi
 
 # Ensure driver config directory exists
 mkdir -p "${IRONIC_NETWORKING_DRIVER_CONFIG_DIR}"

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -136,4 +136,11 @@ render_j2_config "/etc/ironic/ironic.conf.j2" \
 configure_json_rpc_auth
 
 # Make sure ironic traffic bypasses any proxies
-export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"
+export NO_PROXY="${NO_PROXY:-}"
+
+if [[ -n "${IRONIC_IPV6}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
+fi
+if [[ -n "${IRONIC_IP}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+fi

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -49,6 +49,12 @@ export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
 
 wait_for_interface_or_ip
 
+if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+    export IRONIC_HOST_IP="::"
+else
+    export IRONIC_HOST_IP="${IRONIC_IP}"
+fi
+
 # Hostname to use for the current conductor instance.
 export IRONIC_CONDUCTOR_HOST=${IRONIC_CONDUCTOR_HOST:-${IRONIC_URL_HOST}}
 

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -51,6 +51,8 @@ wait_for_interface_or_ip
 
 if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
     export IRONIC_HOST_IP="::"
+elif [[ -n "${ENABLE_IPV6}" ]]; then
+    export IRONIC_HOST_IP="${IRONIC_IPV6}"
 else
     export IRONIC_HOST_IP="${IRONIC_IP}"
 fi

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -112,4 +112,11 @@ if [[ "${IRONIC_NETWORKING_ENABLED}" == "true" ]]; then
 fi
 
 # Make sure ironic traffic bypasses any proxies
-export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"
+export NO_PROXY="${NO_PROXY:-}"
+
+if [[ -n "${IRONIC_IPV6}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
+fi
+if [[ -n "${IRONIC_IP}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+fi

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -55,7 +55,7 @@ if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true
 elif [[ -n "${ENABLE_IPV6}" ]]; then
     export IRONIC_LISTEN_ADDRESS="${IRONIC_IPV6}"
 else
-    export IRONIC_LISTEN_ADDRESS="${IRONIC_IP}"
+    export IRONIC_LISTEN_ADDRESS="${IRONIC_IPV4}"
 fi
 
 # Hostname to use for the current conductor instance.
@@ -125,6 +125,6 @@ export NO_PROXY="${NO_PROXY:-}"
 if [[ -n "${IRONIC_IPV6}" ]]; then
     export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
 fi
-if [[ -n "${IRONIC_IP}" ]]; then
-    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+if [[ -n "${IRONIC_IPV4}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV4}"
 fi

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -50,6 +50,14 @@ export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
 
 wait_for_interface_or_ip
 
+if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+    export IRONIC_LISTEN_ADDRESS="::"
+elif [[ -n "${ENABLE_IPV6}" ]]; then
+    export IRONIC_LISTEN_ADDRESS="${IRONIC_IPV6}"
+else
+    export IRONIC_LISTEN_ADDRESS="${IRONIC_IP}"
+fi
+
 # Hostname to use for the current conductor instance.
 export IRONIC_CONDUCTOR_HOST=${IRONIC_CONDUCTOR_HOST:-${IRONIC_URL_HOST}}
 

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -114,10 +114,20 @@ parse_ip_address()
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 wait_for_interface_or_ip()
 {
-    # If $PROVISIONING_IP is specified, then we wait for that to become
-    # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
-    # for an IP
-    if [[ -n "${PROVISIONING_IP}" ]]; then
+    # IRONIC_IP already defined overrides everything else
+    if [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_IP}" ]]; then
+        # If $PROVISIONING_IP is specified, then we wait for that to become
+        # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
+        # for an IP
         local PARSED_IP
         PARSED_IP="$(parse_ip_address "${PROVISIONING_IP}")"
         if [[ -z "${PARSED_IP}" ]]; then
@@ -135,15 +145,6 @@ wait_for_interface_or_ip()
         echo "Found ${PROVISIONING_IP} on interface \"${IFACE_OF_IP}\"!"
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
-        export IRONIC_IP="${PARSED_IP}"
-    elif [[ -n "${IRONIC_IP}" ]]; then
-        local PARSED_IP
-        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
-        if [[ -z "${PARSED_IP}" ]]; then
-            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
-            exit 1
-        fi
-
         export IRONIC_IP="${PARSED_IP}"
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -48,12 +48,6 @@ get_provisioning_interface()
 
     local interface="provisioning"
 
-    if [[ -n "${PROVISIONING_IP}" ]]; then
-        if ip -br addr show | grep -i " ${PROVISIONING_IP}/" &>/dev/null; then
-            interface="$(ip -br addr show | grep -i " ${PROVISIONING_IP}/" | cut -f 1 -d ' ' | cut -f 1 -d '@')"
-        fi
-    fi
-
     for mac in ${PROVISIONING_MACS//,/ }; do
         if ip -br link show up | grep -i "$mac" &>/dev/null; then
             interface="$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ' | cut -f 1 -d '@')"

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -46,7 +46,7 @@ get_provisioning_interface()
         return
     fi
 
-    local interface="provisioning"
+    local interface=""
 
     for mac in ${PROVISIONING_MACS//,/ }; do
         if ip -br link show up | grep -i "$mac" &>/dev/null; then
@@ -136,13 +136,25 @@ wait_for_interface_or_ip()
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
         export IRONIC_IP="${PARSED_IP}"
-    else
+    elif [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             IRONIC_IP="$(ip -br add show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)"
             export IRONIC_IP
             sleep 1
         done
+    else
+        echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
+        return 1
     fi
 
     # If the IP contains a colon, then it's an IPv6 address, and the HTTP

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -131,10 +131,20 @@ parse_ip_address()
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 wait_for_interface_or_ip()
 {
-    # If $PROVISIONING_IP is specified, then we wait for that to become
-    # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
-    # for an IP
-    if [[ -n "${PROVISIONING_IP}" ]]; then
+    # IRONIC_IP already defined overrides everything else
+    if [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_IP}" ]]; then
+        # If $PROVISIONING_IP is specified, then we wait for that to become
+        # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
+        # for an IP
         local PARSED_IP
         PARSED_IP="$(parse_ip_address "${PROVISIONING_IP}")"
         if [[ -z "${PARSED_IP}" ]]; then
@@ -152,15 +162,6 @@ wait_for_interface_or_ip()
         echo "Found ${PROVISIONING_IP} on interface \"${IFACE_OF_IP}\"!"
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
-        export IRONIC_IP="${PARSED_IP}"
-    elif [[ -n "${IRONIC_IP}" ]]; then
-        local PARSED_IP
-        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
-        if [[ -z "${PARSED_IP}" ]]; then
-            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
-            exit 1
-        fi
-
         export IRONIC_IP="${PARSED_IP}"
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -153,13 +153,25 @@ wait_for_interface_or_ip()
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
         export IRONIC_IP="${PARSED_IP}"
-    else
+    elif [[ -n "${IRONIC_IP}" ]]; then
+        local PARSED_IP
+        PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
+        if [[ -z "${PARSED_IP}" ]]; then
+            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            exit 1
+        fi
+
+        export IRONIC_IP="${PARSED_IP}"
+    elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         until [[ -n "$IRONIC_IP" ]]; do
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             IRONIC_IP="$(ip -br addr show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)"
             export IRONIC_IP
             sleep 1
         done
+    else
+        echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
+        return 1
     fi
 
     # If the IP contains a colon, then it's an IPv6 address, and the HTTP

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 # Export IRONIC_IP to avoid needing to lean on IRONIC_URL_HOST for consumption in
 # e.g. dnsmasq configuration
 export IRONIC_IP="${IRONIC_IP:-}"
+export IRONIC_IPV6=""
 PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
 PROVISIONING_IP="${PROVISIONING_IP:-}"
 PROVISIONING_MACS="${PROVISIONING_MACS:-}"
@@ -87,6 +88,33 @@ export PROVISIONING_INTERFACE
 
 export LISTEN_ALL_INTERFACES="${LISTEN_ALL_INTERFACES:-true}"
 
+get_ip_of_interface()
+{
+    local IP_VERS
+    local IP_ADDR
+
+    if [[ $# -gt 2 ]]; then
+        echo "ERROR: ${FUNCNAME[0]}: too many parameters" >&2
+        exit 1
+    fi
+
+    if [[ $# -eq 2 ]]; then
+        case "$2" in
+        4|6)
+            IP_VERS="-$2"
+            ;;
+        *)
+            echo "ERROR: ${FUNCNAME[0]}: the second parameter should be [4|6] (or missing for both)" >&2
+            exit 1
+            ;;
+        esac
+    fi
+
+    IFACE="$1"
+
+    ip "${IP_VERS[@]}" -br addr show scope global up dev "${IFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1
+}
+
 get_interface_of_ip()
 {
     if [[ $# -lt 1 ]] || [[ $# -gt 2 ]]; then
@@ -140,7 +168,12 @@ wait_for_interface_or_ip()
             exit 1
         fi
 
-        export IRONIC_IP="${PARSED_IP}"
+        if [[ "${PARSED_IP}" =~ .*:.* ]]; then
+            export IRONIC_IPV6="${PARSED_IP}"
+            unset IRONIC_IP
+        else
+            export IRONIC_IP="${PARSED_IP}"
+        fi
     elif [[ -n "${PROVISIONING_IP}" ]]; then
         # If $PROVISIONING_IP is specified, then we wait for that to become
         # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
@@ -162,27 +195,45 @@ wait_for_interface_or_ip()
         echo "Found ${PROVISIONING_IP} on interface \"${IFACE_OF_IP}\"!"
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
-        export IRONIC_IP="${PARSED_IP}"
+        if [[ "${PARSED_IP}" =~ .*:.* ]]; then
+            export IRONIC_IPV6="${PARSED_IP}"
+        else
+            export IRONIC_IP="${PARSED_IP}"
+        fi
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
-        until [[ -n "$IRONIC_IP" ]]; do
-            echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-            IRONIC_IP="$(ip -br addr show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)"
-            export IRONIC_IP
+        until [[ -n "${IRONIC_IPV6}" ]] || [[ -n "${IRONIC_IP}" ]]; do
+            echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured..."
+
+            IRONIC_IPV6="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 6)"
+            sleep 1
+
+            IRONIC_IP="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 4)"
             sleep 1
         done
+
+        # Add some debugging output
+        if [[ -n "${IRONIC_IPV6}" ]]; then
+            echo "Found ${IRONIC_IPV6} on interface \"${PROVISIONING_INTERFACE}\"!"
+            export IRONIC_IPV6
+        fi
+        if [[ -n "${IRONIC_IP}" ]]; then
+            echo "Found ${IRONIC_IP} on interface \"${PROVISIONING_INTERFACE}\"!"
+            export IRONIC_IP
+        fi
     else
         echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
         return 1
     fi
 
-    # If the IP contains a colon, then it's an IPv6 address, and the HTTP
-    # host needs surrounding with brackets
-    if [[ "$IRONIC_IP" =~ .*:.* ]]; then
-        export IPV=6
-        export IRONIC_URL_HOST="[$IRONIC_IP]"
-    else
-        export IPV=4
-        export IRONIC_URL_HOST="$IRONIC_IP"
+    # Define the URLs based on the what we have found,
+    # prioritize IPv6 for IRONIC_URL_HOST
+    if [[ -n "${IRONIC_IP}" ]]; then
+        export ENABLE_IPV4=yes
+        export IRONIC_URL_HOST="${IRONIC_IP}"
+    fi
+    if [[ -n "${IRONIC_IPV6}" ]]; then
+        export ENABLE_IPV6=yes
+        export IRONIC_URL_HOST="[${IRONIC_IPV6}]" # The HTTP host needs surrounding with brackets
     fi
 
     # Avoid having to construct full URL multiple times while allowing

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -109,7 +109,7 @@ get_ip_of_hostname()
 
     local HOSTNAME="$1"
 
-    echo "$(nslookup -type=${QUERY} "${HOSTNAME}" | tail -n2 | grep -w "Address:" | cut -d " " -f2)"
+    nslookup -type=${QUERY} "${HOSTNAME}" | tail -n2 | grep -w "Address:" | cut -d " " -f2
 }
 
 get_ip_of_interface()
@@ -249,12 +249,12 @@ wait_for_interface_or_ip()
         local IPV4_RECORD
 
         # we should get at least one IP address
-        IPV6_RECORD="$(get_ip_of_hostname ${IRONIC_URL_HOSTNAME} 6)"
-        IPV4_RECORD="$(get_ip_of_hostname ${IRONIC_URL_HOSTNAME} 4)"
+        IPV6_RECORD="$(get_ip_of_hostname "${IRONIC_URL_HOSTNAME}" 6)"
+        IPV4_RECORD="$(get_ip_of_hostname "${IRONIC_URL_HOSTNAME}" 4)"
 
         # We couldn't get any IP
         if [[ -z "${IPV4_RECORD}" ]] && [[ -z "${IPV6_RECORD}" ]]; then
-            echo "${FUNCNAME}: no valid IP found for hostname \"${IRONIC_URL_HOSTNAME}\""
+            echo "${FUNCNAME[0]}: no valid IP found for hostname \"${IRONIC_URL_HOSTNAME}\""
             return 1
         fi
 
@@ -264,11 +264,11 @@ wait_for_interface_or_ip()
 
             until [[ -n "${IPV6_IFACE}" ]] || [[ -n "${IPV4_IFACE}" ]]; do
                 echo "Waiting for ${IPV6_RECORD} to be configured on an interface..."
-                IPV6_IFACE="$(get_interface_of_ip ${IPV6_RECORD} 6)"
+                IPV6_IFACE="$(get_interface_of_ip "${IPV6_RECORD}" 6)"
                 sleep 1
 
                 echo "Waiting for ${IPV4_RECORD} to be configured on an interface..."
-                IPV4_IFACE="$(get_interface_of_ip ${IPV4_RECORD} 4)"
+                IPV4_IFACE="$(get_interface_of_ip "${IPV4_RECORD}" 4)"
                 sleep 1
             done
 

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 # Export IRONIC_IP to avoid needing to lean on IRONIC_URL_HOST for consumption in
 # e.g. dnsmasq configuration
 export IRONIC_IP="${IRONIC_IP:-}"
+export IRONIC_IPV4=""
 export IRONIC_IPV6=""
 PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
 PROVISIONING_IP="${PROVISIONING_IP:-}"
@@ -172,7 +173,7 @@ wait_for_interface_or_ip()
             export IRONIC_IPV6="${PARSED_IP}"
             unset IRONIC_IP
         else
-            export IRONIC_IP="${PARSED_IP}"
+            export IRONIC_IPV4="${PARSED_IP}"
         fi
     elif [[ -n "${PROVISIONING_IP}" ]]; then
         # If $PROVISIONING_IP is specified, then we wait for that to become
@@ -198,16 +199,16 @@ wait_for_interface_or_ip()
         if [[ "${PARSED_IP}" =~ .*:.* ]]; then
             export IRONIC_IPV6="${PARSED_IP}"
         else
-            export IRONIC_IP="${PARSED_IP}"
+            export IRONIC_IPV4="${PARSED_IP}"
         fi
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
-        until [[ -n "${IRONIC_IPV6}" ]] || [[ -n "${IRONIC_IP}" ]]; do
+        until [[ -n "${IRONIC_IPV6}" ]] || [[ -n "${IRONIC_IPV4}" ]]; do
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured..."
 
             IRONIC_IPV6="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 6)"
             sleep 1
 
-            IRONIC_IP="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 4)"
+            IRONIC_IPV4="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 4)"
             sleep 1
         done
 
@@ -216,9 +217,9 @@ wait_for_interface_or_ip()
             echo "Found ${IRONIC_IPV6} on interface \"${PROVISIONING_INTERFACE}\"!"
             export IRONIC_IPV6
         fi
-        if [[ -n "${IRONIC_IP}" ]]; then
-            echo "Found ${IRONIC_IP} on interface \"${PROVISIONING_INTERFACE}\"!"
-            export IRONIC_IP
+        if [[ -n "${IRONIC_IPV4}" ]]; then
+            echo "Found ${IRONIC_IPV4} on interface \"${PROVISIONING_INTERFACE}\"!"
+            export IRONIC_IPV4
         fi
     else
         echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
@@ -227,9 +228,9 @@ wait_for_interface_or_ip()
 
     # Define the URLs based on the what we have found,
     # prioritize IPv6 for IRONIC_URL_HOST
-    if [[ -n "${IRONIC_IP}" ]]; then
+    if [[ -n "${IRONIC_IPV4}" ]]; then
         export ENABLE_IPV4=yes
-        export IRONIC_URL_HOST="${IRONIC_IP}"
+        export IRONIC_URL_HOST="${IRONIC_IPV4}"
     fi
     if [[ -n "${IRONIC_IPV6}" ]]; then
         export ENABLE_IPV6=yes

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -10,6 +10,7 @@ export IRONIC_IPV6=""
 PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
 PROVISIONING_IP="${PROVISIONING_IP:-}"
 PROVISIONING_MACS="${PROVISIONING_MACS:-}"
+IRONIC_URL_HOSTNAME="${IRONIC_URL_HOSTNAME:-}"
 IPXE_CUSTOM_FIRMWARE_DIR="${IPXE_CUSTOM_FIRMWARE_DIR:-/shared/custom_ipxe_firmware}"
 # Basename of the EFI iPXE binaries (<basename>-x86_64.efi / <basename>-arm64.efi).
 # Upstream builds them as "snponly"; distros packaging iPXE differently (e.g.
@@ -88,6 +89,28 @@ PROVISIONING_INTERFACE="$(get_provisioning_interface)"
 export PROVISIONING_INTERFACE
 
 export LISTEN_ALL_INTERFACES="${LISTEN_ALL_INTERFACES:-true}"
+
+get_ip_of_hostname()
+{
+    if [[ "$#" -ne 2 ]]; then
+        echo "ERROR: ${FUNCNAME[0]}: two parameters required, $# provided" >&2
+        return 1
+    fi
+
+    case "$2" in
+        4)
+            QUERY="a";;
+        6)
+            QUERY="aaaa";;
+        *)
+            echo "ERROR: ${FUNCNAME[0]}: the second parameter should be <4|6> for A and AAAA records" >&2
+            return 1;;
+    esac
+
+    local HOSTNAME="$1"
+
+    echo "$(nslookup -type=${QUERY} "${HOSTNAME}" | tail -n2 | grep -w "Address:" | cut -d " " -f2)"
+}
 
 get_ip_of_interface()
 {
@@ -221,6 +244,51 @@ wait_for_interface_or_ip()
             echo "Found ${IRONIC_IPV4} on interface \"${PROVISIONING_INTERFACE}\"!"
             export IRONIC_IPV4
         fi
+    elif [[ -n "${IRONIC_URL_HOSTNAME}" ]]; then
+        local IPV6_RECORD
+        local IPV4_RECORD
+
+        # we should get at least one IP address
+        IPV6_RECORD="$(get_ip_of_hostname ${IRONIC_URL_HOSTNAME} 6)"
+        IPV4_RECORD="$(get_ip_of_hostname ${IRONIC_URL_HOSTNAME} 4)"
+
+        # We couldn't get any IP
+        if [[ -z "${IPV4_RECORD}" ]] && [[ -z "${IPV6_RECORD}" ]]; then
+            echo "${FUNCNAME}: no valid IP found for hostname \"${IRONIC_URL_HOSTNAME}\""
+            return 1
+        fi
+
+        if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+            local IPV6_IFACE=""
+            local IPV4_IFACE=""
+
+            until [[ -n "${IPV6_IFACE}" ]] || [[ -n "${IPV4_IFACE}" ]]; do
+                echo "Waiting for ${IPV6_RECORD} to be configured on an interface..."
+                IPV6_IFACE="$(get_interface_of_ip ${IPV6_RECORD} 6)"
+                sleep 1
+
+                echo "Waiting for ${IPV4_RECORD} to be configured on an interface..."
+                IPV4_IFACE="$(get_interface_of_ip ${IPV4_RECORD} 4)"
+                sleep 1
+            done
+
+            # Add some debugging output
+            if [[ -n "${IPV6_IFACE}" ]]; then
+                echo "Found ${IPV6_RECORD} on interface \"${IPV6_IFACE}\"!"
+            fi
+            if [[ -n "$IPV4_IFACE" ]]; then
+                echo "Found ${IPV4_RECORD} on interface \"${IPV4_IFACE}\"!"
+            fi
+
+            # Make sure both IPs are asigned to the same interface
+            if [[ -n "${IPV6_IFACE}" ]] && [[ -n "${IPV4_IFACE}" ]] && [[ "${IPV6_IFACE}" != "${IPV4_IFACE}" ]]; then
+                echo "Warning, the IPv4 and IPv6 addresses from \"${HOSTNAME}\" are assigned to different " \
+                "interfaces (\"${IPV6_IFACE}\" and \"${IPV4_IFACE}\")" >&2
+            fi
+
+            export IRONIC_IPV6="${IPV6_RECORD}"
+            export IRONIC_IPV4="${IPV4_RECORD}"
+        fi
     else
         echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
         return 1
@@ -235,6 +303,11 @@ wait_for_interface_or_ip()
     if [[ -n "${IRONIC_IPV6}" ]]; then
         export ENABLE_IPV6=yes
         export IRONIC_URL_HOST="[${IRONIC_IPV6}]" # The HTTP host needs surrounding with brackets
+    fi
+
+    # Once determined if we have IPv4 and/or IPv6, override the hostname if provided
+    if [[ -n "${IRONIC_URL_HOSTNAME}" ]]; then
+        IRONIC_URL_HOST=${IRONIC_URL_HOSTNAME}
     fi
 
     # Avoid having to construct full URL multiple times while allowing

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -15,7 +15,7 @@ wait_for_interface_or_ip
 if [[ -n "${DNS_IP}" ]]; then
   if [[ "${DNS_IP}" == "provisioning" ]]; then
       if [[ -n "${ENABLE_IPV4}" ]]; then
-        export DNS_IPV4="${IRONIC_IP}"
+        export DNS_IPV4="${IRONIC_IPV4}"
       fi
       if [[ -n "${ENABLE_IPV6}" ]]; then
         export DNS_IPV6="${IRONIC_IPV6}"

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -12,12 +12,22 @@ TFTP_BOOT_DIR="/shared/tftpboot"
 export DNS_PORT=${DNS_PORT:-0}
 
 wait_for_interface_or_ip
-if [[ "${DNS_IP:-}" == "provisioning" ]]; then
-    if [[ "${IPV}" == "4" ]]; then
-      export DNS_IP="${IRONIC_IP}"
+if [[ -n "${DNS_IP}" ]]; then
+  if [[ "${DNS_IP}" == "provisioning" ]]; then
+      if [[ -n "${ENABLE_IPV4}" ]]; then
+        export DNS_IPV4="${IRONIC_IP}"
+      fi
+      if [[ -n "${ENABLE_IPV6}" ]]; then
+        export DNS_IPV6="${IRONIC_IPV6}"
+      fi
+  else
+    #TODO(mchiappero): perform input validation with "parse_ip_address()" first
+    if [[ "${DNS_IP}" =~ .*:.* ]]; then
+      export DNS_IPV6=${DNS_IP}
     else
-      export DNS_IP="[${IRONIC_IP}]"
+      export DNS_IPV4=${DNS_IP}
     fi
+  fi
 fi
 
 mkdir -p "${TFTP_BOOT_DIR}"


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #789 introduced the ability to create IPv4 and IPv6 sockets for Apache, but is limited in the ability to provide true dual-stack behavior with respect to the Ironic API endpoints. Introduce the a new environment variable, IRONIC_URL_HOST, which can contain an hostname which resolves to at least an IPv4 or an IPv6 address. When both are present, the client has the option to connect with whichever version is actually in use or preferred.

This design allows to also bind the servers to the IP addresses the hostname resolves to, when LISTEN_ALL_INTERFACES is not true, which means that such IPs will be searched for on the system when starting. Setting LISTEN_ALL_INTERFACES to true results in Apache binding on IPv4 and/or IPv6 according to the resolved IPs, but not to look for those IPs on the systems. This is to mimic the behavior of IRONIC_IP.

NOTE: depends on PR #1060.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
