### PR TITLE
🌱 Disable prometheus exporter by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,19 @@ media HTTP server configuration:
   `true` will make the server enforce its cipher list ordering for TLS version
   up to 1.2, defaults to `false`
 
+## Prometheus Exporter
+
+The `runironic-exporter` entry point runs the ironic-prometheus-exporter,
+which exposes Ironic sensor data as Prometheus metrics via an HTTP `/metrics`
+endpoint.
+
+- `IRONIC_EXPORTER_ENABLED` - Whether to run the Prometheus exporter (default
+  `false`). Must be set to `true` to run the exporter.
+- `FLASK_RUN_HOST` - IP address the metrics endpoint listens on (default
+  `0.0.0.0`, all interfaces). Can be set to a specific IP to limit exposure
+  to a particular network interface.
+- `FLASK_RUN_PORT` - Port the metrics endpoint listens on (default `9608`).
+
 ## Ironic Networking
 
 The ironic networking configuration can be overridden by various environment

--- a/scripts/runironic-exporter
+++ b/scripts/runironic-exporter
@@ -1,5 +1,15 @@
 #!/usr/bin/bash
 
+set -euxo pipefail
+
+# The operator sets this to "true" when enabling the exporter.
+IRONIC_EXPORTER_ENABLED=${IRONIC_EXPORTER_ENABLED:-false}
+
+if [[ "${IRONIC_EXPORTER_ENABLED}" != "true" ]]; then
+    echo " Exporter is disabled. Set EXPORTER_ENABLED=true to enable."
+    exit 0
+fi
+
 # Set dummy provisioning IP to avoid interface detection issues (not needed to run IPE to service `/metrics`)
 export PROVISIONING_IP="127.0.0.1"
 # Set to true since running this script implies sensor data metrics are needed


### PR DESCRIPTION

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Disable the exporter by default so `IRONIC_EXPORTER_ENABLED` must be explicitly set to true to enable the exporter. Update documentation to explain this and explain how `FLASK_RUN_HOST` can be changed for added hardening

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [X] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
