### PR TITLE
🌱Enable bootc deploy interface

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -6,7 +6,7 @@ default_inspect_interface = agent
 default_network_interface = noop
 enabled_bios_interfaces = no-bios,redfish,idrac-redfish,irmc
 enabled_boot_interfaces = ipxe,pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,redfish-https
-enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent
+enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent,bootc
 enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.


### PR DESCRIPTION
**What this PR does / why we need it**:

This change[1] allows the direct deploy interface to be used for bootc images, and detection logic will switch to the bootc interface when required.

However for this to work, the bootc deploy interface needs to be enabled. This change does that for the Ironic image.

[1] https://review.opendev.org/c/openstack/ironic/+/966761

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
