### PR TITLE
:seedling: fix reapprover workflow

### DIFF
--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -6,7 +6,7 @@ name: Approve GH Workflows
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [edited, labeled, reopened, synchronize]
 
 permissions: {}
 
@@ -20,6 +20,8 @@ jobs:
 
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
+    - name: Wait for workflows to be created
+      run: sleep 10
     - name: Update PR
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       continue-on-error: true


### PR DESCRIPTION
The reapprover workflow does not seem to trigger most of the times. One probable cause is race condition of pull request workflows being created and this one running. This one might run before the workflows are created, so it doesn't approve them as it doesn't see them.

Also, remove open/ready_for_review triggers as those are not relevant for this workflow. Add labeled instead, so adding /ok-to-test should trigger this and approve the workflows.

Per the earlier PRs in metal3-docs and BMO, it seems to work properly with the sleep.