### PR TITLE
⚠️ Replace IRONIC_IP with IRONIC_IPV4 and IRONIC_IPV6, for correct dual-stack and single stack binding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ functionality:
 - `DHCP_OPTIONS` - a `;` separated list of additional `dhcp-option` directives
    that allows passing specific network configuration parameters (like routers,
    DNS servers, and NTP) to DHCP clients (empty by default). Only applies to
-   IPv4 provisioning (`IPV=4` or unset). For more details on `dhcp-option` see
+   IPv4 provisioning, if enabled . For more details on `dhcp-option` see
    [the man page](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html).
 - `DHCP_IGNORE` - a set of tags on hosts that should be ignored and not allocate
    DHCP leases for, e.g. `tag:!known` to ignore any unknown hosts (empty by

--- a/ironic-config/apache2-ipxe.conf.j2
+++ b/ironic-config/apache2-ipxe.conf.j2
@@ -1,4 +1,5 @@
-Listen {{ env.IPXE_TLS_PORT }}
+Listen 0.0.0.0:{{ env.IPXE_TLS_PORT }}
+Listen [::]:{{ env.IPXE_TLS_PORT }}
 
 <VirtualHost *:{{ env.IPXE_TLS_PORT }}>
     ErrorLog /dev/stderr

--- a/ironic-config/apache2-vmedia.conf.j2
+++ b/ironic-config/apache2-vmedia.conf.j2
@@ -1,4 +1,5 @@
-Listen {{ env.VMEDIA_TLS_PORT }}
+Listen 0.0.0.0:{{ env.VMEDIA_TLS_PORT }}
+Listen [::]:{{ env.VMEDIA_TLS_PORT }}
 
 <VirtualHost *:{{ env.VMEDIA_TLS_PORT }}>
     ErrorLog /dev/stderr

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -42,12 +42,12 @@ dhcp-option={{ opt }}
 dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9
 # Client is (i)PXE booting on EFI machine
-dhcp-boot=tag:efi,/{{ env.SNP_BASENAME }}-x86_64.efi,{{ env.IRONIC_IP }}
+dhcp-boot=tag:efi,/{{ env.SNP_BASENAME }}-x86_64.efi,{{ env.IRONIC_IPV4 }}
 # Client is (i)PXE booting on arm64 EFI machine
 dhcp-match=set:efi-arm64,option:client-arch,11
-dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IP }}
+dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IPV4 }}
 # Client is running (i)PXE on BIOS machine
-dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IP }}
+dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IPV4 }}
 {%- if env.IPXE_TLS_SETUP != "true" %}
 dhcp-boot=tag:ipxe,http://{{ env.IRONIC_IPV4 }}:{{ env.HTTP_PORT }}/boot.ipxe
 {% endif %}

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -15,17 +15,13 @@ dhcp-range={{ item }}
 {%- endfor %}
 {% endif %}
 
-{%- if env["DNS_IP"] is undefined %}
-# Disable DNS over provisioning network
-dhcp-option=6
-{% else %}
-dhcp-option=option{% if ":" in env["DNS_IP"] %}6{% endif %}:dns-server,{{ env["DNS_IP"] }}
-{% endif %}
-
 {# Network boot options for IPv4 and IPv6 #}
-{%- if env.IPV == "4" or env.IPV is undefined %}
+{%- if env.ENABLE_IPV4 %}
 # IPv4 Configuration:
 dhcp-match=ipxe,175
+
+# Either set the DNS option with DNS_IPV4 or disable the option
+dhcp-option=option:dns-server{% if env.DNS_IPV4 %},{{ env.DNS_IPV4 }}{% endif %}
 
 {# Set the router or disable it. Setting router is IPv4 specific, in v6 there #}
 {# are router advertisements that do the same thing. #}
@@ -53,14 +49,17 @@ dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IP }}
 # Client is running (i)PXE on BIOS machine
 dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IP }}
 {%- if env.IPXE_TLS_SETUP != "true" %}
-dhcp-boot=tag:ipxe,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
+dhcp-boot=tag:ipxe,http://{{ env.IRONIC_IPV4 }}:{{ env.HTTP_PORT }}/boot.ipxe
 {% endif %}
 {% endif %}
 
-{% if env.IPV == "6" %}
+{%- if env.ENABLE_IPV6 %}
 # IPv6 Configuration:
 enable-ra
 ra-param={{ env.PROVISIONING_INTERFACE }},0,0
+
+# Either set the DNS option with DNS_IPV6 or disable the option
+dhcp-option=option6:dns-server{% if env.DNS_IPV6 %},[{{ env.DNS_IPV6 }}]{% endif %}
 
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -17,12 +17,12 @@ Listen [::]:{{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
 {% if env.ENABLE_IPV4 %}
-Listen {{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}
+Listen {{ env.IRONIC_IPV4 }}:{{ env.IRONIC_LISTEN_PORT }}
 {% endif %}
 {% if env.ENABLE_IPV6 %}
 Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
 {% endif %}
-<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
+<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IPV4 }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
 {% endif %}
 
     DocumentRoot "/shared/html"

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -12,11 +12,17 @@
 
 
 {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.IRONIC_LISTEN_PORT }}
+Listen 0.0.0.0:{{ env.IRONIC_LISTEN_PORT }}
+Listen [::]:{{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost *:{{ env.IRONIC_LISTEN_PORT }}>
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
- <VirtualHost {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}>
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}
+{% endif %}
+<VirtualHost {% if env.ENABLE_IPV4 %}{{ env.IRONIC_IP }}:{{ env.IRONIC_LISTEN_PORT }}{% endif %} {% if env.ENABLE_IPV6 %}[{{ env.IRONIC_IPV6 }}]:{{ env.IRONIC_LISTEN_PORT }}{% endif %}>
 {% endif %}
 
     DocumentRoot "/shared/html"

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -1,8 +1,14 @@
 ServerRoot {{ env.HTTPD_DIR }}
 {%- if env.LISTEN_ALL_INTERFACES | lower == "true" %}
-Listen {{ env.HTTP_PORT }}
+Listen 0.0.0.0:{{ env.HTTP_PORT }}
+Listen [::]:{{ env.HTTP_PORT }}
 {% else %}
-Listen {{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}
+{% if env.ENABLE_IPV4 %}
+Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+Listen [{{ env.IRONIC_IPV6 }}]:{{ env.HTTP_PORT }}
+{% endif %}
 {% endif %}
 Include /etc/httpd/conf.modules.d/*.conf
 User apache

--- a/ironic-config/httpd.conf.j2
+++ b/ironic-config/httpd.conf.j2
@@ -4,7 +4,7 @@ Listen 0.0.0.0:{{ env.HTTP_PORT }}
 Listen [::]:{{ env.HTTP_PORT }}
 {% else %}
 {% if env.ENABLE_IPV4 %}
-Listen {{ env.IRONIC_IP }}:{{ env.HTTP_PORT }}
+Listen {{ env.IRONIC_IPV4 }}:{{ env.HTTP_PORT }}
 {% endif %}
 {% if env.ENABLE_IPV6 %}
 Listen [{{ env.IRONIC_IPV6 }}]:{{ env.HTTP_PORT }}

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -39,7 +39,13 @@ rpc_transport = none
 use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
+{% if env.ENABLE_IPV4 %}
 my_ip = {{ env.IRONIC_IP }}
+{% endif %}
+{% if env.ENABLE_IPV6 %}
+my_ipv6 = {{ env.IRONIC_IPV6 }}
+{% endif %}
+
 host = {{ env.IRONIC_CONDUCTOR_HOST }}
 
 # If a path to a certificate is defined, use that first for webserver
@@ -85,7 +91,7 @@ port = {{ env.IRONIC_PRIVATE_PORT }}
 {% endif %}
 public_endpoint = {{ env.IRONIC_BASE_URL }}
 {% else %}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_LISTEN_ADDRESS }}
 port = {{ env.IRONIC_LISTEN_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 enable_ssl_api = true
@@ -212,7 +218,7 @@ cipher_suite_versions = 3,17
 # containers are in host networking.
 auth_strategy = http_basic
 http_basic_auth_user_file = {{ env.IRONIC_RPC_HTPASSWD_FILE }}
-host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+host_ip = {{ env.IRONIC_LISTEN_ADDRESS }}
 port = {{ env.IRONIC_JSON_RPC_PORT }}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 use_ssl = true

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -40,7 +40,7 @@ use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
 {% if env.ENABLE_IPV4 %}
-my_ip = {{ env.IRONIC_IP }}
+my_ip = {{ env.IRONIC_IPV4 }}
 {% endif %}
 {% if env.ENABLE_IPV6 %}
 my_ipv6 = {{ env.IRONIC_IPV6 }}

--- a/scripts/configure-ironic-networking.sh
+++ b/scripts/configure-ironic-networking.sh
@@ -35,8 +35,8 @@ export NO_PROXY="${NO_PROXY:-}"
 if [[ -n "${IRONIC_IPV6}" ]]; then
     export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
 fi
-if [[ -n "${IRONIC_IP}" ]]; then
-    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+if [[ -n "${IRONIC_IPV4}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV4}"
 fi
 
 # Ensure driver config directory exists

--- a/scripts/configure-ironic-networking.sh
+++ b/scripts/configure-ironic-networking.sh
@@ -30,7 +30,14 @@ render_j2_config "/etc/ironic/ironic-networking.conf.j2" \
 configure_json_rpc_auth "ironic_networking_json_rpc"
 
 # Make sure ironic traffic bypasses any proxies
-export NO_PROXY="${NO_PROXY:-},${IRONIC_IP}"
+export NO_PROXY="${NO_PROXY:-}"
+
+if [[ -n "${IRONIC_IPV6}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
+fi
+if [[ -n "${IRONIC_IP}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+fi
 
 # Ensure driver config directory exists
 mkdir -p "${IRONIC_NETWORKING_DRIVER_CONFIG_DIR}"

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -112,4 +112,11 @@ if [[ "${IRONIC_NETWORKING_ENABLED}" == "true" ]]; then
 fi
 
 # Make sure ironic traffic bypasses any proxies
-export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"
+export NO_PROXY="${NO_PROXY:-}"
+
+if [[ -n "${IRONIC_IPV6}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
+fi
+if [[ -n "${IRONIC_IP}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+fi

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -55,7 +55,7 @@ if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true
 elif [[ -n "${ENABLE_IPV6}" ]]; then
     export IRONIC_LISTEN_ADDRESS="${IRONIC_IPV6}"
 else
-    export IRONIC_LISTEN_ADDRESS="${IRONIC_IP}"
+    export IRONIC_LISTEN_ADDRESS="${IRONIC_IPV4}"
 fi
 
 # Hostname to use for the current conductor instance.
@@ -125,6 +125,6 @@ export NO_PROXY="${NO_PROXY:-}"
 if [[ -n "${IRONIC_IPV6}" ]]; then
     export NO_PROXY="${NO_PROXY},${IRONIC_IPV6}"
 fi
-if [[ -n "${IRONIC_IP}" ]]; then
-    export NO_PROXY="${NO_PROXY},${IRONIC_IP}"
+if [[ -n "${IRONIC_IPV4}" ]]; then
+    export NO_PROXY="${NO_PROXY},${IRONIC_IPV4}"
 fi

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -50,6 +50,14 @@ export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
 
 wait_for_interface_or_ip
 
+if [[ "$(echo "${LISTEN_ALL_INTERFACES}" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+    export IRONIC_LISTEN_ADDRESS="::"
+elif [[ -n "${ENABLE_IPV6}" ]]; then
+    export IRONIC_LISTEN_ADDRESS="${IRONIC_IPV6}"
+else
+    export IRONIC_LISTEN_ADDRESS="${IRONIC_IP}"
+fi
+
 # Hostname to use for the current conductor instance.
 export IRONIC_CONDUCTOR_HOST=${IRONIC_CONDUCTOR_HOST:-${IRONIC_URL_HOST}}
 

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 # Export IRONIC_IP to avoid needing to lean on IRONIC_URL_HOST for consumption in
 # e.g. dnsmasq configuration
 export IRONIC_IP="${IRONIC_IP:-}"
+export IRONIC_IPV4=""
 export IRONIC_IPV6=""
 PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
 PROVISIONING_IP="${PROVISIONING_IP:-}"
@@ -199,7 +200,7 @@ wait_for_interface_or_ip()
             export IRONIC_IPV6="${PARSED_IP}"
             unset IRONIC_IP
         else
-            export IRONIC_IP="${PARSED_IP}"
+            export IRONIC_IPV4="${PARSED_IP}"
         fi
     elif [[ -n "${PROVISIONING_IP}" ]]; then
         # If $PROVISIONING_IP is specified, then we wait for that to become
@@ -228,17 +229,17 @@ wait_for_interface_or_ip()
         if [[ "${PARSED_IP}" =~ .*:.* ]]; then
             export IRONIC_IPV6="${PARSED_IP}"
         else
-            export IRONIC_IP="${PARSED_IP}"
+            export IRONIC_IPV4="${PARSED_IP}"
         fi
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         local deadline=$(( SECONDS + IRONIC_IP_WAIT_TIMEOUT ))
-        until [[ -n "${IRONIC_IPV6}" ]] || [[ -n "${IRONIC_IP}" ]]; do
+        until [[ -n "${IRONIC_IPV6}" ]] || [[ -n "${IRONIC_IPV4}" ]]; do
             fail_if_timed_out "${deadline}" "${IRONIC_IP_WAIT_TIMEOUT}" \
                 "waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             IRONIC_IPV6="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 6)"
             sleep "${IRONIC_IP_WAIT_INTERVAL}"
-            IRONIC_IP="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 4)"
+            IRONIC_IPV4="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 4)"
             sleep "${IRONIC_IP_WAIT_INTERVAL}"
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured..."
         done
@@ -248,9 +249,9 @@ wait_for_interface_or_ip()
             echo "Found ${IRONIC_IPV6} on interface \"${PROVISIONING_INTERFACE}\"!"
             export IRONIC_IPV6
         fi
-        if [[ -n "${IRONIC_IP}" ]]; then
-            echo "Found ${IRONIC_IP} on interface \"${PROVISIONING_INTERFACE}\"!"
-            export IRONIC_IP
+        if [[ -n "${IRONIC_IPV4}" ]]; then
+            echo "Found ${IRONIC_IPV4} on interface \"${PROVISIONING_INTERFACE}\"!"
+            export IRONIC_IPV4
         fi
     else
         echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
@@ -259,9 +260,9 @@ wait_for_interface_or_ip()
 
     # Define the URLs based on the what we have found,
     # prioritize IPv6 for IRONIC_URL_HOST
-    if [[ -n "${IRONIC_IP}" ]]; then
+    if [[ -n "${IRONIC_IPV4}" ]]; then
         export ENABLE_IPV4=yes
-        export IRONIC_URL_HOST="${IRONIC_IP}"
+        export IRONIC_URL_HOST="${IRONIC_IPV4}"
     fi
     if [[ -n "${IRONIC_IPV6}" ]]; then
         export ENABLE_IPV6=yes

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 # Export IRONIC_IP to avoid needing to lean on IRONIC_URL_HOST for consumption in
 # e.g. dnsmasq configuration
 export IRONIC_IP="${IRONIC_IP:-}"
+export IRONIC_IPV6=""
 PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
 PROVISIONING_IP="${PROVISIONING_IP:-}"
 PROVISIONING_MACS="${PROVISIONING_MACS:-}"
@@ -114,6 +115,33 @@ export PROVISIONING_INTERFACE
 
 export LISTEN_ALL_INTERFACES="${LISTEN_ALL_INTERFACES:-true}"
 
+get_ip_of_interface()
+{
+    local IP_VERS
+    local IP_ADDR
+
+    if [[ $# -gt 2 ]]; then
+        echo "ERROR: ${FUNCNAME[0]}: too many parameters" >&2
+        exit 1
+    fi
+
+    if [[ $# -eq 2 ]]; then
+        case "$2" in
+        4|6)
+            IP_VERS="-$2"
+            ;;
+        *)
+            echo "ERROR: ${FUNCNAME[0]}: the second parameter should be [4|6] (or missing for both)" >&2
+            exit 1
+            ;;
+        esac
+    fi
+
+    IFACE="$1"
+
+    ip "${IP_VERS[@]}" -br addr show scope global up dev "${IFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1
+}
+
 get_interface_of_ip()
 {
     if [[ $# -lt 1 ]] || [[ $# -gt 2 ]]; then
@@ -167,7 +195,12 @@ wait_for_interface_or_ip()
             exit 1
         fi
 
-        export IRONIC_IP="${PARSED_IP}"
+        if [[ "${PARSED_IP}" =~ .*:.* ]]; then
+            export IRONIC_IPV6="${PARSED_IP}"
+            unset IRONIC_IP
+        else
+            export IRONIC_IP="${PARSED_IP}"
+        fi
     elif [[ -n "${PROVISIONING_IP}" ]]; then
         # If $PROVISIONING_IP is specified, then we wait for that to become
         # available on an interface, otherwise we look at $PROVISIONING_INTERFACE
@@ -192,30 +225,47 @@ wait_for_interface_or_ip()
         echo "Found ${PROVISIONING_IP} on interface \"${IFACE_OF_IP}\"!"
 
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
-        export IRONIC_IP="${PARSED_IP}"
+        if [[ "${PARSED_IP}" =~ .*:.* ]]; then
+            export IRONIC_IPV6="${PARSED_IP}"
+        else
+            export IRONIC_IP="${PARSED_IP}"
+        fi
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
         local deadline=$(( SECONDS + IRONIC_IP_WAIT_TIMEOUT ))
-        until [[ -n "$IRONIC_IP" ]]; do
+        until [[ -n "${IRONIC_IPV6}" ]] || [[ -n "${IRONIC_IP}" ]]; do
             fail_if_timed_out "${deadline}" "${IRONIC_IP_WAIT_TIMEOUT}" \
                 "waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-            IRONIC_IP="$(ip -br addr show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)"
-            export IRONIC_IP
+            IRONIC_IPV6="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 6)"
             sleep "${IRONIC_IP_WAIT_INTERVAL}"
+            IRONIC_IP="$(get_ip_of_interface "${PROVISIONING_INTERFACE}" 4)"
+            sleep "${IRONIC_IP_WAIT_INTERVAL}"
+            echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured..."
         done
+
+        # Add some debugging output
+        if [[ -n "${IRONIC_IPV6}" ]]; then
+            echo "Found ${IRONIC_IPV6} on interface \"${PROVISIONING_INTERFACE}\"!"
+            export IRONIC_IPV6
+        fi
+        if [[ -n "${IRONIC_IP}" ]]; then
+            echo "Found ${IRONIC_IP} on interface \"${PROVISIONING_INTERFACE}\"!"
+            export IRONIC_IP
+        fi
     else
         echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
         return 1
     fi
 
-    # If the IP contains a colon, then it's an IPv6 address, and the HTTP
-    # host needs surrounding with brackets
-    if [[ "$IRONIC_IP" =~ .*:.* ]]; then
-        export IPV=6
-        export IRONIC_URL_HOST="[$IRONIC_IP]"
-    else
-        export IPV=4
-        export IRONIC_URL_HOST="$IRONIC_IP"
+    # Define the URLs based on the what we have found,
+    # prioritize IPv6 for IRONIC_URL_HOST
+    if [[ -n "${IRONIC_IP}" ]]; then
+        export ENABLE_IPV4=yes
+        export IRONIC_URL_HOST="${IRONIC_IP}"
+    fi
+    if [[ -n "${IRONIC_IPV6}" ]]; then
+        export ENABLE_IPV6=yes
+        export IRONIC_URL_HOST="[${IRONIC_IPV6}]" # The HTTP host needs surrounding with brackets
     fi
 
     # Avoid having to construct full URL multiple times while allowing

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -12,12 +12,22 @@ TFTP_BOOT_DIR="/shared/tftpboot"
 export DNS_PORT=${DNS_PORT:-0}
 
 wait_for_interface_or_ip
-if [[ "${DNS_IP:-}" == "provisioning" ]]; then
-    if [[ "${IPV}" == "4" ]]; then
-      export DNS_IP="${IRONIC_IP}"
+if [[ -n "${DNS_IP}" ]]; then
+  if [[ "${DNS_IP}" == "provisioning" ]]; then
+      if [[ -n "${ENABLE_IPV4}" ]]; then
+        export DNS_IPV4="${IRONIC_IP}"
+      fi
+      if [[ -n "${ENABLE_IPV6}" ]]; then
+        export DNS_IPV6="${IRONIC_IPV6}"
+      fi
+  else
+    #TODO(mchiappero): perform input validation with "parse_ip_address()" first
+    if [[ "${DNS_IP}" =~ .*:.* ]]; then
+      export DNS_IPV6=${DNS_IP}
     else
-      export DNS_IP="[${IRONIC_IP}]"
+      export DNS_IPV4=${DNS_IP}
     fi
+  fi
 fi
 
 mkdir -p "${TFTP_BOOT_DIR}"

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -12,10 +12,10 @@ TFTP_BOOT_DIR="/shared/tftpboot"
 export DNS_PORT=${DNS_PORT:-0}
 
 wait_for_interface_or_ip
-if [[ -n "${DNS_IP}" ]]; then
+if [[ -n "${DNS_IP:-}" ]]; then
   if [[ "${DNS_IP}" == "provisioning" ]]; then
       if [[ -n "${ENABLE_IPV4}" ]]; then
-        export DNS_IPV4="${IRONIC_IP}"
+        export DNS_IPV4="${IRONIC_IPV4}"
       fi
       if [[ -n "${ENABLE_IPV6}" ]]; then
         export DNS_IPV6="${IRONIC_IPV6}"


### PR DESCRIPTION
What this PR does / why we need it:

Currently the configuration and startup scripts rely on the assumption that all the services should either be exposed on an IPv4 or an IPv6 address. Dual-stack support is somewhat provided by leveraging IPv4-mapped IPv6 addresses, that is, only an IPv6 socket is allocated (which is a discouraged practice). Enable true dual-stack support, both in ironic.conf and all the Apache instances, by introducing IRONIC_IPV6 alongside the existing IRONIC_IP (now renamed IRONIC_IPV4), so that either or both IPs can be leveraged when defined or detected.

To avoid breaking changes and keep the PR simple, externally provided IRONIC_IP and PROVISIONING_IP values will result in either an IPv4 or an IPv6 socket allocated and not both. However, when PROVISIONING_INTERFACE is used, the new code will attempt to detect both IP versions, potentially resulting in a proper dual-stack configuration on a dual-stack system. In this case, IPv6 will however take precedence for URL generation. Future PRs will introduce the ability to handle hostname based URLs, potentially resolving to both IPv4 and IPv6 address, but the core logic to make it possible is contained in this PR.

NOTE:
- it depends on #788, commits are stacked wrt that PR
- it replaces #789, now stale and closed