### PR TITLE
[Prototype] Allow disabling iPXE when building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG SETUPTOOLS_VERSION=82.0.1
 
 FROM $BASE_IMAGE AS ironic-builder
 
+ARG DISABLE_IPXE=false
 ARG IPXE_COMMIT_HASH=d0ea2b1bb8f78b219f74424d435b92ff8aa0ea8d
 ARG TARGETARCH
 
@@ -19,8 +20,12 @@ COPY prepare-ipxe.sh build-ipxe.sh prepare-efi.sh /bin/
 
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked <<EORUN
 set -euxo pipefail
-prepare-ipxe.sh
-build-ipxe.sh
+if [[ "${DISABLE_IPXE,,}" != true ]]; then
+    prepare-ipxe.sh
+    build-ipxe.sh
+else
+    mkdir -p /tmp/ipxe/out
+fi
 prepare-efi.sh centos
 EORUN
 
@@ -120,6 +125,9 @@ ARG PKGS_LIST=main-packages-list.txt
 ARG ARCH_PKGS_LIST=main-packages-list-${TARGETARCH}.txt
 ARG EXTRA_PKGS_LIST
 ARG PATCH_LIST
+
+ARG DISABLE_IPXE=false
+ENV DISABLE_IPXE=${DISABLE_IPXE}
 
 COPY ${PKGS_LIST} ${ARCH_PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
 COPY ironic-config/ /tmp/ironic-config/

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -9,12 +9,12 @@ default_network_interface = ironic-networking
 default_network_interface = noop
 {% endif -%}
 enabled_bios_interfaces = no-bios,redfish,idrac-redfish
-enabled_boot_interfaces = ipxe,pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,redfish-https
+enabled_boot_interfaces = {% if env.DISABLE_IPXE | lower != "true" %}ipxe,pxe,{% endif %}fake,redfish-virtual-media,idrac-redfish-virtual-media,redfish-https
 enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent,bootc
 enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
-enabled_hardware_types = ipmi,idrac,fake-hardware,redfish,manual-management
+enabled_hardware_types = {% if env.DISABLE_IPXE | lower != "true" %}ipmi,{% endif %}idrac,fake-hardware,redfish,manual-management
 enabled_inspect_interfaces = agent,fake,redfish
 enabled_management_interfaces = ipmitool,fake,redfish,idrac-redfish,noop
 {%- if env.IRONIC_NETWORKING_ENABLED | lower == "true" %}
@@ -160,7 +160,7 @@ dhcp_provider = none
 # NOTE(dtantsur): we properly configure the "unmanaged" inspection boot (i.e.
 # booting IPA through a separate inspector.ipxe rather than the driver's boot
 # interface), so managed boot is not required.
-require_managed_boot = False
+require_managed_boot = {{ env.DISABLE_IPXE }}
 power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
 # Also keep in mind that only parameters unique for inspection go here.

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -41,6 +41,8 @@ export IRONIC_USE_MARIADB="${IRONIC_USE_MARIADB:-false}"
 # Allow override in ironic-networking use cases
 export IRONIC_FORCE_DHCP="${IRONIC_FORCE_DHCP:-false}"
 
+export DISABLE_IPXE="${DISABLE_IPXE:-false}"
+
 get_provisioning_interface()
 {
     if [[ -n "$PROVISIONING_INTERFACE" ]]; then


### PR DESCRIPTION
Some users indicated desire to save some build time and size by building
images that only support virtual media. This change adds a new
build-time option DISABLE_IPXE that can be set to skip building iPXE
and disable the corresponding boot interfaces.

Fixes: #823 
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
