### PR TITLE
:seedling: Add strict mode to runlogwatch.sh

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -euxo pipefail
 
 # Ramdisk logs path
 export LOG_DIR="/shared/log/ironic/deploy"


### PR DESCRIPTION
runlogwatch.sh was the only entry-point script without any error handling. Failures in tar, sed, or rm were silently ignored. Add set -euxo pipefail consistent with the other scripts.
