### PR TITLE
🐛 Provide a fallback bootloader when cpu_arch is not set

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -80,6 +80,10 @@ api_workers = {{ env.NUMWORKERS }}
 automated_clean = {{ env.IRONIC_AUTOMATED_CLEAN }}
 # NOTE(dtantsur): keep aligned with [pxe]boot_retry_timeout below.
 deploy_callback_timeout = 4800
+{% if env.BOOTLOADER is defined %}
+# Fallback bootloader when cpu_arch is not set
+bootloader = {{ env.BOOTLOADER }}
+{% endif %}
 bootloader_by_arch = {{ env.BOOTLOADER_BY_ARCH }}
 verify_step_priority_override = management.clear_job_queue:90
 # We don't use this feature, and it creates an additional load on the database
@@ -87,12 +91,14 @@ node_history = False
 # Provide for a timeout longer than 60 seconds for certain vendor's hardware
 power_state_change_timeout = 120
 {% if env.DEPLOY_KERNEL_URL is defined %}
+# Fallback deploy_kernel when cpu_arch is not set
 deploy_kernel = {{ env.DEPLOY_KERNEL_URL }}
 {% endif %}
 {% if env.DEPLOY_KERNEL_BY_ARCH is defined %}
 deploy_kernel_by_arch = {{ env.DEPLOY_KERNEL_BY_ARCH }}
 {% endif %}
 {% if env.DEPLOY_RAMDISK_URL is defined %}
+# Fallback deploy_ramdisk when cpu_arch is not set
 deploy_ramdisk = {{ env.DEPLOY_RAMDISK_URL }}
 {% endif %}
 {% if env.DEPLOY_RAMDISK_BY_ARCH is defined %}

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -107,6 +107,9 @@ BOOTLOADER_BY_ARCH=""
 for bootloader in /templates/uefi_esp_*.img; do
     BOOTLOADER_ARCH="$(basename "${bootloader#/templates/uefi_esp_}" .img)"
     BOOTLOADER_BY_ARCH+="${BOOTLOADER_ARCH}:file://${bootloader},"
+    if [[ -z "${BOOTLOADER:-}" ]] && [[ "$(uname -m)" == "${BOOTLOADER_ARCH}" ]]; then
+        export BOOTLOADER="file://${bootloader}"
+    fi
 done
 export BOOTLOADER_BY_ARCH="${BOOTLOADER_BY_ARCH%?}"
 


### PR DESCRIPTION
This is a problem exposed by https://github.com/metal3-io/baremetal-operator/issues/2909.
While it no longer affects BMO (it always sets cpu_arch), it affects
older BMO versions as well as any potential consumers of IrSO.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
