### PR TITLE
✨Switch to default_deploy_interface = autodetect

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -6,7 +6,8 @@
 [DEFAULT]
 auth_strategy = noauth
 debug = true
-default_deploy_interface = direct
+default_deploy_interface = autodetect
+autodetect_deploy_interfaces = ramdisk,bootc,direct
 default_inspect_interface = agent
 {%- if env.IRONIC_NETWORKING_ENABLED | lower == "true" %}
 default_network_interface = ironic-networking
@@ -15,7 +16,7 @@ default_network_interface = noop
 {% endif -%}
 enabled_bios_interfaces = no-bios,redfish,idrac-redfish
 enabled_boot_interfaces = ipxe,pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,redfish-https
-enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent,bootc
+enabled_deploy_interfaces = autodetect,direct,fake,ramdisk,custom-agent,bootc
 enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the default deploy interface from direct to autodetect[1]. For all existing supported scenarios this will result in the direct interface being used during deployment, but this will also enable bootc container images to be used for deployment.

The check for bootc only occurs when the image source uses an oci:// URL protocol.

[1] https://docs.openstack.org/ironic/latest/admin/interfaces/deploy.html#id6

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
