### PR TITLE
 🐛 fix: BMC atomic cert injection/update

### DIFF
--- a/scripts/runironic
+++ b/scripts/runironic
@@ -14,17 +14,50 @@ fi
 if [[ "${IRONIC_INJECT_IPA}" == "true" ]]; then
     generate_cacert_bundle_initrd /shared/html/ipa-cacert-bundle
 fi
+
 configure_restart_on_certificate_update "${IRONIC_INJECT_IPA}" ironic "${WEBSERVER_CACERT_FILE:-}"
 configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" ironic "${IRONIC_CERT_FILE}"
 
 configure_ironic_auth
 
 if [[ "${BMC_TLS_ENABLED}" == "true" ]]; then
-    # shellcheck disable=SC2034
+    # Check if BMC_CACERTS_PATH is set
+    if [[ -z "${BMC_CACERTS_PATH}" ]]; then
+        echo "ERROR: BMC_CACERTS_PATH is not set" >&2
+        exit 1
+    fi
+    
+    # Check IF any shell injection attempts in BMC_CACERTS_PATH
+    if [[ "${BMC_CACERTS_PATH}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERTS_PATH}" =~ \$\( ]]; then
+        echo "ERROR: BMC_CACERTS_PATH contains invalid characters (potential shell injection): ${BMC_CACERTS_PATH}" >&2
+        exit 1
+    fi
+    
+    # Check if BMC_CACERT_FILE is set
+    if [[ -z "${BMC_CACERT_FILE}" ]]; then
+        echo "ERROR: BMC_CACERT_FILE is not set" >&2
+        exit 1
+    fi
+    
+    # Check IF any hell injection attempts in BMC_CACERT_FILE
+    if [[ "${BMC_CACERT_FILE}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERT_FILE}" =~ \$\( ]]; then
+        echo "ERROR: BMC_CACERT_FILE contains invalid characters (potential shell injection): ${BMC_CACERT_FILE}" >&2
+        exit 1
+    fi
+    
+    # Verify directory exists
+    if ! test -d "${BMC_CACERTS_PATH}"; then
+        echo "ERROR: BMC_CACERTS_PATH is not a valid directory: ${BMC_CACERTS_PATH}" >&2
+        exit 1
+    fi
+    
+    # shellcheck disable=SC2016
     watchmedo shell-command \
         --patterns="*" \
         --ignore-directories \
-        --command='cat "${BMC_CACERTS_PATH}"/* > "${BMC_CACERT_FILE}"' \
+        --command='tmp=$(mktemp --tmpdir="$(dirname "${BMC_CACERT_FILE}")") && \
+cat "${BMC_CACERTS_PATH}"/* > "${tmp}" && \
+copy_atomic "${tmp}" "${BMC_CACERT_FILE}"' \
         "${BMC_CACERTS_PATH}" &
 fi
 

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -21,43 +21,47 @@ configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" ironic "${IRONIC_C
 configure_ironic_auth
 
 if [[ "${BMC_TLS_ENABLED}" == "true" ]]; then
+    # Characters we reject in the BMC cert paths
+    # Defined once and matched literally as a regex class.
+    bad_chars='[;|&$`!()]'
+
     # Check if BMC_CACERTS_PATH is set
     if [[ -z "${BMC_CACERTS_PATH}" ]]; then
         echo "ERROR: BMC_CACERTS_PATH is not set" >&2
         exit 1
     fi
-    
-    # Check IF any shell injection attempts in BMC_CACERTS_PATH
-    if [[ "${BMC_CACERTS_PATH}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERTS_PATH}" =~ \$\( ]]; then
+
+    # Check if any shell injection attempts in BMC_CACERTS_PATH
+    if [[ "${BMC_CACERTS_PATH}" =~ $bad_chars ]]; then
         echo "ERROR: BMC_CACERTS_PATH contains invalid characters (potential shell injection): ${BMC_CACERTS_PATH}" >&2
         exit 1
     fi
-    
+
     # Check if BMC_CACERT_FILE is set
     if [[ -z "${BMC_CACERT_FILE}" ]]; then
         echo "ERROR: BMC_CACERT_FILE is not set" >&2
         exit 1
     fi
-    
-    # Check IF any hell injection attempts in BMC_CACERT_FILE
-    if [[ "${BMC_CACERT_FILE}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERT_FILE}" =~ \$\( ]]; then
+
+    # Check if any shell injection attempts in BMC_CACERT_FILE
+    if [[ "${BMC_CACERT_FILE}" =~ $bad_chars ]]; then
         echo "ERROR: BMC_CACERT_FILE contains invalid characters (potential shell injection): ${BMC_CACERT_FILE}" >&2
         exit 1
     fi
-    
+
     # Verify directory exists
     if ! test -d "${BMC_CACERTS_PATH}"; then
         echo "ERROR: BMC_CACERTS_PATH is not a valid directory: ${BMC_CACERTS_PATH}" >&2
         exit 1
     fi
-    
+
     # shellcheck disable=SC2016
     watchmedo shell-command \
         --patterns="*" \
         --ignore-directories \
         --command='tmp=$(mktemp --tmpdir="$(dirname "${BMC_CACERT_FILE}")") && \
 cat "${BMC_CACERTS_PATH}"/* > "${tmp}" && \
-copy_atomic "${tmp}" "${BMC_CACERT_FILE}"' \
+mv "${tmp}" "${BMC_CACERT_FILE}"' \
         "${BMC_CACERTS_PATH}" &
 fi
 

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -16,17 +16,50 @@ fi
 if [[ "${IRONIC_INJECT_IPA}" == "true" ]]; then
     generate_cacert_bundle_initrd /shared/html/ipa-cacert-bundle
 fi
+
 configure_restart_on_certificate_update "${IRONIC_INJECT_IPA}" ironic "${WEBSERVER_CACERT_FILE:-}"
 configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" ironic "${IRONIC_CERT_FILE}"
 
 configure_ironic_auth
 
 if [[ "${BMC_TLS_ENABLED}" == "true" ]]; then
-    # shellcheck disable=SC2034
+    # Check if BMC_CACERTS_PATH is set
+    if [[ -z "${BMC_CACERTS_PATH}" ]]; then
+        echo "ERROR: BMC_CACERTS_PATH is not set" >&2
+        exit 1
+    fi
+    
+    # Check IF any shell injection attempts in BMC_CACERTS_PATH
+    if [[ "${BMC_CACERTS_PATH}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERTS_PATH}" =~ \$\( ]]; then
+        echo "ERROR: BMC_CACERTS_PATH contains invalid characters (potential shell injection): ${BMC_CACERTS_PATH}" >&2
+        exit 1
+    fi
+    
+    # Check if BMC_CACERT_FILE is set
+    if [[ -z "${BMC_CACERT_FILE}" ]]; then
+        echo "ERROR: BMC_CACERT_FILE is not set" >&2
+        exit 1
+    fi
+    
+    # Check IF any hell injection attempts in BMC_CACERT_FILE
+    if [[ "${BMC_CACERT_FILE}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERT_FILE}" =~ \$\( ]]; then
+        echo "ERROR: BMC_CACERT_FILE contains invalid characters (potential shell injection): ${BMC_CACERT_FILE}" >&2
+        exit 1
+    fi
+    
+    # Verify directory exists
+    if ! test -d "${BMC_CACERTS_PATH}"; then
+        echo "ERROR: BMC_CACERTS_PATH is not a valid directory: ${BMC_CACERTS_PATH}" >&2
+        exit 1
+    fi
+    
+    # shellcheck disable=SC2016
     watchmedo shell-command \
         --patterns="*" \
         --ignore-directories \
-        --command='cat "${BMC_CACERTS_PATH}"/* > "${BMC_CACERT_FILE}"' \
+        --command='tmp=$(mktemp --tmpdir="$(dirname "${BMC_CACERT_FILE}")") && \
+cat "${BMC_CACERTS_PATH}"/* > "${tmp}" && \
+copy_atomic "${tmp}" "${BMC_CACERT_FILE}"' \
         "${BMC_CACERTS_PATH}" &
 fi
 

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -23,43 +23,11 @@ configure_restart_on_certificate_update "${IRONIC_TLS_SETUP}" ironic "${IRONIC_C
 configure_ironic_auth
 
 if [[ "${BMC_TLS_ENABLED}" == "true" ]]; then
-    # Check if BMC_CACERTS_PATH is set
-    if [[ -z "${BMC_CACERTS_PATH}" ]]; then
-        echo "ERROR: BMC_CACERTS_PATH is not set" >&2
-        exit 1
-    fi
-    
-    # Check IF any shell injection attempts in BMC_CACERTS_PATH
-    if [[ "${BMC_CACERTS_PATH}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERTS_PATH}" =~ \$\( ]]; then
-        echo "ERROR: BMC_CACERTS_PATH contains invalid characters (potential shell injection): ${BMC_CACERTS_PATH}" >&2
-        exit 1
-    fi
-    
-    # Check if BMC_CACERT_FILE is set
-    if [[ -z "${BMC_CACERT_FILE}" ]]; then
-        echo "ERROR: BMC_CACERT_FILE is not set" >&2
-        exit 1
-    fi
-    
-    # Check IF any hell injection attempts in BMC_CACERT_FILE
-    if [[ "${BMC_CACERT_FILE}" =~ [';|&$`!'] ]] || [[ "${BMC_CACERT_FILE}" =~ \$\( ]]; then
-        echo "ERROR: BMC_CACERT_FILE contains invalid characters (potential shell injection): ${BMC_CACERT_FILE}" >&2
-        exit 1
-    fi
-    
-    # Verify directory exists
-    if ! test -d "${BMC_CACERTS_PATH}"; then
-        echo "ERROR: BMC_CACERTS_PATH is not a valid directory: ${BMC_CACERTS_PATH}" >&2
-        exit 1
-    fi
-    
     # shellcheck disable=SC2016
     watchmedo shell-command \
         --patterns="*" \
         --ignore-directories \
-        --command='tmp=$(mktemp --tmpdir="$(dirname "${BMC_CACERT_FILE}")") && \
-cat "${BMC_CACERTS_PATH}"/* > "${tmp}" && \
-copy_atomic "${tmp}" "${BMC_CACERT_FILE}"' \
+        --command='tmp=$(mktemp "${BMC_CACERT_FILE}.XXXXXX") && cat "${BMC_CACERTS_PATH}"/* > "${tmp}" && mv "${tmp}" "${BMC_CACERT_FILE}"' \
         "${BMC_CACERTS_PATH}" &
 fi
 

--- a/scripts/tls-common.sh
+++ b/scripts/tls-common.sh
@@ -145,11 +145,12 @@ configure_restart_on_certificate_update()
 
 if ls "${BMC_CACERTS_PATH}"/* > /dev/null 2>&1; then
     export BMC_TLS_ENABLED="true"
-    BMC_CACERT_TMPFILE="$(mktemp --tmpdir="$(dirname "${BMC_CACERT_FILE}")")"
-    trap 'rm -f "${BMC_CACERT_TMPFILE}"' EXIT
-    cat "${BMC_CACERTS_PATH}"/* > "${BMC_CACERT_TMPFILE}" || { echo "ERROR: Failed to concatenate BMC certificates"; exit 1; }
-    chmod --reference="${BMC_CACERT_FILE}" "${BMC_CACERT_TMPFILE}" 2>/dev/null || { echo "WARNING: Could not preserve permissions"; }
-    mv "${BMC_CACERT_TMPFILE}" "${BMC_CACERT_FILE}" || { echo "ERROR: Failed to move certificate file"; exit 1; }
+    bmc_tmp=$(mktemp "${BMC_CACERT_FILE}.XXXXXX")
+    if ! { cat "${BMC_CACERTS_PATH}"/* > "${bmc_tmp}" && chmod 0644 "${bmc_tmp}" && mv "${bmc_tmp}" "${BMC_CACERT_FILE}"; }; then
+        rm -f "${bmc_tmp}"
+        echo "Failed to assemble BMC CA bundle from ${BMC_CACERTS_PATH}" >&2
+        exit 1
+    fi
 else
     export BMC_TLS_ENABLED="false"
 fi
@@ -157,7 +158,7 @@ fi
 if [[ -f "${WEBSERVER_CACERT_FILE:-}" ]]; then
     export IRONIC_INJECT_IPA="true"
     copy_atomic "${WEBSERVER_CACERT_FILE}" "${IPA_CACERT_FILE}"
-    
+
     if [[ -f "${IRONIC_CACERT_FILE}" ]]; then
         cat "${IRONIC_CACERT_FILE}" >> "${IPA_CACERT_FILE}"
     fi


### PR DESCRIPTION
Switches the cert bundle write to a temp file + atomic move, so the live file is never seen empty or partially written during rotation.