### PR TITLE
🐛 Fix DHCPv6 PXE boot: use option6:61 for arch detection

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -56,15 +56,14 @@ ra-param={{ env.PROVISIONING_INTERFACE }},0,0
 
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE
-# Architecture detection via DHCPv6 option 61 (RFC 5970).
-# Note: option:client-arch is a DHCPv4-only alias (option 93) and silently
-# adds rules to the DHCPv4 match list; use option6:client-arch for DHCPv6.
-dhcp-match=set:amd64,option6:client-arch,7
-dhcp-match=set:amd64,option6:client-arch,9
+# option6:client-arch is not defined in dnsmasq upstream, resort to architecture
+# detection via DHCPv6 option 61 (RFC 5970)
 # Client is (i)PXE booting on EFI machine
+dhcp-match=set:amd64,option6:61,7
+dhcp-match=set:amd64,option6:61,9
 dhcp-option=tag:pxe6,tag:amd64,option6:bootfile-url,tftp://{{ env.IRONIC_URL_HOST }}/snponly-x86_64.efi
 # Client is (i)PXE booting on arm64 EFI machine
-dhcp-match=set:arm64,option6:client-arch,11
+dhcp-match=set:arm64,option6:61,11
 dhcp-option=tag:pxe6,tag:arm64,option6:bootfile-url,tftp://{{ env.IRONIC_URL_HOST }}/snponly-arm64.efi
 # Fallback: serve x86_64 when PXE client is detected but architecture
 # could not be determined. Legacy BIOS does not support IPv6 PXE.


### PR DESCRIPTION
## Summary

- Fix DHCPv6 PXE boot by replacing `option:client-arch` (DHCPv4-only alias for option 93) with `option6:client-arch` (DHCPv6 option 61, RFC 5970)
- Replace impossible BIOS fallback (`undionly.kpxe` over IPv6) with x86_64 EFI fallback for PXE clients whose architecture could not be determined

## Root cause

The IPv6 section of `dnsmasq.conf.j2` used `option:client-arch` in `dhcp-match` directives. In dnsmasq, `option:` is a DHCPv4-only prefix — it resolves `client-arch` to option 93 via `opttab[]` and adds the match rule to `daemon->dhcp_match`. The DHCPv6 server code (`rfc3315.c`) only iterates `daemon->dhcp_match6`, so these rules were silently ignored. The `amd64`/`arm64` tags were never set, the EFI bootfile was never served, and UEFI nodes could not PXE boot over IPv6.

The correct syntax is `option6:client-arch`, which resolves to DHCPv6 option 61 via `opttab6[]`. Both EDK2/OVMF and iPXE send this option in DHCPv6 SOLICIT messages.

**Note:** `option6:client-arch` requires the `client-arch` entry in dnsmasq's `opttab6[]` table. Upstream dnsmasq is [missing this entry](https://lists.thekelleys.org.uk/mailman/listinfo/dnsmasq-discuss), but Red Hat has carried a [downstream patch](https://gitlab.com/redhat/centos-stream/rpms/dnsmasq/-/blob/c9s/dnsmasq-2.86-dhcpv6-client-arch.patch?ref_type=heads) adding it since 2021, which is included in the CentOS Stream 9 base image used by this container.

## Test plan

- [x] `make build` succeeds (w/ `CONTAINER_ENGINE=docker make build`)
- [x] Deploy with `IPV=6` and verify dnsmasq config renders correctly
- [x] UEFI amd64 node with EDK2/OVMF (libvirt) PXE boots over IPv6 and receives `snponly-x86_64.efi`
- [x] UEFI amd64 node with igb (Gigabyte server) PXE boots over IPv6 and receives `snponly-x86_64.efi`
- [ ] UEFI arm64 node PXE boots over IPv6 and receives `snponly-arm64.efi` -- will not be tested, no access to relevant hardware
- [ ] iPXE chainloading (`boot.ipxe`) still works when `IPXE_TLS_SETUP != "true"` -- will not be tested, hoping for relevant e2e tests

Fixes: #916

---

UPDATE: Play it safe re. upstream dnsmasq vs Red Hat patches by using `option6:61` in favor of alias `option6:client-arch`.