### PR TITLE
✨ Support custom DHCP options via DHCP_OPTIONS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ functionality:
    addresses like `00:20:e0:3b:13:af;00:20:e0:3b:14:af` (empty by default). For
    more details on `dhcp-host` see
    [the man page](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html).
+- `DHCP_OPTIONS` - a `;` separated list of additional `dhcp-option` directives
+   that allows passing specific network configuration parameters (like routers,
+   DNS servers, and NTP) to DHCP clients (empty by default). Only applies to
+   IPv4 provisioning (`IPV=4` or unset). For more details on `dhcp-option` see
+   [the man page](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html).
 - `DHCP_IGNORE` - a set of tags on hosts that should be ignored and not allocate
    DHCP leases for, e.g. `tag:!known` to ignore any unknown hosts (empty by
    default)

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -36,6 +36,12 @@ dhcp-option=3
 dhcp-option=option:router,{{ env["GATEWAY_IP"] }}
 {% endif %}
 
+{%- if env.get("DHCP_OPTIONS", "") | length %}
+{%- for opt in env.DHCP_OPTIONS.split(";") %}
+dhcp-option={{ opt }}
+{%- endfor %}
+{% endif %}
+
 # Note: Need to test EFI booting
 dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9


### PR DESCRIPTION
  **What this PR does / why we need it**:

  Add support for passing arbitrary `dhcp-option` directives to dnsmasq
  through the `DHCP_OPTIONS` environment variable. This allows passing
  specific network configuration parameters (like routers, DNS servers,
  and NTP) to DHCP clients.

  Multiple options can be specified using semicolon separation, following
  the same convention used by `DHCP_RANGE` and `DHCP_HOSTS`.

  ## Companion PR
  - metal3-io/ironic-standalone-operator#673
  
  ## Test plan
  - [ ] Verify unset/empty `DHCP_OPTIONS` produces no extra `dhcp-option=` lines
  - [ ] Verify single option: `DHCP_OPTIONS=tag:vl3001,option:router,10.224.56.6` renders one `dhcp-option=` line
  - [ ] Verify multiple options: `DHCP_OPTIONS=tag:vl3001,option:router,10.224.56.6;tag:vl3002,option:router,10.224.57.6` renders two lines
  - [ ] Verify dnsmasq starts successfully with custom options configured

  **Checklist:**

  - [x] Documentation has been updated, if necessary.
  - [ ] Integration tests have been added, if necessary.