### PR TITLE
:bug: Use IRONIC_ACCESS_PORT instead of hardcoded 6385 in ironic-probe.sh

### DIFF
--- a/scripts/ironic-probe.sh
+++ b/scripts/ironic-probe.sh
@@ -10,7 +10,7 @@ set -eu -o pipefail
 PROBE_CURL_ARGS=
 if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "true" ]]; then
     if [[ "${IRONIC_PRIVATE_PORT}" == "unix" ]]; then
-        PROBE_URL="http://127.0.0.1:6385"
+        PROBE_URL="http://127.0.0.1:${IRONIC_ACCESS_PORT}"
         PROBE_CURL_ARGS="--unix-socket /shared/ironic.sock"
     else
         PROBE_URL="http://127.0.0.1:${IRONIC_PRIVATE_PORT}"


### PR DESCRIPTION
The probe URL for Unix socket mode had port 6385 hardcoded, ignoring any override via IRONIC_ACCESS_PORT. Use the variable, which is already sourced from ironic-common.sh and defaults to 6385.

