### PR TITLE
:sparkles: Inject Ironic CA Cert in IPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ have sensible defaults):
 - `IRONIC_JSON_RPC_PORT` - port used by the ironic json-rpc service (default to
   6189).
 - `WEBSERVER_CACERT_FILE` - Specifies the CA or CA bundle that will be used
-  by Ironic to verify disk and IPA images.
+  by Ironic to verify disk and IPA images. Will also be used by IPA to verify
+  disk images and connection to Ironic if `IRONIC_IPA_INSECURE` is set to `0`.
 
 The following mountpoints can be passed in to customize run-time
 functionality:

--- a/ironic-config/inspector.ipxe.j2
+++ b/ironic-config/inspector.ipxe.j2
@@ -3,7 +3,7 @@
 echo In inspector.ipxe
 
 {%- macro kernel_cmdline(kernel_path, ramdisk_name) -%}
-kernel --timeout 60000 {{ kernel_path }} ipa-insecure={{ env.IRONIC_IPA_INSECURE | default('1') }} ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} systemd.journald.forward_to_console={{ env.IPA_FORWARD_CONSOLE | default('yes') }} BOOTIF=${mac} ipa-debug={{ env.IRONIC_IPA_DEBUG | default('1') }} ipa-enable-vlan-interfaces={{ env.IRONIC_ENABLE_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces={{ env.IRONIC_IPA_INSPECTION_DHCP_ALL_INTERFACES | default('1') }} ipa-collect-lldp={{ env.IRONIC_IPA_COLLECT_LLDP | default('1') }} {{ env.INSPECTOR_EXTRA_ARGS }} initrd={{ ramdisk_name }} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} || goto retry_boot
+kernel --timeout 60000 {{ kernel_path }} ipa-insecure={{ env.IRONIC_IPA_INSECURE | default('1') }} ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} systemd.journald.forward_to_console={{ env.IPA_FORWARD_CONSOLE | default('yes') }} BOOTIF=${mac} ipa-debug={{ env.IRONIC_IPA_DEBUG | default('1') }} ipa-enable-vlan-interfaces={{ env.IRONIC_ENABLE_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces={{ env.IRONIC_IPA_INSPECTION_DHCP_ALL_INTERFACES | default('1') }} ipa-collect-lldp={{ env.IRONIC_IPA_COLLECT_LLDP | default('1') }} {{ env.INSPECTOR_EXTRA_ARGS }} initrd={{ ramdisk_name }} {% if env.IRONIC_INJECT_IPA == 'true' %}initrd=ipa-cacert-bundle{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} || goto retry_boot
 {%- endmacro -%}
 
 {% if env.DEPLOY_KERNEL_BY_ARCH is defined %}
@@ -55,6 +55,9 @@ imgfree
 # ironic-inspector-image and configuration in configure-ironic.sh
 {{ kernel_cmdline('${ipa_kernel}', '${ipa_ramdisk_name}') }}
 initrd --timeout 60000 ${ipa_ramdisk} || goto retry_boot
+{%- if env.IRONIC_INJECT_IPA == 'true' %}
+initrd --timeout 60000 {{ env.IRONIC_IPA_BASE_URL }}/ipa-cacert-bundle || goto retry_boot
+{%- endif %}
 boot
 {% else %}
 :retry_boot
@@ -63,5 +66,8 @@ imgfree
 # ironic-inspector-image and configuration in configure-ironic.sh
 {{ kernel_cmdline(env.IRONIC_IPA_BASE_URL + '/images/ironic-python-agent.kernel', 'ironic-python-agent.initramfs') }}
 initrd --timeout 60000 {{ env.IRONIC_IPA_BASE_URL }}/images/ironic-python-agent.initramfs || goto retry_boot
+{%- if env.IRONIC_INJECT_IPA == 'true' %}
+initrd --timeout 60000 {{ env.IRONIC_IPA_BASE_URL }}/ipa-cacert-bundle || goto retry_boot
+{%- endif %}
 boot
 {% endif %}

--- a/ironic-config/ipxe_config.template
+++ b/ironic-config/ipxe_config.template
@@ -7,21 +7,29 @@ goto deploy
 
 :deploy
 imgfree
+{%- if ipxe_tls_setup %}
 {%- if pxe_options.deployment_aki_path %}
 {%- set aki_path_https_elements = pxe_options.deployment_aki_path.split(':') %}
 {%- set aki_port_and_path = aki_path_https_elements[2].split('/') %}
 {%- set aki_afterport = aki_port_and_path[1:]|join('/') %}
-{%- set aki_path_https = ['https:', aki_path_https_elements[1], ':8084/', aki_afterport]|join %}
+{%- set aki_path = ['https:', aki_path_https_elements[1], ':8084/', aki_afterport]|join %}
 {%- endif %}
 {%- if pxe_options.deployment_ari_path %}
 {%- set ari_path_https_elements = pxe_options.deployment_ari_path.split(':') %}
 {%- set ari_port_and_path = ari_path_https_elements[2].split('/') %}
 {%- set ari_afterport = ari_port_and_path[1:]|join('/') %}
-{%- set ari_path_https = ['https:', ari_path_https_elements[1], ':8084/', ari_afterport]|join %}
+{%- set ari_path = ['https:', ari_path_https_elements[1], ':8084/', ari_afterport]|join %}
 {%- endif %}
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ aki_path_https }} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }} BOOTIF=${mac} initrd={{ pxe_options.initrd_filename|default("deploy_ramdisk", true) }} || goto retry
+{%- else %}
+{%- set ari_path = pxe_options.deployment_ari_path %}
+{%- set aki_path = pxe_options.deployment_aki_path %}
+{%- endif %}
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ aki_path }} selinux=0 troubleshoot=0 text {{ pxe_options.pxe_append_params|default("", true) }} BOOTIF=${mac} initrd={{ pxe_options.initrd_filename|default("deploy_ramdisk", true) }} {% if inject_cacert_bundle %}initrd=ipa-cacert-bundle{% endif %} || goto retry
 
-initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ ari_path_https }} || goto retry
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ ari_path }} || goto retry
+{%- if inject_cacert_bundle %}
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %} ../ipa-cacert-bundle || goto retry
+{%- endif %}
 boot
 
 :retry
@@ -39,8 +47,8 @@ poweroff
 
 :boot_anaconda
 imgfree
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ aki_path_https }} text {{ pxe_options.pxe_append_params|default("", true) }} inst.ks={{ pxe_options.ks_cfg_url }} {% if pxe_options.repo_url %}inst.repo={{ pxe_options.repo_url }}{% else %}inst.stage2={{ pxe_options.stage2_url }}{% endif %} initrd=ramdisk || goto boot_anaconda
-initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ ari_path_https }} || goto boot_anaconda
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ aki_path }} text {{ pxe_options.pxe_append_params|default("", true) }} inst.ks={{ pxe_options.ks_cfg_url }} {% if pxe_options.repo_url %}inst.repo={{ pxe_options.repo_url }}{% else %}inst.stage2={{ pxe_options.stage2_url }}{% endif %} initrd=ramdisk || goto boot_anaconda
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ ari_path }} || goto boot_anaconda
 boot
 
 :boot_ramdisk
@@ -48,8 +56,8 @@ imgfree
 {%- if pxe_options.boot_iso_url %}
 sanboot {{ pxe_options.boot_iso_url }}
 {%- else %}
-kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ aki_path_https }} root=/dev/ram0 text {{ pxe_options.pxe_append_params|default("", true) }} {{ pxe_options.ramdisk_opts|default('', true) }} initrd=ramdisk || goto boot_ramdisk
-initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ ari_path_https }} || goto boot_ramdisk
+kernel {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ aki_path }} root=/dev/ram0 text {{ pxe_options.pxe_append_params|default("", true) }} {{ pxe_options.ramdisk_opts|default('', true) }} initrd=ramdisk || goto boot_ramdisk
+initrd {% if pxe_options.ipxe_timeout > 0 %}--timeout {{ pxe_options.ipxe_timeout }} {% endif %}{{ ari_path }} || goto boot_ramdisk
 boot
 {%- endif %}
 

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -62,6 +62,9 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1822763
 max_command_attempts = 30
 certificates_path = {{ env.IRONIC_GEN_CERT_DIR }}
+{% if env.IRONIC_INJECT_IPA == 'true' %}
+api_ca_file = {{ env.IPA_CACERT_FILE }}
+{% endif %}
 
 [api]
 {% if env.IRONIC_REVERSE_PROXY_SETUP == "true" %}
@@ -242,20 +245,18 @@ images_path = /shared/html/tmp
 instance_master_path = /shared/html/master_images
 tftp_master_path = /shared/tftpboot/master_images
 tftp_root = /shared/tftpboot
-kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console={{ env.IPA_FORWARD_CONSOLE | default('yes') }}
+kernel_append_params = nofb nomodeset vga=normal ipa-insecure={{ env.IRONIC_IPA_INSECURE | default('1') }} {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console={{ env.IPA_FORWARD_CONSOLE | default('yes') }}
 # This makes networking boot templates generated even for nodes using local
 # boot (the default), ensuring that they boot correctly even if they start
 # netbooting for some reason (e.g. with the noop management interface).
 enable_netboot_fallback = true
 # Enable the fallback path to in-band inspection
 ipxe_fallback_script = inspector.ipxe
-{% if env.IPXE_TLS_SETUP | lower == "true" %}
-ipxe_config_template = /templates/ipxe_config.template
-{% endif %}
+ipxe_config_template = {{ env.IRONIC_CONF_DIR }}/ipxe_config.template
 
 [redfish]
 use_swift = false
-kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console={{ env.IPA_FORWARD_CONSOLE | default('yes') }}
+kernel_append_params = nofb nomodeset vga=normal ipa-insecure={{ env.IRONIC_IPA_INSECURE | default('1') }} {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console={{ env.IPA_FORWARD_CONSOLE | default('yes') }}
 {% if env.BMC_TLS_ENABLED == "true" %}
 # idrac uses the same options as the redfish driver
 verify_ca = {{ env.BMC_CACERT_FILE }}

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,3 +1,4 @@
+cpio
 dnsmasq
 dosfstools
 httpd

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -94,6 +94,11 @@ if [[ -f /proc/sys/crypto/fips_enabled ]]; then
     export ENABLE_FIPS_IPA
 fi
 
+# inject TLS and cacert bundle variables in ipxe_template
+sed "1 a\
+\{%- set ipxe_tls_setup = $IRONIC_TLS_SETUP -%}\\
+\{%- set inject_cacert_bundle = $IRONIC_INJECT_IPA -%}" /templates/ipxe_config.template > "${IRONIC_CONF_DIR}/ipxe_config.template"
+
 # The original ironic.conf is empty, and can be found in ironic.conf.orig
 render_j2_config "/etc/ironic/ironic.conf.j2" \
     "${IRONIC_CONF_DIR}/ironic.conf"

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -20,6 +20,7 @@ if [[ "${DNS_IP:-}" == "provisioning" ]]; then
 fi
 
 mkdir -p /shared/tftpboot
+mkdir -p /shared/html
 
 # Copy files to shared mount
 if [[ -r "${IPXE_CUSTOM_FIRMWARE_DIR}" ]]; then

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -11,6 +11,10 @@ if [[ "${IRONIC_SKIP_DBSYNC:-false}" != true ]]; then
     run_ironic_dbsync
 fi
 
+if [[ "${IRONIC_INJECT_IPA}" == "true" ]]; then
+    generate_cacert_bundle_initrd /shared/html/ipa-cacert-bundle
+fi
+configure_restart_on_certificate_update "${IRONIC_INJECT_IPA}" ironic "${WEBSERVER_CACERT_FILE:-}"
 configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" ironic "${IRONIC_CERT_FILE}"
 
 configure_ironic_auth

--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -22,7 +22,8 @@ export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPD
 export MARIADB_CACERT_FILE=/certs/ca/mariadb/tls.crt
 export BMC_CACERTS_PATH=/certs/ca/bmc
 export BMC_CACERT_FILE=/conf/bmc-tls.pem
-export IRONIC_CACERT_FILE=/certs/ca/ironic/tls.crt
+export IRONIC_CACERT_FILE=${IRONIC_CACERT_FILE:-"/certs/ca/ironic/tls.crt"}
+export IPA_CACERT_FILE=/conf/ipa-tls.pem
 
 export IPXE_TLS_PORT="${IPXE_TLS_PORT:-8084}"
 
@@ -129,3 +130,38 @@ if ls "${BMC_CACERTS_PATH}"/* > /dev/null 2>&1; then
 else
     export BMC_TLS_ENABLED="false"
 fi
+
+if [[ -f "${WEBSERVER_CACERT_FILE:-}" ]]; then
+    export IRONIC_INJECT_IPA="true"
+    copy_atomic "${WEBSERVER_CACERT_FILE}" "${IPA_CACERT_FILE}"
+    
+    if [[ -f "${IRONIC_CACERT_FILE}" ]]; then
+        cat "${IRONIC_CACERT_FILE}" >> "${IPA_CACERT_FILE}"
+    fi
+else
+    export IRONIC_INJECT_IPA="false"
+fi
+
+generate_cacert_bundle_initrd()
+(
+    set -euo pipefail
+
+    local output_path="$1"
+    local temp_dir
+
+    temp_dir="$(mktemp -d)"
+    trap 'rm -rf "${temp_dir}"' EXIT
+
+    chmod 0755 "${temp_dir}"
+
+    cd "${temp_dir}"
+
+    mkdir -p etc/ironic-python-agent.d etc/ironic-python-agent
+    cp "${IPA_CACERT_FILE}" etc/ironic-python-agent/ironic.crt
+    cat > etc/ironic-python-agent.d/ironic-tls.conf <<EOF
+[DEFAULT]
+cafile = /etc/ironic-python-agent/ironic.crt
+EOF
+
+    find . -print0 | sort -z | cpio -0 -o -H newc -R +0:+0 --reproducible >> "${output_path}"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a way to inject the Ironic CA as well as additional CA certificates into the IPA image, it allows removing the `ipa-insecure` flag and actually validate the Ironic certificate from the IPA.

This solution should work for both virtualmedia and PXE based deployments.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
