### PR TITLE
🌱Update PIP_VERSION to latest released pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=quay.io/centos/centos:stream9-minimal
 
 # Python tooling versions - update these regularly
-ARG PIP_VERSION=24.1
+ARG PIP_VERSION=26.0.1
 ARG SETUPTOOLS_VERSION=74.1.2
 
 ## Build iPXE w/ IPv6 Support


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Without this change, building ironic-image with master ironic fails with
this error:

ERROR: Cannot install oslo-concurrency 7.2.0 (from
/tmp/all-wheels/oslo_concurrency-7.2.0-py3-none-any.whl) and
oslo-concurrency 7.3.0 (from
/tmp/all-wheels/oslo_concurrency-7.3.0-py3-none-any.whl) because these
package versions have conflicting dependencies.

The conflict is caused by:
    The user requested oslo-concurrency 7.2.0 (from /tmp/all-wheels/oslo_concurrency-7.2.0-py3-none-any.whl)
    The user requested oslo-concurrency 7.3.0 (from /tmp/all-wheels/oslo_concurrency-7.3.0-py3-none-any.whl)

pip-24.1 is from June 2024, so an update is also overdue for the "update
these regularly" comment to be accurate.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
