### PR TITLE
:bug: Minimal viable fix for ipxe template rendering

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -96,8 +96,8 @@ fi
 
 # inject TLS and cacert bundle variables in ipxe_template
 sed "1 a\
-\{%- set ipxe_tls_setup = $IRONIC_TLS_SETUP -%}\\
-\{%- set inject_cacert_bundle = $IRONIC_INJECT_IPA -%}" /templates/ipxe_config.template > "${IRONIC_CONF_DIR}/ipxe_config.template"
+\{%- set ipxe_tls_setup = $IPXE_TLS_SETUP %}\\
+\{%- set inject_cacert_bundle = $IRONIC_INJECT_IPA %}" /templates/ipxe_config.template > "${IRONIC_CONF_DIR}/ipxe_config.template"
 
 # The original ironic.conf is empty, and can be found in ironic.conf.orig
 render_j2_config "/etc/ironic/ironic.conf.j2" \


### PR DESCRIPTION
This commit:
 - Introduces a minimal viable fix to resolve the node specific IPXE script rendering issue. Currently the 2 jinja lines injected via sed in configure-ironic.sh remove all the tabulation between the shebang line and the first functional command during jinaj rendering, thus an unusable pxe script will be created.

This has to be back-ported, this is a serious regression, IPXE is broken in v35 . Also we should discuss the use of sed in a followup related to the jinja template as I think the use of sed in this scenario is redundant at best.

Example of the output:
`#!ipxeset attempts:int32 10                                                     
set i:int32 0

...`

fixes #971 