### PR TITLE
:bug: Use IPXE_TLS_PORT in ipxe_config.template instead of hardcoded 8084

### DIFF
--- a/ironic-config/ipxe_config.template
+++ b/ironic-config/ipxe_config.template
@@ -12,13 +12,13 @@ imgfree
 {%- set aki_path_https_elements = pxe_options.deployment_aki_path.split(':') %}
 {%- set aki_port_and_path = aki_path_https_elements[2].split('/') %}
 {%- set aki_afterport = aki_port_and_path[1:]|join('/') %}
-{%- set aki_path = ['https:', aki_path_https_elements[1], ':8084/', aki_afterport]|join %}
+{%- set aki_path = ['https:', aki_path_https_elements[1], ':', ipxe_tls_port, '/', aki_afterport]|join %}
 {%- endif %}
 {%- if pxe_options.deployment_ari_path %}
 {%- set ari_path_https_elements = pxe_options.deployment_ari_path.split(':') %}
 {%- set ari_port_and_path = ari_path_https_elements[2].split('/') %}
 {%- set ari_afterport = ari_port_and_path[1:]|join('/') %}
-{%- set ari_path = ['https:', ari_path_https_elements[1], ':8084/', ari_afterport]|join %}
+{%- set ari_path = ['https:', ari_path_https_elements[1], ':', ipxe_tls_port, '/', ari_afterport]|join %}
 {%- endif %}
 {%- else %}
 {%- set ari_path = pxe_options.deployment_ari_path %}

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -97,7 +97,8 @@ fi
 # inject TLS and cacert bundle variables in ipxe_template
 sed "1 a\
 \{%- set ipxe_tls_setup = $IPXE_TLS_SETUP %}\\
-\{%- set inject_cacert_bundle = $IRONIC_INJECT_IPA %}" /templates/ipxe_config.template > "${IRONIC_CONF_DIR}/ipxe_config.template"
+\{%- set inject_cacert_bundle = $IRONIC_INJECT_IPA %}\\
+\{%- set ipxe_tls_port = $IPXE_TLS_PORT %}" /templates/ipxe_config.template > "${IRONIC_CONF_DIR}/ipxe_config.template"
 
 # The original ironic.conf is empty, and can be found in ironic.conf.orig
 render_j2_config "/etc/ironic/ironic.conf.j2" \


### PR DESCRIPTION
The iPXE boot template had port 8084 hardcoded in the TLS URL construction. This breaks when IPXE_TLS_PORT is overridden via environment. Inject the port variable alongside the existing ipxe_tls_setup and inject_cacert_bundle sed injections.

