### PR TITLE
:seedling: fix irso-functional by using IRSO 0.8 checkout

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: metal3-io/ironic-standalone-operator
+        ref: release-0.8
         path: ironic-standalone-operator
     - name: Calculate go version
       id: vars


### PR DESCRIPTION
We need to use IRSO version that supports this Ironic version.

Fixes: #1015