### PR TITLE
🐛 Bump sushy to 5.10.1 in upper-constraints

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -351,7 +351,7 @@ tooz===8.1.0
 idna===3.11
 yamlloader===1.6.0
 protobuf===6.33.5
-sushy===5.10.0
+sushy===5.10.1
 python-neutronclient===11.8.0
 pika===1.3.2
 oslo.cache===4.1.1


### PR DESCRIPTION
5.10.0 contains a critical bug in the Connector fixed by
https://review.opendev.org/c/openstack/sushy/+/982471

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
