### PR TITLE
:bug: Fix dnsmasq data dir path and make it configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ ARG PKGS_LIST=main-packages-list.txt
 ARG ARCH_PKGS_LIST=main-packages-list-${TARGETARCH}.txt
 ARG EXTRA_PKGS_LIST
 ARG PATCH_LIST
+ARG DNSMASQ_DATA_DIR=/data/dnsmasq
 
 COPY ${PKGS_LIST} ${ARCH_PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} ${PATCH_LIST:-$PKGS_LIST} /tmp/
 COPY ironic-config/ /tmp/ironic-config/

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ functionality:
   always agree. Defaults to `snponly` (the upstream-built name). Distros that
   package iPXE under a different name (e.g. openSUSE/SLE ship `snp-<arch>.efi`)
   can set `SNP_BASENAME=snp`.
+- `DNSMASQ_DATA_DIR` - directory for dnsmasq runtime data such as lease files
+  (default `/data/dnsmasq`).
+  Also available as a Dockerfile build argument.
 
 ### Multi-Architecture IPA Support
 
@@ -352,6 +355,11 @@ It is also possible to specify an upper-constraints file using the
 file found in the container context; the content of the file can be modified
 keeping the default name or it's possible to specify an entire different
 filename as far as it's in the container context.
+
+The dnsmasq data directory can be changed at build time using
+**DNSMASQ_DATA_DIR** (default `/data/dnsmasq`).
+This is useful for non-root setups with a read-write filesystem where the
+default path may not be a mounted volume.
 
 ## Apply project patches to the images during build
 

--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -15,6 +15,9 @@ set -eux
 IRONIC_USER="ironic"
 IRONIC_GROUP="ironic"
 
+# Default must match the runtime value in scripts/ironic-common.sh
+DNSMASQ_DATA_DIR="${DNSMASQ_DATA_DIR:-/data/dnsmasq}"
+
 # most containers mount /shared but dnsmasq can live without it
 mkdir -p /shared
 chown "${IRONIC_USER}":"${IRONIC_GROUP}" /shared
@@ -38,10 +41,11 @@ chmod 2775 /var/lib/ironic
 chmod 664 /var/lib/ironic/ironic.sqlite
 
 # dnsmasq, and the capabilities required to run it as non-root user
-chown -R root:"${IRONIC_GROUP}" /etc/dnsmasq.conf /var/lib/dnsmasq
-chmod 2775 /var/lib/dnsmasq
-touch /var/lib/dnsmasq/dnsmasq.leases
-chmod 664 /etc/dnsmasq.conf /var/lib/dnsmasq/dnsmasq.leases
+chown root:"${IRONIC_GROUP}" /etc/dnsmasq.conf
+chmod 664 /etc/dnsmasq.conf
+mkdir -p "${DNSMASQ_DATA_DIR}"
+chown -R root:"${IRONIC_GROUP}" "${DNSMASQ_DATA_DIR}"
+chmod 2775 "${DNSMASQ_DATA_DIR}"
 
 # probes that are created before start
 touch /bin/ironic-{readi,live}ness

--- a/ironic-config/dnsmasq.conf.j2
+++ b/ironic-config/dnsmasq.conf.j2
@@ -3,7 +3,7 @@ bind-dynamic
 enable-tftp
 tftp-root=/shared/tftpboot
 log-queries
-dhcp-leasefile=/data/dnsmasq/dnsmasq.leases
+dhcp-leasefile={{ env.DNSMASQ_DATA_DIR }}/dnsmasq.leases
 
 # Configure listening for DNS (0 disables DNS)
 port={{ env.DNS_PORT }}

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -22,6 +22,7 @@ fi
 
 mkdir -p "${TFTP_BOOT_DIR}"
 mkdir -p /shared/html
+touch "${DNSMASQ_DATA_DIR}/dnsmasq.leases"
 
 # Copy files to shared mount. Prefer a user-provided custom firmware dir,
 # otherwise fall back to the image's built-in /tftpboot.


### PR DESCRIPTION
The dnsmasq lease file was prepared at /var/lib/dnsmasq/ during build
but referenced at /data/dnsmasq/ at runtime via dnsmasq.conf.j2. Fix
the mismatch by using the DNSMASQ_DATA_DIR variable in the template
and creating the lease file at runtime in rundnsmasq.

Make DNSMASQ_DATA_DIR configurable via a Dockerfile build arg so that
configure-nonroot.sh no longer hardcodes the path. Document the new
variable in README.md.

