### PR TITLE
✨ Add TLS support for the ironic-prometheus-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,14 @@ TLS configuration:
   `true` will make the server enforce its cipher list ordering for TLS version
   up to 1.2, defaults to `false`
 
+The following environment variables can be passed to customize the Ironic
+Prometheus Exporter TLS configuration:
+
+- `IRONIC_PROMETHEUS_EXPORTER_CERT_FILE` - TLS certificate for the exporter
+  (default `/certs/ironic-prometheus-exporter/tls.crt`)
+- `IRONIC_PROMETHEUS_EXPORTER_KEY_FILE` - TLS private key for the exporter
+  (default `/certs/ironic-prometheus-exporter/tls.key`)
+
 The following environment variables can be passed to customize the virtual
 media HTTP server configuration:
 

--- a/scripts/runironic-exporter
+++ b/scripts/runironic-exporter
@@ -16,5 +16,13 @@ FLASK_RUN_PORT=${FLASK_RUN_PORT:-9608}
 
 export IRONIC_CONFIG="${IRONIC_CONF_DIR}/ironic.conf"
 
-exec gunicorn -b "${FLASK_RUN_HOST}:${FLASK_RUN_PORT}" -w 4 \
-    ironic_prometheus_exporter.app.wsgi:application
+if [[ "${IRONIC_PROMETHEUS_EXPORTER_TLS_SETUP}" == "true" ]]; then
+    configure_restart_on_certificate_update "${IRONIC_PROMETHEUS_EXPORTER_TLS_SETUP}" gunicorn "${IRONIC_PROMETHEUS_EXPORTER_CERT_FILE}"
+    exec gunicorn -b "${FLASK_RUN_HOST}:${FLASK_RUN_PORT}" -w 4 \
+        --certfile "${IRONIC_PROMETHEUS_EXPORTER_CERT_FILE}" \
+        --keyfile "${IRONIC_PROMETHEUS_EXPORTER_KEY_FILE}" \
+        ironic_prometheus_exporter.app.wsgi:application
+else
+    exec gunicorn -b "${FLASK_RUN_HOST}:${FLASK_RUN_PORT}" -w 4 \
+        ironic_prometheus_exporter.app.wsgi:application
+fi

--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -15,6 +15,8 @@ export IRONIC_VMEDIA_KEY_FILE=/certs/vmedia/tls.key
 export IPXE_CERT_FILE=/certs/ipxe/tls.crt
 export IPXE_KEY_FILE=/certs/ipxe/tls.key
 
+export IRONIC_PROMETHEUS_EXPORTER_CERT_FILE=${IRONIC_PROMETHEUS_EXPORTER_CERT_FILE:-/certs/ironic-prometheus-exporter/tls.crt}
+export IRONIC_PROMETHEUS_EXPORTER_KEY_FILE=${IRONIC_PROMETHEUS_EXPORTER_KEY_FILE:-/certs/ironic-prometheus-exporter/tls.key}
 export RESTART_CONTAINER_CERTIFICATE_UPDATED=${RESTART_CONTAINER_CERTIFICATE_UPDATED:-"false"}
 
 # By default every cert has to be signed with Ironic's
@@ -51,6 +53,15 @@ if [[ -f "$IPXE_CERT_FILE" ]] && [[ ! -f "$IPXE_KEY_FILE" ]]; then
 fi
 if [[ ! -f "$IPXE_CERT_FILE" ]] && [[ -f "$IPXE_KEY_FILE" ]]; then
     echo "Missing TLS Certificate file $IPXE_CERT_FILE"
+    exit 1
+fi
+
+if [[ -f "$IRONIC_PROMETHEUS_EXPORTER_CERT_FILE" ]] && [[ ! -f "$IRONIC_PROMETHEUS_EXPORTER_KEY_FILE" ]]; then
+    echo "Missing TLS Certificate key file $IRONIC_PROMETHEUS_EXPORTER_KEY_FILE"
+    exit 1
+fi
+if [[ ! -f "$IRONIC_PROMETHEUS_EXPORTER_CERT_FILE" ]] && [[ -f "$IRONIC_PROMETHEUS_EXPORTER_KEY_FILE" ]]; then
+    echo "Missing TLS Certificate file $IRONIC_PROMETHEUS_EXPORTER_CERT_FILE"
     exit 1
 fi
 
@@ -93,6 +104,12 @@ if [[ -f "$IPXE_CERT_FILE" ]]; then
 else
     export IPXE_SCHEME="http"
     export IPXE_TLS_SETUP="false"
+fi
+
+if [[ -f "$IRONIC_PROMETHEUS_EXPORTER_CERT_FILE" ]]; then
+    export IRONIC_PROMETHEUS_EXPORTER_TLS_SETUP="true"
+else
+    export IRONIC_PROMETHEUS_EXPORTER_TLS_SETUP="false"
 fi
 
 if [[ -f "$MARIADB_CACERT_FILE" ]]; then


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: When TLS certificates are mounted, gunicorn interfaces using TLS.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:** 

- [X] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
