### PR TITLE
🌱 customize some firmware update configs

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -250,6 +250,9 @@ kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.ENABLE
 {% if env.BMC_TLS_ENABLED == "true" %}
 # idrac uses the same options as the redfish driver
 verify_ca = {{ env.BMC_CACERT_FILE }}
+# Firmware Updates configs
+firmware_update_wait_unresponsive_bmc = 0
+firmware_update_resource_validation_timeout = 480
 {% endif %}
 
 [irmc]


### PR DESCRIPTION
While testing firmware updates in different hardware models, we noticed it would require to change some of the default values we have in ironic.
In the redfish section we changed the following configs:
- increase firmware_update_resource_validation_timeout to 480
- set firmware_update_wait_unresponsive_bmc to 0