### PR TITLE
:seedling: Reduce /shared/html directory permissions

### DIFF
--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -22,7 +22,7 @@ export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
 wait_for_interface_or_ip
 
 mkdir -p /shared/html
-chmod 2775 /shared/html
+chmod 0777 /shared/html
 
 INSPECTOR_EXTRA_ARGS=" ipa-inspection-callback-url=${IRONIC_BASE_URL}/v1/continue_inspection"
 
@@ -66,7 +66,7 @@ fi
 if [[ "$IPXE_TLS_SETUP" == "true" ]]; then
     HTTPS_IPXE_BOOT_DIR="/shared/html/custom-ipxe"
     mkdir -p "${HTTPS_IPXE_BOOT_DIR}"
-    chmod 2775 "${HTTPS_IPXE_BOOT_DIR}"
+    chmod 0777 "${HTTPS_IPXE_BOOT_DIR}"
     render_j2_config "/templates/httpd-ipxe.conf.j2" "${HTTPD_CONF_DIR_D}/ipxe.conf"
     copy_ipxe_firmware "${IPXE_CUSTOM_FIRMWARE_DIR}" "${HTTPS_IPXE_BOOT_DIR}"
 fi


### PR DESCRIPTION

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Reduce permissions on /shared/html and /shared/html/custom-ipx from 777 to 755, and relying on group ownership(ironic:ironic) for write access in the custom. This prevents potential boot integrity tampering by other containers sharing the /shared volume.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
