### PR TITLE
✨ Support multiple DHCP ranges via semicolon-separated DHCP_RANGE

### DIFF
--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -10,7 +10,9 @@ port={{ env.DNS_PORT }}
 
 {%- if env.DHCP_RANGE | length %}
 log-dhcp
-dhcp-range={{ env.DHCP_RANGE }}
+{%- for item in env.DHCP_RANGE.split(";") %}
+dhcp-range={{ item }}
+{%- endfor %}
 {% endif %}
 
 {%- if env["DNS_IP"] is undefined %}


### PR DESCRIPTION
## Summary
- Split `DHCP_RANGE` env var on `;` to emit one `dhcp-range=` line per entry in the dnsmasq Jinja2 template
- Enables multiple subnets served via DHCPv6 relay agents from a single dnsmasq instance
- Fully backward compatible: a single range with no semicolons produces identical output to before

## Companion PR
- metal3-io/ironic-standalone-operator#553 — CRD + controller changes to populate the semicolon-separated `DHCP_RANGE` env var

## Test plan
- [x] Verify single `DHCP_RANGE=a::1,a::ff,64` (no semicolons) still renders one `dhcp-range=` line
- [x] Verify `DHCP_RANGE=a::1,a::ff,64;b::1,b::ff,64` renders two `dhcp-range=` lines
- [x] Verify dnsmasq starts successfully with multiple ranges configured