### PR TITLE
:seedling: harden github actions workflows

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'ironic'
       pushImage: true
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'ironic_cs10'
       pushImage: true
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'sushy-tools'
       dockerfile-directory: resources/sushy-tools
@@ -68,7 +68,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'vbmc'
       dockerfile-directory: resources/vbmc
@@ -85,7 +85,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'ironic-client'
       dockerfile-directory: resources/ironic-client

--- a/.github/workflows/ironic-image-build-pr.yml
+++ b/.github/workflows/ironic-image-build-pr.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     types: [ opened, edited, reopened, synchronize, ready_for_review ]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm'}}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +24,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
     - name: Set base image

--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     types: [ opened, edited, reopened, synchronize, ready_for_review ]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: oracle-vm-4cpu-16gb-x86-64
+    permissions:
+      checks: write
+      contents: read
     env:
       CLUSTER_TYPE: minikube
       CONTAINER_RUNTIME: docker
@@ -22,10 +27,12 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: ironic-image
+        persist-credentials: false
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: metal3-io/ironic-standalone-operator
         path: ironic-standalone-operator
+        persist-credentials: false
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make -sC ironic-standalone-operator go-version)" >> $GITHUB_OUTPUT
@@ -47,7 +54,7 @@ jobs:
       run: ironic-standalone-operator/test/collect-logs.sh
       if: always()
     - name: Upload logs artifacts
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: functional
         path: /tmp/logs/*

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -5,7 +5,7 @@
 name: Approve GH Workflows
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [edited, labeled, reopened, synchronize]
 
 permissions: {}

--- a/.github/workflows/pr-link-check.yml
+++ b/.github/workflows/pr-link-check.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   check-pr-links:
-    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main
+    uses: metal3-io/project-infra/.github/workflows/pr-link-check.yml@main # zizmor: ignore[unpinned-uses]
     with:
       upstream: https://github.com/metal3-io/ironic-image.git

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -3,10 +3,10 @@ name: PR Verifier
 permissions: {}
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, edited, reopened, synchronize ]
 
 jobs:
   verify:
     name: verify PR contents
-    uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main
+    uses: metal3-io/project-infra/.github/workflows/pr-verifier.yaml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,12 +28,15 @@ jobs:
       uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
     - name: Get release version
       id: release-version
+      env:
+        STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES_COUNT: ${{ steps.changed-files.outputs.all_changed_files_count }}
+        STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
       run: |
-        if [[ ${{ steps.changed-files.outputs.all_changed_files_count }} != 1 ]]; then
-          echo "1 release notes file should be changed to create a release tag, found ${{ steps.changed-files.outputs.all_changed_files_count }}"
+        if [[ "${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES_COUNT}" != "1" ]]; then
+          echo "1 release notes file should be changed to create a release tag, found ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES_COUNT}"
           exit 1
         fi
-        for changed_file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+        for changed_file in ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}; do
           export RELEASE_VERSION=$(echo "${changed_file}" | grep -oP '(?<=/)[^/]+(?=\.md)')
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_ENV}
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> ${GITHUB_OUTPUT}
@@ -94,16 +97,18 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ env.RELEASE_TAG }}
+        persist-credentials: false
     - name: Calculate go version
       run: echo "go_version=$(make go-version)" >> ${GITHUB_ENV}
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: ${{ env.go_version }}
+        cache: false
     - name: get release notes
       run: |
-        curl -L "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${{ env.RELEASE_TAG }}.md" \
-        -o "${{ env.RELEASE_TAG }}.md"
+        curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/main/releasenotes/${RELEASE_TAG}.md" \
+        -o "${RELEASE_TAG}.md"
     - name: Release
       uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
@@ -117,7 +122,7 @@ jobs:
     needs: push_release_tags
     name: Build Ironic-image container image
     if: github.repository == 'metal3-io/ironic-image'
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'ironic'
       pushImage: true
@@ -135,7 +140,7 @@ jobs:
     needs: push_release_tags
     name: Build Ironic-image container image
     if: github.repository == 'metal3-io/ironic-image'
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'ironic_cs10'
       pushImage: true

--- a/.github/workflows/scheduled-link-check.yml
+++ b/.github/workflows/scheduled-link-check.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   check-links:
-    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main
+    uses: metal3-io/project-infra/.github/workflows/scheduled-link-check.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,6 +10,6 @@ on:
 jobs:
   yamllint-check:
     name: yaml-lint
-    uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main
+    uses: metal3-io/project-infra/.github/workflows/yamllint.yaml@main # zizmor: ignore[unpinned-uses]
     with:
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Add persist-credentials: false to checkout actions, switch pr-verifier from pull_request_target to pull_request, add explicit permissions to workflows, bump actions to latest major versions, suppress accepted findings, and apply zizmor safe fixes.
