### PR TITLE
✨ Add BMO e2e test integration

### DIFF
--- a/.github/workflows/bmo-e2e.yml
+++ b/.github/workflows/bmo-e2e.yml
@@ -1,0 +1,65 @@
+name: BMO E2E Tests
+
+on:
+  pull_request:
+    types: [ opened, edited, reopened, synchronize, ready_for_review ]
+
+jobs:
+  test:
+    runs-on: oracle-vm-4cpu-16gb-x86-64
+    permissions:
+      contents: read
+      actions: read
+    env:
+      CLUSTER_TYPE: kind
+      CONTAINER_RUNTIME: docker
+      IRONIC_CUSTOM_IMAGE: localhost/ironic:bmo-e2e
+      # Use latest stable BMO release - update this when new releases are available
+      BMO_VERSION: v0.12.1
+    steps:
+    - name: Check docker version
+      run: docker --version
+
+    - name: Checkout ironic-image
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        path: ironic-image
+        persist-credentials: false
+
+    - name: Checkout BMO at release version
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        repository: metal3-io/baremetal-operator
+        ref: ${{ env.BMO_VERSION }}
+        path: baremetal-operator
+        persist-credentials: false
+
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make -sC baremetal-operator go-version)" >> $GITHUB_OUTPUT
+
+    - name: Set up Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libvirt-clients libvirt-daemon-system xorriso
+
+    - name: Configure libvirt permissions
+      run: |
+        # Start libvirtd service
+        sudo systemctl start libvirtd
+        sudo systemctl enable libvirtd
+        # Add current user to libvirt group for socket access
+        sudo usermod -aG libvirt $USER
+
+    - name: Prepare and run BMO e2e tests
+      run: sg libvirt -c "ironic-image/hack/prepare-bmo-tests.sh"
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: bmo-e2e-artifacts
+        path: baremetal-operator/test/e2e/_artifacts
+      if: always()

--- a/hack/prepare-bmo-tests.sh
+++ b/hack/prepare-bmo-tests.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+cd "${REPO_ROOT}" || exit 1
+
+CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+IRONIC_CUSTOM_IMAGE="${IRONIC_CUSTOM_IMAGE:-localhost/ironic:bmo-e2e}"
+BMO_ROOT="${REPO_ROOT}/../baremetal-operator"
+
+# Build the ironic image
+echo "Building ironic image: ${IRONIC_CUSTOM_IMAGE}"
+"${CONTAINER_RUNTIME}" build -t "${IRONIC_CUSTOM_IMAGE}" .
+
+# Create a custom kustomize overlay in BMO that uses our image.
+# This avoids duplicating BMO's entire e2e config - we only override the ironic image.
+# TODO: Propose to BMO to accept IRONIC_IMAGE_OVERRIDE env var to simplify this further.
+# See: https://github.com/metal3-io/baremetal-operator/commit/b35cccb8 for their
+# recent refactoring that moved image overrides to kustomize overlays.
+CUSTOM_OVERLAY="${BMO_ROOT}/test/e2e/data/ironic-standalone-operator/ironic/overlays/ironic-image-custom"
+mkdir -p "${CUSTOM_OVERLAY}"
+
+cat > "${CUSTOM_OVERLAY}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../e2e
+patches:
+- target:
+    kind: Ironic
+  patch: |-
+    - op: replace
+      path: /spec/images/ironic
+      value: ${IRONIC_CUSTOM_IMAGE}
+EOF
+
+# Patch BMO's e2e config to add our custom image and use our overlay.
+# We only modify what's necessary - everything else uses BMO's defaults.
+BMO_CONFIG="${BMO_ROOT}/test/e2e/config/ironic.yaml"
+cp "${BMO_CONFIG}" "${BMO_CONFIG}.bak"
+
+# Add our custom image to the images list (after the BMO e2e image loadBehavior line)
+sed -i '/name: quay.io\/metal3-io\/baremetal-operator:e2e/,/loadBehavior:/{
+  /loadBehavior:/a\
+# Use custom ironic-image build\
+- name: '"${IRONIC_CUSTOM_IMAGE}"'\
+  loadBehavior: tryLoad
+}' "${BMO_CONFIG}"
+
+# Add our custom kustomization path to the variables section
+sed -i '/NAMESPACE_SCOPED:/a\
+  # Use custom ironic-image overlay\
+  IRONIC_KUSTOMIZATION: "data/ironic-standalone-operator/ironic/overlays/ironic-image-custom"' "${BMO_CONFIG}"
+
+# Run the BMO e2e tests
+cd "${BMO_ROOT}" || exit 1
+echo "Running BMO e2e tests with custom ironic image: ${IRONIC_CUSTOM_IMAGE}"
+export GINKGO_FOCUS=""
+./hack/ci-e2e.sh


### PR DESCRIPTION
Integrates Bare Metal Operator's e2e test suite to test ironic-image with live-ISO provisioning scenarios. Uses Method 1 from issue #758: clones BMO at release v0.12.1, builds custom ironic image, and runs tests via BMO's ci-e2e.sh script.

Fixes: #758