### PR TITLE
:seedling: harden the file extraction in runlogwatch

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -14,7 +14,7 @@ process_log_file() {
     echo "************ Contents of ${LOG_DIR}/${FILENAME} ramdisk log file bundle **************"
     tar -tzf "${FILEPATH}" | while read -r entry; do
         echo "${FILENAME}: **** Entry: ${entry} ****"
-        tar -xOzf "${FILEPATH}" "${entry}" | sed -e "s/^/${FILENAME}: /"
+        tar -xOzf "${FILEPATH}" -- "${entry}" | sed -e "s/^/${FILENAME}: /"
         echo
     done
     rm -f "${FILEPATH}"


### PR DESCRIPTION
This PR:
 - Makes sure that files extracted from the Ironic logs by "runlogwatch" are not interpreted as options.

Although the content of the deployment logs are expected to have deterministic names and contain only logs sent back by a registered IPA, the hardening has very little footprint and backward compatible so there is no reason to not include it.