### PR TITLE
🐛 fix: correct dhcp tag for ipv6 pxe

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -55,9 +55,9 @@ ra-param={{ env.PROVISIONING_INTERFACE }},0,0
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE
 # Client is (i)PXE booting on EFI machine
-dhcp-option=tag:efi,option6:bootfile-url,{{ env.IRONIC_URL_HOST }}/snponly.efi
+dhcp-option=tag:pxe6,option6:bootfile-url,tftp://{{ env.IRONIC_URL_HOST }}/snponly.efi
 # Client is running (i)PXE on BIOS machine
-dhcp-option=tag:!efi,option6:bootfile-url,{{ env.IRONIC_URL_HOST }}/undionly.kpxe
+dhcp-option=tag:!pxe6,option6:bootfile-url,tftp://{{ env.IRONIC_URL_HOST }}/undionly.kpxe
 {%- if env.IPXE_TLS_SETUP != "true" %}
 dhcp-option=tag:ipxe6,option6:bootfile-url,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
 {% endif %}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Currently, when network booting using IPv6, wrong NBP file is sent to UEFI clients. This PR fixes this by using correct tag to hand out correct NBP depending on the client being BIOS / UEFI.
- `tftp://` scheme has also been added to the URLs sent back to clients

- This has been tested on bare metal UEFI client, BIOS testing would be appreciated.

Fixes #790

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Integration tests have been added, if necessary.
