### PR TITLE
:seedling: Uplift python dependencies to fix voulnerabilities

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -28,7 +28,7 @@ dnf install -y python3.12-pip "${BUILD_DEPS[@]}"
 # incompatibilities and errors during packages installation;
 # versions should be updated regularly, for example
 # after cutting a release branch.
-python3.12 -m pip install --no-cache-dir pip==24.1 setuptools==74.1.2
+python3.12 -m pip install --no-cache-dir pip==25.3 setuptools==78.1.1
 
 UPPER_CONSTRAINTS_PATH="/tmp/${UPPER_CONSTRAINTS_FILE:-}"
 

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -171,7 +171,7 @@ reno===4.1.0
 ncclient===0.6.19
 imagesize===1.4.1
 pydot===4.0.1
-urllib3===1.26.20
+urllib3===2.6.3
 graphviz===0.21
 PyKMIP===0.10.0
 python-observabilityclient===1.2.0
@@ -184,7 +184,7 @@ mock===5.2.0
 PyYAML===6.0.2
 beautifulsoup4===4.13.4
 ovs===3.5.1
-cryptography===43.0.3
+cryptography===44.0.1
 httpcore===1.0.9
 URLObject===3.0.0
 psycopg2-binary===2.9.10
@@ -231,7 +231,7 @@ XStatic-JQuery.quicksearch===2.0.3.2
 pyasn1_modules===0.4.1
 mpmath===1.3.0
 python-binary-memcached===0.31.4
-jaraco.context===6.0.1
+jaraco.context===6.1.0
 django-debreach===2.1.0
 sphinx-feature-classification===2.0.0
 XStatic-JQuery-Migrate===3.3.2.1
@@ -517,7 +517,7 @@ boto===2.49.0
 hyperlink===21.0.0
 mitba===1.1.1
 python-masakariclient===8.7.0
-Werkzeug===3.1.3
+Werkzeug===3.1.5
 APScheduler===3.11.0
 xmlschema===2.5.1
 python-troveclient===8.9.0


### PR DESCRIPTION
This commit is:
 - Bumping python dependencies to highest recommended fix version to get rid of the following issues:
 
Werkzeug: 
     - CVE-2025-66221  
      - CVE-2026-21860
cryptography :   CVE-2024-12797
jaraco.context:  GHSA-58pv-8j8x-9vj2       
pip                    CVE-2025-8869 
setuptools        CVE-2025-47273
urllib3
     - CVE-2025-66418
     - CVE-2025-66471
     - CVE-2026-21441
     - CVE-2025-5018