### PR TITLE
:seedling: Add pipefail and missing local declarations

### DIFF
--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -9,7 +9,7 @@
 # which we provide via "setcap", and "allowPrivilegeEscalation: true" in
 # manifest.
 
-set -eux
+set -euxo pipefail
 
 # user and group are from ironic rpms (uid 997, gid 994)
 IRONIC_USER="ironic"

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -212,6 +212,7 @@ detect_ipa_by_arch()
     fi
 
     # Detect architectures from env vars (DEPLOY_KERNEL_URL_<ARCH>) and files
+    local var_arch file_arch
     declare -A detected_arch
     for var_arch in "${!DEPLOY_KERNEL_URL_@}"; do
         local IPA_ARCH="${var_arch#DEPLOY_KERNEL_URL_}"

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set -eux
+set -euxo pipefail
 
 # shellcheck disable=SC1091
 . /bin/ironic-common.sh


### PR DESCRIPTION
Add pipefail to set -eux in rundnsmasq and configure-nonroot.sh to catch failures in piped commands.

Declare var_arch and file_arch as local in detect_ipa_by_arch to prevent leaking loop variables into the outer scope.
