### PR TITLE
:bug: Set the default IRONIC_CACERT_FILE path under /conf for readOnlyFilesystem

### DIFF
--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -70,6 +70,8 @@ if [[ -f "$IRONIC_CERT_FILE" ]] || [[ -f "$IRONIC_CACERT_FILE" ]]; then
     export IRONIC_TLS_SETUP="true"
     export IRONIC_SCHEME="https"
     if [[ ! -f "$IRONIC_CACERT_FILE" ]]; then
+        # For missing cacert file, change the var to writable path
+        export IRONIC_CACERT_FILE=/conf/certs/ca/ironic/tls.crt
         mkdir -p "$(dirname "${IRONIC_CACERT_FILE}")"
         copy_atomic "$IRONIC_CERT_FILE" "$IRONIC_CACERT_FILE"
     fi


### PR DESCRIPTION
Right now, we have `IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt` which creates an issue, due to that path being readOnly, when [copying cert to ca_cert](https://github.com/metal3-io/ironic-image/blob/main/scripts/tls-common.sh#L74) in case of self-signed certs.
