### PR TITLE
🐛 Use placeholder in iPXE template for variable injection

### DIFF
--- a/ironic-config/ipxe_config.template
+++ b/ironic-config/ipxe_config.template
@@ -1,4 +1,5 @@
 #!ipxe
+{# INJECT_VARIABLES #}
 
 set attempts:int32 10
 set i:int32 0

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -95,9 +95,7 @@ if [[ -f /proc/sys/crypto/fips_enabled ]]; then
 fi
 
 # inject TLS and cacert bundle variables in ipxe_template
-sed "1 a\
-\{%- set ipxe_tls_setup = $IRONIC_TLS_SETUP -%}\\
-\{%- set inject_cacert_bundle = $IRONIC_INJECT_IPA -%}" /templates/ipxe_config.template > "${IRONIC_CONF_DIR}/ipxe_config.template"
+sed "s/{# INJECT_VARIABLES #}/{% set ipxe_tls_setup = $IRONIC_TLS_SETUP %}\n{% set inject_cacert_bundle = $IRONIC_INJECT_IPA %}/" /templates/ipxe_config.template > "${IRONIC_CONF_DIR}/ipxe_config.template"
 
 # The original ironic.conf is empty, and can be found in ironic.conf.orig
 render_j2_config "/etc/ironic/ironic.conf.j2" \


### PR DESCRIPTION

**What this PR does / why we need it**:
Replace sed append operation with a placeholder-based substitution for injecting Jinja2 variables into the iPXE template. This makes the template modification more explicit and maintainable.
Also remove whitespace control to avoid issues with it being too greedy.

Fixes #971
Implements change requested in #851 (comment)

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
