### PR TITLE
Allow to fallback to http OCI registries in ironic ; added secure_cdn_registries parameter

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -274,8 +274,14 @@ key_file = {{ env.IRONIC_KEY_FILE }}
 {% endif %}
 
 [oci]
+{% if env.IRONIC_OCI_SECURE_CDN_REGISTRIES is defined %}
+secure_cdn_registries = {{ env.IRONIC_OCI_SECURE_CDN_REGISTRIES }}
+{% endif %}
 {% if env.IRONIC_OCI_AUTH_CONFIG is defined %}
 authentication_config = {{ env.IRONIC_OCI_AUTH_CONFIG }}
+{% endif %}
+{% if env.IRONIC_OCI_HTTP_FALLBACK is defined %}
+permit_fallback_to_http_transport = {{ env.IRONIC_OCI_HTTP_FALLBACK }}
 {% endif %}
 
 {% if env.IRONIC_NETWORKING_ENABLED | lower == "true" %}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Support for additional OCI parameters.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
