### PR TITLE
:seedling: Reduce code duplication in entry point scripts

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -39,9 +39,6 @@ fi
 export NUMWORKERS=${NUMWORKERS:-0}
 
 
-# Whether to enable fast_track provisioning or not
-export IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
-
 # Whether cleaning disks before and after deployment
 export IRONIC_AUTOMATED_CLEAN=${IRONIC_AUTOMATED_CLEAN:-true}
 

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -41,6 +41,8 @@ export IRONIC_USE_MARIADB="${IRONIC_USE_MARIADB:-false}"
 # Allow override in ironic-networking use cases
 export IRONIC_FORCE_DHCP="${IRONIC_FORCE_DHCP:-false}"
 
+export IRONIC_FAST_TRACK="${IRONIC_FAST_TRACK:-true}"
+
 get_provisioning_interface()
 {
     if [[ -n "$PROVISIONING_INTERFACE" ]]; then

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -43,9 +43,7 @@ else
 fi
 
 # Template and write dnsmasq.conf
-# we template via /tmp as sed otherwise creates temp files in /etc directory
-# where we can't write
-python3.12 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' <"/templates/dnsmasq.conf.j2" >"${DNSMASQ_TEMP_DIR}/dnsmasq_temp.conf"
+render_j2_config "/templates/dnsmasq.conf.j2" "${DNSMASQ_TEMP_DIR}/dnsmasq_temp.conf"
 
 for iface in $(echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
     sed -i -e "/^interface=.*/ a\except-interface=${iface}" "${DNSMASQ_TEMP_DIR}/dnsmasq_temp.conf"

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -13,9 +13,6 @@ export IRONIC_REVERSE_PROXY_SETUP=${IRONIC_REVERSE_PROXY_SETUP:-false}
 # called user images.
 export HTTPD_SERVE_NODE_IMAGES="${HTTPD_SERVE_NODE_IMAGES:-true}"
 
-# Whether to enable fast_track provisioning or not
-IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
-
 # Whether to activate the EnableSendfile apache directive for httpd
 HTTPD_ENABLE_SENDFILE="${HTTPD_ENABLE_SENDFILE:-false}"
 


### PR DESCRIPTION
Replace the inline python3.12 Jinja2 render in rundnsmasq with the render_j2_config function already defined in ironic-common.sh.

Move the IRONIC_FAST_TRACK default to ironic-common.sh instead of duplicating it in both runhttpd and configure-ironic.sh.

