### PR TITLE
📖 Document how the last value in the cipher suite list is choosen as the default value

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -194,6 +194,8 @@ command_retry_timeout = 60
 # List of possible cipher suites versions that can be
 # supported by the hardware in case the field `cipher_suite`
 # is not set for the node. (list value)
+# Last value in the list is the chosen as the default value
+# Ironic traverses the list last-to-first
 cipher_suite_versions = 3,17
 
 {% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of thhttps://github.com/openstack/ironic/blob/62dc38f151fc7ceee749794ae919757cbdd77fb7/ironic/drivers/modules/ipmitool.py#L591e changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Ironic checks the values of the list from last to first so the final value is the default. This behavior is  unconventional and should thus be documented.
https://github.com/openstack/ironic/blob/62dc38f151fc7ceee749794ae919757cbdd77fb7/ironic/drivers/modules/ipmitool.py#L591

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:** 

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
