### PR TITLE
:seedling: future-proof irso-functional by using IRSO 0.9 checkout

### DIFF
--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: metal3-io/ironic-standalone-operator
+        ref: release-0.9
         path: ironic-standalone-operator
         persist-credentials: false
     - name: Calculate go version


### PR DESCRIPTION
Functional would break in future if not pinned, when IRSO main drops it.
