### PR TITLE
🌱 Require explicit GitHub token for release notes tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,7 @@ endif
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
-	cd hack/tools && $(GO) run release/notes.go $(RELEASE_NOTES_ARGS) > $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md
+	@echo "Generating release notes for $(RELEASE_TAG)..."
+	@cd hack/tools && $(GO) run release/notes.go $(RELEASE_NOTES_ARGS) \
+	--githubToken="$(GITHUB_TOKEN)" > $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md
+	@echo "Release notes generated at $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md"

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,15 @@ ifneq ($(PREVIOUS_RELEASE_TAG),)
 RELEASE_NOTES_ARGS += --previousReleaseTag=$(PREVIOUS_RELEASE_TAG)
 endif
 
+# Provide a GitHub token explicitly to generate release notes, e.g.:
+#   RELEASE_NOTES_TOKEN="$(gh auth token)" make release-notes
+# It is passed to the tool through a scoped environment variable (not a CLI
+# flag) so the secret is not exposed in process arguments or CI logs. This is
+# intentionally separate from the ambient GITHUB_TOKEN so that delegating a
+# credential to this tool is a deliberate choice. If unset, the tool falls back
+# to the GITHUB_TOKEN environment variable (deprecated).
+RELEASE_NOTES_TOKEN ?=
+
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
-	cd hack/tools && $(GO) run release/notes.go $(RELEASE_NOTES_ARGS) > $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md
+	@cd hack/tools && RELEASE_NOTES_TOKEN="$(RELEASE_NOTES_TOKEN)" $(GO) run release/notes.go $(RELEASE_NOTES_ARGS) > $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -130,8 +130,17 @@ Finally, return to the release branch in this repository and update:
 - Create a new branch for the release notes**:
   `git checkout origin/main -b release-notes-x.y.z`
 
-- Generate the release notes: `RELEASE_TAG=vx.y.z make release-notes`
+- Generate the release notes. Prefix the command with `RELEASE_NOTES_TOKEN` so
+  the token is passed via the environment (use a fine-grained token with
+  read-only repository contents access):
+
+  ```sh
+  RELEASE_TAG=vx.y.z RELEASE_NOTES_TOKEN="$(gh auth token)" make release-notes
+  ```
+
    - Replace `vx.y.z` with the new release tag you're creating.
+   - If `RELEASE_NOTES_TOKEN` is omitted, the tool falls back to the
+    `GITHUB_TOKEN` environment variable, which is deprecated.
    - This command generates the release notes here
     `releasenotes/<RELEASE_TAG>.md` .
 

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -65,8 +65,9 @@ var (
 		unknown,
 		superseded,
 	}
-	toTag   = flag.String("releaseTag", "", "The tag or commit to end to.")
-	fromTag = flag.String("previousReleaseTag", "", "The tag to start from. If not set, it is computed automatically.")
+	toTag       = flag.String("releaseTag", "", "The tag or commit to end to.")
+	fromTag     = flag.String("previousReleaseTag", "", "The tag to start from. If not set, it is computed automatically.")
+	githubToken = flag.String("githubToken", "", "The GitHub token for API access. Should have minimal scopes (e.g., public_repo or contents:read).")
 )
 
 func main() {
@@ -329,9 +330,15 @@ func formatMerge(line, prNumber string) string {
 // For minor and pre releases, it returns the main branch's latest commit.
 // For patch releases, it returns the latest commit on the corresponding release branch.
 func getCommitHashFromNewTag(newTag string) (string, error) {
-	token := os.Getenv("GITHUB_TOKEN")
+	token := *githubToken
 	if token == "" {
-		return "", errors.New("GITHUB_TOKEN is required")
+		token = os.Getenv("GITHUB_TOKEN")
+		if token != "" {
+			log.Println("WARNING: Using GITHUB_TOKEN from environment variable. Please use the --github-token flag instead for better security.")
+		}
+	}
+	if token == "" {
+		return "", errors.New("GITHUB_TOKEN is required. Use --github-token or set GITHUB_TOKEN environment variable.")
 	}
 
 	ctx := context.Background()

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -325,13 +325,30 @@ func formatMerge(line, prNumber string) string {
 	return fmt.Sprintf("%s (%s)", line, prNumber)
 }
 
+// resolveGitHubToken returns the token to use for GitHub API access. It reads
+// the token from the RELEASE_NOTES_TOKEN environment variable, which is set
+// explicitly (e.g. via "RELEASE_NOTES_TOKEN=... make release-notes"). The token
+// is intentionally not accepted as a command-line flag so it is not exposed in
+// process arguments or CI logs. For backwards compatibility it falls back to
+// the GITHUB_TOKEN environment variable, which is deprecated.
+func resolveGitHubToken() (string, error) {
+	if token := os.Getenv("RELEASE_NOTES_TOKEN"); token != "" {
+		return token, nil
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		log.Println("WARNING: reading the GitHub token from the GITHUB_TOKEN environment variable is deprecated; set RELEASE_NOTES_TOKEN instead")
+		return token, nil
+	}
+	return "", errors.New("a GitHub token is required: set RELEASE_NOTES_TOKEN")
+}
+
 // getCommitHashFromNewTag returns the latest commit hash for the specified tag.
 // For minor and pre releases, it returns the main branch's latest commit.
 // For patch releases, it returns the latest commit on the corresponding release branch.
 func getCommitHashFromNewTag(newTag string) (string, error) {
-	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
-		return "", errors.New("GITHUB_TOKEN is required")
+	token, err := resolveGitHubToken()
+	if err != nil {
+		return "", err
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Harden release tool by requiring the github token to be passed explicitly via `--githubToken` flag instead of reading from the enviromment.

Improvements:
- Makes toke delegation visible and intentional
- Enables scope enforcement (devs/CI can use minimal-scope tokens)
- Reduces unintended token reuse across tools

The env variable is kept as a fallback with a deprecation warning for backwards compatibility.