### PR TITLE
:sparkles: scripts: tolerate distro iPXE binary names and harden firmware copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ functionality:
 - `DEPLOY_KERNEL_URL` and `DEPLOY_RAMDISK_URL` provide the default IPA kernel
   and initramfs images. If they're not set, the images from IPA downloader are
   used (if present).
+- `SNP_BASENAME` - basename of the iPXE EFI binaries served over TFTP
+  (`<basename>-x86_64.efi` / `<basename>-arm64.efi`). It controls both the
+  on-disk firmware name and the bootfile name advertised by dnsmasq, so the two
+  always agree. Defaults to `snponly` (the upstream-built name). Distros that
+  package iPXE under a different name (e.g. openSUSE/SLE ship `snp-<arch>.efi`)
+  can set `SNP_BASENAME=snp`.
 
 ### Multi-Architecture IPA Support
 

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -46,10 +46,10 @@ dhcp-option={{ opt }}
 dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9
 # Client is (i)PXE booting on EFI machine
-dhcp-boot=tag:efi,/snponly-x86_64.efi,{{ env.IRONIC_IP }}
+dhcp-boot=tag:efi,/{{ env.SNP_BASENAME }}-x86_64.efi,{{ env.IRONIC_IP }}
 # Client is (i)PXE booting on arm64 EFI machine
 dhcp-match=set:efi-arm64,option:client-arch,11
-dhcp-boot=tag:efi-arm64,/snponly-arm64.efi,{{ env.IRONIC_IP }}
+dhcp-boot=tag:efi-arm64,/{{ env.SNP_BASENAME }}-arm64.efi,{{ env.IRONIC_IP }}
 # Client is running (i)PXE on BIOS machine
 dhcp-boot=tag:!efi,tag:!efi-arm64,/undionly.kpxe,{{ env.IRONIC_IP }}
 {%- if env.IPXE_TLS_SETUP != "true" %}
@@ -69,13 +69,13 @@ dhcp-userclass=set:ipxe6,iPXE
 # Client is (i)PXE booting on EFI machine
 dhcp-match=set:amd64,option6:61,7
 dhcp-match=set:amd64,option6:61,9
-dhcp-option=tag:pxe6,tag:amd64,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/snponly-x86_64.efi
+dhcp-option=tag:pxe6,tag:amd64,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/{{ env.SNP_BASENAME }}-x86_64.efi
 # Client is (i)PXE booting on arm64 EFI machine
 dhcp-match=set:arm64,option6:61,11
-dhcp-option=tag:pxe6,tag:arm64,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/snponly-arm64.efi
+dhcp-option=tag:pxe6,tag:arm64,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/{{ env.SNP_BASENAME }}-arm64.efi
 # Fallback: serve x86_64 when PXE client is detected but architecture
 # could not be determined. Legacy BIOS does not support IPv6 PXE.
-dhcp-option=tag:pxe6,tag:!amd64,tag:!arm64,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/snponly-x86_64.efi
+dhcp-option=tag:pxe6,tag:!amd64,tag:!arm64,option6:bootfile-url,{{ env.IRONIC_TFTP_URL }}/{{ env.SNP_BASENAME }}-x86_64.efi
 {%- if env.IPXE_TLS_SETUP != "true" %}
 dhcp-option=tag:ipxe6,option6:bootfile-url,{{ env.IRONIC_HTTP_URL }}/boot.ipxe
 {% endif %}

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -9,6 +9,11 @@ PROVISIONING_INTERFACE="${PROVISIONING_INTERFACE:-}"
 PROVISIONING_IP="${PROVISIONING_IP:-}"
 PROVISIONING_MACS="${PROVISIONING_MACS:-}"
 IPXE_CUSTOM_FIRMWARE_DIR="${IPXE_CUSTOM_FIRMWARE_DIR:-/shared/custom_ipxe_firmware}"
+# Basename of the EFI iPXE binaries (<basename>-x86_64.efi / <basename>-arm64.efi).
+# Upstream builds them as "snponly"; distros packaging iPXE differently (e.g.
+# openSUSE/SLE ship "snp") can override this via env or a downstream patch. Used
+# both when copying the binaries and in dnsmasq.conf.j2 that advertises them.
+export SNP_BASENAME="${SNP_BASENAME:-snponly}"
 CUSTOM_CONFIG_DIR="${CUSTOM_CONFIG_DIR:-/conf}"
 CUSTOM_DATA_DIR="${CUSTOM_DATA_DIR:-/data}"
 export DNSMASQ_CONF_DIR="${CUSTOM_CONFIG_DIR}/dnsmasq"
@@ -42,6 +47,30 @@ export IRONIC_USE_MARIADB="${IRONIC_USE_MARIADB:-false}"
 export IRONIC_FORCE_DHCP="${IRONIC_FORCE_DHCP:-false}"
 
 export IRONIC_FAST_TRACK="${IRONIC_FAST_TRACK:-true}"
+
+# Copy iPXE firmware binaries from a source directory into a destination
+# directory. The EFI binary basename is taken from ${SNP_BASENAME} so the served
+# name (dnsmasq.conf.j2) and the on-disk name always agree; downstreams whose
+# distro 'ipxe' package names them differently (e.g. openSUSE/SLE ship
+# snp-<arch>.efi) just override SNP_BASENAME. Missing files are skipped; it is
+# fatal only if no usable iPXE binary was copied.
+copy_ipxe_firmware()
+{
+    local src_dir="$1" dst_dir="$2" fw_file
+    for fw_file in undionly.kpxe "${SNP_BASENAME}-x86_64.efi" "${SNP_BASENAME}-arm64.efi"; do
+        if [[ -f "${src_dir}/${fw_file}" ]]; then
+            cp "${src_dir}/${fw_file}" "${dst_dir}/${fw_file}"
+        else
+            echo "INFO: ${src_dir}/${fw_file} is unavailable, skipping."
+        fi
+    done
+
+    # Validate that at least one legacy bios and one efi iPXE binary was successfully copied
+    if ! ls "${dst_dir}/"*.{kpxe,efi} &>/dev/null; then
+        echo "ERROR: No iPXE firmware files found in ${dst_dir} after copying from ${src_dir}!"
+        exit 1
+    fi
+}
 
 get_provisioning_interface()
 {

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -23,23 +23,12 @@ fi
 mkdir -p "${TFTP_BOOT_DIR}"
 mkdir -p /shared/html
 
-# Copy files to shared mount
+# Copy files to shared mount. Prefer a user-provided custom firmware dir,
+# otherwise fall back to the image's built-in /tftpboot.
 if [[ -r "${IPXE_CUSTOM_FIRMWARE_DIR}" ]]; then
-    for fw_file in undionly.kpxe snponly-x86_64.efi snponly-arm64.efi; do
-        if [[ -f "${IPXE_CUSTOM_FIRMWARE_DIR}/${fw_file}" ]]; then
-            cp "${IPXE_CUSTOM_FIRMWARE_DIR}/${fw_file}" "${TFTP_BOOT_DIR}"
-        else
-            echo "INFO: ${IPXE_CUSTOM_FIRMWARE_DIR}/${fw_file} is unavailable, skipping."
-        fi
-    done
-
-    # Validate that at least one legacy bios and one efi iPXE binary was successfully copied
-    if ! ls "${TFTP_BOOT_DIR}/"*.{kpxe,efi} &>/dev/null; then
-        echo "ERROR: No iPXE firmware files found in ${TFTP_BOOT_DIR} after copying from ${IPXE_CUSTOM_FIRMWARE_DIR}!"
-        exit 1
-    fi
+    copy_ipxe_firmware "${IPXE_CUSTOM_FIRMWARE_DIR}" "${TFTP_BOOT_DIR}"
 else
-    cp /tftpboot/undionly.kpxe /tftpboot/snponly-x86_64.efi /tftpboot/snponly-arm64.efi "${TFTP_BOOT_DIR}"
+    copy_ipxe_firmware /tftpboot "${TFTP_BOOT_DIR}"
 fi
 
 # Template and write dnsmasq.conf

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -68,19 +68,7 @@ if [[ "$IPXE_TLS_SETUP" == "true" ]]; then
     mkdir -p "${HTTPS_IPXE_BOOT_DIR}"
     chmod 0777 "${HTTPS_IPXE_BOOT_DIR}"
     render_j2_config "/templates/httpd-ipxe.conf.j2" "${HTTPD_CONF_DIR_D}/ipxe.conf"
-    for fw_file in undionly.kpxe snponly-x86_64.efi snponly-arm64.efi; do
-        if [[ -f "${IPXE_CUSTOM_FIRMWARE_DIR}/${fw_file}" ]]; then
-            cp "${IPXE_CUSTOM_FIRMWARE_DIR}/${fw_file}" "${HTTPS_IPXE_BOOT_DIR}"
-        else
-            echo "INFO: ${IPXE_CUSTOM_FIRMWARE_DIR}/${fw_file} is unavailable, skipping."
-        fi
-    done
-
-    # Validate that at least one legacy bios and one efi iPXE binary was successfully copied
-    if ! ls "${HTTPS_IPXE_BOOT_DIR}/"*.{kpxe,efi} &>/dev/null; then
-        echo "ERROR: No iPXE firmware files found in ${HTTPS_IPXE_BOOT_DIR} after copying from ${IPXE_CUSTOM_FIRMWARE_DIR}!"
-        exit 1
-    fi
+    copy_ipxe_firmware "${IPXE_CUSTOM_FIRMWARE_DIR}" "${HTTPS_IPXE_BOOT_DIR}"
 fi
 
 # Set up inotify to kill the container (restart) whenever cert files for ironic api change


### PR DESCRIPTION
## What this PR does

`rundnsmasq` and `runhttpd` copy the iPXE firmware using the upstream-built
filenames (`undionly.kpxe`, `snponly-x86_64.efi`, `snponly-arm64.efi`). Two issues:

1. The `rundnsmasq` **else-branch** (built-in `/tftpboot`) used an unconditional
   `cp a b c` that aborts on the *first* missing file — unlike the custom-firmware
   branch directly above it, which already skips missing files and validates.
2. Neither path knows about distro-packaged iPXE names. Rebuilds that install iPXE
   from a distro package — e.g. openSUSE/SLE, whose `ipxe` package ships
   `snp-x86_64.efi` / `snp-arm64.efi` — crash the `ironic-dnsmasq` container on start:
   ```
   cp: cannot stat '/tftpboot/snponly-x86_64.efi': No such file or directory
   ```

This factors the copy into a shared `copy_ipxe_firmware()` helper in
`ironic-common.sh` that (a) skips absent files gracefully on both paths and
(b) falls back to the distro `snp-<arch>.efi` name, copying it to the expected
`snponly-<arch>.efi` so the dnsmasq/httpd templates still resolve it. `rundnsmasq`
and `runhttpd` both call it, so the custom-firmware-dir and built-in `/tftpboot`
paths share one implementation + validation. **No change for the standard image**
(when `snponly-*.efi` are present they are copied as-is).

## Why

Hit on the SUSE Edge ironic image (`registry.suse.com/edge/3.6/ironic`), which
rebuilds this project on SLE with the distro `ipxe` package — downstream report:
suse-edge/charts#255. The change also makes the `else`-branch consistent with the
already-hardened custom-firmware branch.

## Testing

- `shellcheck` clean on the three scripts.
- Unit-tested the helper: a source dir with `undionly.kpxe` + `snp-{x86_64,arm64}.efi`
  (no `snponly-*`) yields `snponly-{x86_64,arm64}.efi` + `undionly.kpxe` in the dest;
  the upstream case (`snponly-*` present) copies as-is.
- Verified end-to-end on real hardware: with firmware under the expected names a
  bare-metal node completed DHCP → TFTP (`snponly-x86_64.efi`) → iPXE → IPA download
  and Ironic inspection.