### PR TITLE
🐛 Guard against empty BMC CA volume

### DIFF
--- a/scripts/runironic
+++ b/scripts/runironic
@@ -15,7 +15,7 @@ configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" ironic "${IRONIC_C
 
 configure_ironic_auth
 
-if [[ -d "${BMC_CACERTS_PATH}" ]]; then
+if [[ "${BMC_TLS_ENABLED}" == "true" ]]; then
     # shellcheck disable=SC2034
     watchmedo shell-command \
         --patterns="*" \

--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -121,7 +121,7 @@ configure_restart_on_certificate_update()
     fi
 }
 
-if [ -d "${BMC_CACERTS_PATH}" ]; then
+if ls "${BMC_CACERTS_PATH}"/* > /dev/null 2>&1; then
     export BMC_TLS_ENABLED="true"
     cat "${BMC_CACERTS_PATH}"/* > "${BMC_CACERT_FILE}"
 else


### PR DESCRIPTION
If the ConfigMap is mounted as optional, it will end up in an empty
directory, and `cat dir/*` will fail on it.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
