### PR TITLE
🐛 Fix missing changeLogUrl in Renovate customManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,7 +63,8 @@
       "depNameTemplate": "openstack-ironic",
       "packageNameTemplate": "https://github.com/openstack/ironic.git",
       "versioningTemplate": "loose",
-      "autoReplaceStringTemplate": "ARG IRONIC_SOURCE={{#if newDigest}}{{{newDigest}}}{{else}}{{{newValue}}}{{/if}} # {{{currentValue}}}"
+      "autoReplaceStringTemplate": "ARG IRONIC_SOURCE={{#if newDigest}}{{{newDigest}}}{{else}}{{{newValue}}}{{/if}} # {{{currentValue}}}",
+      "changelogUrl": "https://github.com/openstack/ironic/compare/{{currentDigest}}..{{newDigest}}"
     }
   ]
 }


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->


**What this PR does / why we need it**:
Adds `changelogUrl` configuration to the `customManagers` section for the openstack-ironic dependency. This ensures that Renovate PRs for ironic version updates include a changelog link comparing the old and new commit digests, making it easier to review what changed between versions.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #810

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
