### PR TITLE
:seedling: improve Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,13 +13,19 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "automerge": false,
+  "labels": [
+    "ok-to-test"
+  ],
+  "commitMessagePrefix": ":seedling: ",
+  "semanticCommits": "disabled",
   "packageRules": [
     {
       "matchBaseBranches": [
         "main"
       ],
+      "description": "run before 6am on Mondays",
       "schedule": [
-        "before 3am on Monday"
+        "* 0-5 * * 1"
       ]
     },
     {
@@ -28,8 +34,9 @@
         "release-31.0",
         "release-32.0"
       ],
+      "description": "run before 6am every day",
       "schedule": [
-        "after 12am and before 2am"
+        "* 0-5 * * *"
       ]
     }
   ],
@@ -46,7 +53,8 @@
       "depNameTemplate": "openstack-ironic",
       "packageNameTemplate": "https://opendev.org/openstack/ironic.git",
       "versioningTemplate": "loose",
-      "autoReplaceStringTemplate": "ARG IRONIC_SOURCE={{#if newDigest}}{{{newDigest}}}{{else}}{{{newValue}}}{{/if}} # {{{currentValue}}}"
+      "autoReplaceStringTemplate": "ARG IRONIC_SOURCE={{#if newDigest}}{{{newDigest}}}{{else}}{{{newValue}}}{{/if}} # {{{currentValue}}}",
+      "changelogUrlTemplate": "https://github.com/openstack/ironic/compare/{{{currentDigest}}}...{{{newDigest}}}"
     }
   ]
 }


### PR DESCRIPTION
This makes Renovate:
- automatically add :seedling: for PR title verifier workflow
- prevents Renovate renaming the title if someone modifies it
- adds changelog entry for easy upstream diff viewing
- adds "ok-to-test" label to allow running tests
- use recommended cron style scheduling, and extend the update window for releases to 6am

Fixes: #796
