### PR TITLE
:sparkles: add image SBOM attestation to image builds

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -15,10 +15,14 @@ jobs:
   build_ironic:
     name: Build Ironic container image with default base image
     if: github.repository == 'metal3-io/ironic-image'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: 'ironic'
       pushImage: true
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -26,11 +30,15 @@ jobs:
   build_ironic_cs10:
     name: Build Ironic container image with CentOS Stream 10
     if: github.repository == 'metal3-io/ironic-image'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: 'ironic_cs10'
       pushImage: true
       image-build-args: 'BASE_IMAGE=quay.io/centos/centos:stream10'
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -38,11 +46,15 @@ jobs:
   build_sushy-tools:
     name: Build sushy-tools image
     if: github.repository == 'metal3-io/ironic-image'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: 'sushy-tools'
       dockerfile-directory: resources/sushy-tools
       pushImage: true
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -50,11 +62,15 @@ jobs:
   build_vbmc:
     name: build vbmc image
     if: github.repository == 'metal3-io/ironic-image'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: 'vbmc'
       dockerfile-directory: resources/vbmc
       pushImage: true
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -62,11 +78,15 @@ jobs:
   build_client:
     name: build ironic-client image
     if: github.repository == 'metal3-io/ironic-image'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: 'ironic-client'
       dockerfile-directory: resources/ironic-client
       pushImage: true
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,6 +113,7 @@ jobs:
   build_ironic_image:
     permissions:
       contents: read
+      id-token: write
     needs: push_release_tags
     name: Build Ironic-image container image
     if: github.repository == 'metal3-io/ironic-image'
@@ -121,6 +122,7 @@ jobs:
       image-name: 'ironic'
       pushImage: true
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
@@ -128,6 +130,7 @@ jobs:
   build_ironic_image_cs10:
     permissions:
       contents: read
+      id-token: write
     needs: push_release_tags
     name: Build Ironic-image container image
     if: github.repository == 'metal3-io/ironic-image'
@@ -137,6 +140,7 @@ jobs:
       pushImage: true
       image-build-args: 'BASE_IMAGE=quay.io/centos/centos:stream10'
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Use reusable container build workflow from project-infra to enable image SBOM attestations to be attached to the image digest when any IPAM image is built.

For this, we need id-token permission for keyless signing and enabling the SBOM generation via flag.
