### PR TITLE
🌱 BMO e2e: respect IRONIC_CUSTOM_VERSION

### DIFF
--- a/.github/workflows/bmo-e2e.yml
+++ b/.github/workflows/bmo-e2e.yml
@@ -14,6 +14,9 @@ jobs:
       CLUSTER_TYPE: kind
       CONTAINER_RUNTIME: docker
       IRONIC_CUSTOM_IMAGE: localhost/ironic:bmo-e2e
+      # NOTE(dtantsur): change this on stable branches to make sure the correct
+      # logic is used in IrSO.
+      IRONIC_CUSTOM_VERSION: latest
       # Use latest stable BMO release - update this when new releases are available
       BMO_VERSION: v0.12.1
     steps:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -266,9 +266,9 @@ operator code as well. After that, an
 will be prepared.
 
 Finally, return to the release branch in this repository and update
-`IRONIC_CUSTOM_VERSION` in the IrSO workflow
-(`.github/workflows/irso-functional.yml`) to match the correct version (e.g.
-`32.0` on `release-32.0`).
+`IRONIC_CUSTOM_VERSION` in the IrSO (`.github/workflows/irso-functional.yml`)
+and BMO (`.github/workflows/bmo-e2e.yml`) workflows to match the correct
+version (e.g. `35.0` on `release-35.0`).
 
 ## Additional actions outside this repository
 

--- a/hack/prepare-bmo-tests.sh
+++ b/hack/prepare-bmo-tests.sh
@@ -8,6 +8,7 @@ cd "${REPO_ROOT}" || exit 1
 CLUSTER_TYPE="${CLUSTER_TYPE:-kind}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 IRONIC_CUSTOM_IMAGE="${IRONIC_CUSTOM_IMAGE:-localhost/ironic:bmo-e2e}"
+IRONIC_CUSTOM_VERSION="${IRONIC_CUSTOM_VERSION:-latest}"
 BMO_ROOT="${REPO_ROOT}/../baremetal-operator"
 
 . hack/image-common.sh
@@ -35,6 +36,9 @@ patches:
     - op: replace
       path: /spec/images/ironic
       value: ${IRONIC_CUSTOM_IMAGE}
+    - op: replace
+      path: /spec/version
+      value: ${IRONIC_CUSTOM_VERSION}
 EOF
 
 # Patch BMO's e2e config to add our custom image and use our overlay.


### PR DESCRIPTION
To run the job reliably on older branches, we need to be able to tell
IrSO, which Ironic version the job is based on.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
