### PR TITLE
✨  httpd logLevel from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ functionality:
    element to inject the key.
 - `IRONIC_KERNEL_PARAMS` - This parameter can be used to add additional kernel
    parameters to nodes running IPA
+- `IRONIC_HTTPD_LOGLEVEL` - This parameter can be used to change the LogLevel
+   parameter of the api's httpd container (default `debug`)
 - `GATEWAY_IP` - gateway IP address to use for ironic dnsmasq(dhcpd)
 - `DNS_IP` - DNS IP address to use for ironic dnsmasq(dhcpd)
 - `IRONIC_IPA_COLLECTORS` - Use a custom set of collectors to be run on

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -44,7 +44,11 @@ Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
     SetEnv APACHE_RUN_GROUP ironic
 
     ErrorLog /dev/stderr
+    {% if env.IRONIC_HTTPD_LOGLEVEL is defined %}
+    LogLevel {{ env.IRONIC_HTTPD_LOGLEVEL }}
+    {% else %}
     LogLevel debug
+    {% endif %}
     CustomLog /dev/stdout combined
 
 {% if env.IRONIC_TLS_SETUP == "true" %}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**Set the logLevel of the httpd container's ironic-api's virtualhost's configuration from IRONIC_HTTPD_LOGLEVEL environment variable**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes # -

**Checklist:**

- [- ] Documentation has been updated, if necessary.
- [ -] Integration tests have been added, if necessary.
