### PR TITLE
:sparkles: Add wheel-builder stages to pre-build Python packages

### DIFF
--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+# This script builds Python wheels for all Ironic dependencies.
+# It runs in the wheel-builder stage of the Docker build.
+
+UPPER_CONSTRAINTS_PATH="/tmp/${UPPER_CONSTRAINTS_FILE:-}"
+
+# If the content of the upper-constraints file is empty,
+# we assume we're on the master branch
+if [[ ! -s "${UPPER_CONSTRAINTS_PATH}" ]]; then
+    UPPER_CONSTRAINTS_PATH="/tmp/upper-constraints.txt"
+    curl -L https://releases.openstack.org/constraints/upper/master -o "${UPPER_CONSTRAINTS_PATH}"
+fi
+
+# Install build dependencies
+python3.12 -m pip install --no-cache-dir pip=="${PIP_VERSION}" setuptools=="${SETUPTOOLS_VERSION}" wheel jinja2
+
+# Allow override via environment variable (used by deps-wheel-builder stage)
+IRONIC_PKG_LIST="${IRONIC_PKG_LIST:-/tmp/ironic-packages-list}"
+IRONIC_PKG_LIST_FINAL="/tmp/ironic-packages-list-final"
+
+# Render the Jinja2 template for the package list
+python3.12 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ, path=os.path))' < "${IRONIC_PKG_LIST}" > "${IRONIC_PKG_LIST_FINAL}"
+
+# Remove sushy constraint if building from source
+if [[ -n ${SUSHY_SOURCE:-} ]]; then
+    sed -i '/^sushy===/d' "${UPPER_CONSTRAINTS_PATH}"
+fi
+
+# Build wheels for all packages
+# Note: some packages may not produce wheels (pure Python), but pip wheel handles this
+python3.12 -m pip wheel \
+    --wheel-dir=/wheels \
+    --no-cache-dir \
+    -r "${IRONIC_PKG_LIST_FINAL}" \
+    -c "${UPPER_CONSTRAINTS_PATH}"
+
+echo "Wheels built successfully in /wheels"
+ls -la /wheels/

--- a/ironic-deps-list
+++ b/ironic-deps-list
@@ -1,0 +1,8 @@
+crudini
+gunicorn
+ironic-prometheus-exporter
+jinja2
+PyMySQL>=0.8.0
+python-scciclient
+watchdog
+

--- a/ironic-packages-list
+++ b/ironic-packages-list
@@ -1,5 +1,3 @@
-crudini
-gunicorn
 {% if env.IRONIC_SOURCE %}
     {% if path.isdir('/sources/' + env.IRONIC_SOURCE) %}
 git+file:///sources/{{ env.IRONIC_SOURCE }}
@@ -9,9 +7,6 @@ ironic @ git+https://opendev.org/openstack/ironic@{{ env.IRONIC_SOURCE }}
 {% else %}
 ironic @ git+https://opendev.org/openstack/ironic
 {% endif %}
-ironic-prometheus-exporter
-PyMySQL>=0.8.0
-python-scciclient
 {% if env.SUSHY_SOURCE %}
     {% if path.isdir('/sources/' + env.SUSHY_SOURCE) %}
 git+file:///sources/{{ env.SUSHY_SOURCE }}

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -12,54 +12,38 @@ EOF
 IRONIC_UID=997
 IRONIC_GID=994
 
-declare -a BUILD_DEPS=(
-    gcc
-    git-core
-    python3.12-devel
-    python3.12-setuptools
-)
-
 dnf upgrade -y
 
 # NOTE(dtantsur): pip is a requirement of python3 in CentOS
-dnf install -y python3.12-pip "${BUILD_DEPS[@]}"
+dnf install -y python3.12-pip
 
 # NOTE(elfosardo): pinning pip and setuptools version to avoid
 # incompatibilities and errors during packages installation;
 # versions should be updated regularly, for example
 # after cutting a release branch.
-python3.12 -m pip install --no-cache-dir pip==24.1 setuptools==74.1.2
+python3.12 -m pip install --no-cache-dir pip=="${PIP_VERSION}" setuptools=="${SETUPTOOLS_VERSION}"
 
-UPPER_CONSTRAINTS_PATH="/tmp/${UPPER_CONSTRAINTS_FILE:-}"
+# Install from pre-built wheels (mounted from both wheel-builder stages)
+# No compilation needed here - wheels are already built
+# Combine wheels into single directory, deduplicating
+mkdir -p /tmp/all-wheels
+cp -n /deps-wheels/*.whl /tmp/all-wheels/ 2>/dev/null || true
+cp -n /ironic-wheels/*.whl /tmp/all-wheels/ 2>/dev/null || true
 
-# NOTE(elfosardo): if the content of the upper-constraints file is empty,
-# we give as assumed that we're on the master branch
-if [[ ! -s "${UPPER_CONSTRAINTS_PATH}" ]]; then
-    UPPER_CONSTRAINTS_PATH="/tmp/upper-constraints.txt"
-    curl -L https://releases.openstack.org/constraints/upper/master -o "${UPPER_CONSTRAINTS_PATH}"
-fi
+python3.12 -m pip install \
+    --no-cache-dir \
+    --no-index \
+    --find-links=/tmp/all-wheels \
+    --ignore-installed \
+    --prefix /usr \
+    /tmp/all-wheels/*.whl
 
-# NOTE(elfosardo): install dependencies constrained
-python3.12 -m pip install jinja2 watchdog -c "${UPPER_CONSTRAINTS_PATH}"
-
-IRONIC_PKG_LIST="/tmp/ironic-packages-list"
-IRONIC_PKG_LIST_FINAL="/tmp/ironic-packages-list-final"
-
-python3.12 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ, path=os.path))' < "${IRONIC_PKG_LIST}" > "${IRONIC_PKG_LIST_FINAL}"
-
-if [[ -n ${SUSHY_SOURCE:-} ]]; then
-    sed -i '/^sushy===/d' "${UPPER_CONSTRAINTS_PATH}"
-fi
-
-python3.12 -m pip install --no-cache-dir --ignore-installed --prefix /usr -r "${IRONIC_PKG_LIST_FINAL}" -c "${UPPER_CONSTRAINTS_PATH}"
+rm -rf /tmp/all-wheels
 
 # ironic system configuration
 mkdir -p /var/log/ironic /var/lib/ironic
 getent group ironic > /dev/null || groupadd -r ironic -g "${IRONIC_GID}"
 getent passwd ironic > /dev/null || useradd -r -g ironic -u "${IRONIC_UID}" -s /sbin/nologin ironic -d /var/lib/ironic
-
-# clean installed build dependencies
-dnf remove -y "${BUILD_DEPS[@]}"
 
 xargs -rtd'\n' dnf install -y < /tmp/"${PKGS_LIST}"
 if [[ -s "/tmp/${ARCH_PKGS_LIST}" ]]; then


### PR DESCRIPTION
Introduce a multi-stage build approach where Python packages are
compiled into wheels in dedicated wheel-builder stages, one for
the dependencies and one for ironic, then installed in the final
image without requiring build dependencies.

Benefits:
- Build dependencies (gcc, python-devel, etc.) are no longer
  installed/removed in the final image stage
- Improved build caching - wheel-builder layer is reused if
  package list doesn't change
- Cleaner separation between compilation and runtime

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>
