### PR TITLE
:bug: Add tar package for centos-minimal compatibility

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -9,5 +9,6 @@ mod_ssl
 procps
 qemu-img
 sqlite
+tar
 util-linux
 xorriso


### PR DESCRIPTION
The centos minimal base image doesn't include tar by default. This is required for kubectl cp operations and the runlogwatch.sh script that processes ramdisk log bundles.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>

Fixes: #891