### PR TITLE
🐛Add package tar

### DIFF
--- a/ironic-deps-list
+++ b/ironic-deps-list
@@ -4,5 +4,6 @@ ironic-prometheus-exporter
 jinja2
 PyMySQL>=0.8.0
 python-scciclient
+tar
 watchdog
 


### PR DESCRIPTION

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

The default base image quay.io/centos/centos:stream9-minimal doesn't actually have the tar package installed, and runlogwatch.sh currently fails to print logs due to this missing package.

This change explicitly adds the tar package to fix runlogwatch.sh

Fixes #921

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
