### PR TITLE
:sparkles: introduce ironic and ngs version labels and related automation

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -12,8 +12,12 @@ on:
     - 'v*'
 
 jobs:
+  generate-core-component-source-versions:
+    if: github.repository == 'metal3-io/ironic-image'
+    uses: ./.github/workflows/generate-core-component-source-versions.yml
   build_ironic:
     name: Build Ironic container image with default base image
+    needs: generate-core-component-source-versions
     if: github.repository == 'metal3-io/ironic-image'
     permissions:
       contents: read
@@ -22,6 +26,9 @@ jobs:
     with:
       image-name: 'ironic'
       pushImage: true
+      image-build-args: |
+        IRONIC_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ironic-version }}
+        NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
       generate-sbom: true
       sign-image: true
     secrets:
@@ -30,6 +37,7 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   build_ironic_cs10:
     name: Build Ironic container image with CentOS Stream 10
+    needs: generate-core-component-source-versions
     if: github.repository == 'metal3-io/ironic-image'
     permissions:
       contents: read
@@ -38,7 +46,10 @@ jobs:
     with:
       image-name: 'ironic_cs10'
       pushImage: true
-      image-build-args: 'BASE_IMAGE=quay.io/centos/centos:stream10-minimal'
+      image-build-args: |
+        IRONIC_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ironic-version }}
+        NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
+        BASE_IMAGE=quay.io/centos/centos:stream10-minimal
       generate-sbom: true
       sign-image: true
     secrets:

--- a/.github/workflows/generate-core-component-source-versions.yml
+++ b/.github/workflows/generate-core-component-source-versions.yml
@@ -1,0 +1,30 @@
+name: Generate ironic-image core component versions
+
+on:
+  workflow_call:
+    outputs:
+      ironic-version:
+        description: "Ironic source version from git describe"
+        value: ${{ jobs.generate-core-component-source-versions.outputs.ironic-version }}
+      ngs-version:
+        description: "Networking-generic-switch source version from git describe"
+        value: ${{ jobs.generate-core-component-source-versions.outputs.ngs-version }}
+
+jobs:
+  generate-core-component-source-versions:
+    name: Generate ironic-image core component versions based on git metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ironic-version: ${{ steps.compute.outputs.ironic-version }}
+      ngs-version: ${{ steps.compute.outputs.networking-generic-switch-version }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Generate ironic-image core component versions based on git metadata
+      id: compute
+      run: |
+        ./generate_core_component_source_versions.sh >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ironic-image-build-pr.yml
+++ b/.github/workflows/ironic-image-build-pr.yml
@@ -7,8 +7,14 @@ on:
 permissions: {}
 
 jobs:
+  generate-core-component-source-versions:
+    if: github.repository == 'metal3-io/ironic-image'
+    uses: ./.github/workflows/generate-core-component-source-versions.yml
+    permissions:
+      contents: read
   build:
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm'}}
+    needs: generate-core-component-source-versions
     permissions:
       contents: read
     strategy:
@@ -45,6 +51,8 @@ jobs:
         tags: ironic:${{ matrix.centos_version }}
         platforms: ${{ matrix.platform }}
         build-args: |
+          IRONIC_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ironic-version }}
+          NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
           BASE_IMAGE=${{ steps.base-image.outputs.base_image }}
         cache-from: type=gha,scope=${{ matrix.centos_version }}
         cache-to: type=gha,mode=max,scope=${{ matrix.centos_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+
+# Dev tool work dirs
+versioncheck/

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,12 +99,14 @@ RUN /bin/build-wheels.sh
 FROM $BASE_IMAGE
 
 # Re-declare ARGs for this stage
+ARG IRONIC_VERSION_LABEL=unknown
+ARG NGS_VERSION_LABEL=unknown
 ARG PIP_VERSION
 ARG SETUPTOOLS_VERSION
 ENV PIP_VERSION=${PIP_VERSION} \
     SETUPTOOLS_VERSION=${SETUPTOOLS_VERSION}
 
-# image.version will be set by automation during build
+# image.version and image.revision will be set by automation during build
 LABEL org.opencontainers.image.authors="metal3-dev@googlegroups.com"
 LABEL org.opencontainers.image.description="Container image to run OpenStack Ironic as part of Metal³"
 LABEL org.opencontainers.image.documentation="https://book.metal3.io/ironic/introduction"
@@ -112,6 +114,9 @@ LABEL org.opencontainers.image.licenses="Apache License 2.0"
 LABEL org.opencontainers.image.title="Metal3 Ironic Container"
 LABEL org.opencontainers.image.url="https://github.com/metal3-io/ironic-image"
 LABEL org.opencontainers.image.vendor="Metal3-io"
+# Version of key components installed into the image
+LABEL io.metal3.ironic.version="${IRONIC_VERSION_LABEL}"
+LABEL io.metal3.networking-generic-switch.version="${NGS_VERSION_LABEL}"
 
 ARG TARGETARCH
 

--- a/generate_core_component_source_versions.sh
+++ b/generate_core_component_source_versions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+DEBUG=false
+[[ "${1:-}" == "--debug" ]] && DEBUG=true
+debug() {
+    if [[ "${DEBUG}" == true ]]; then
+        echo "[DEBUG] $*" >&2
+    fi
+}
+
+CURRENT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+VERSION_DIR="${CURRENT_DIR}/versioncheck"
+mkdir -p "${VERSION_DIR}"
+
+for component in 'NGS:networking-generic-switch' 'IRONIC:ironic'; do
+    REPO_NAME="${component#*:}"
+    COMPONENT_MARKER="${component%:*}"
+    debug "REPO NAME:${REPO_NAME} ----- COMPONENT MARKER:${COMPONENT_MARKER}"
+
+    EXPRESSION="^ARG ${COMPONENT_MARKER}_SOURCE=\K[[:xdigit:]]* # .*"
+    COMMIT_LINE="$(grep -oP "${EXPRESSION}" "${CURRENT_DIR}/Dockerfile" )"
+    debug "Found ${COMPONENT_MARKER} source in Dockerfile:${COMMIT_LINE}"
+
+    COMMIT_SHA="${COMMIT_LINE%[[:space:]]#[[:space:]]*}"
+    BRANCH="${COMMIT_LINE#*[[:space:]]#[[:space:]]}"
+    rm -rf "${VERSION_DIR:?}/${REPO_NAME}" || true
+    git clone -q -b "${BRANCH}" --filter=blob:none \
+        "https://opendev.org/openstack/${REPO_NAME}.git" \
+        "${VERSION_DIR}/${REPO_NAME}" &>/dev/null
+    GIT_DESCRIBE="$(git -C "${VERSION_DIR}/${REPO_NAME}" describe --tags "${COMMIT_SHA}")"
+
+    echo "${REPO_NAME}-version=${GIT_DESCRIBE}"
+done
+


### PR DESCRIPTION
This PR:
 - Introduces 2 new OCI labels for the Ironic Dockerfile thus the ironic-image deliverable.
 - Implements support for io.metal3.ironic-version label in ironic-image Dockerfile via the related build argument and implements automation to set the label in the ironic-image build workflows.
 - Implements support for io.metal3.networking-generic-switch-version in the ironic-image Dockerfile and related workflow to generate the value for the label during image building.
 - Reusable script that can be used in a standalone way to generate ironic and ngs version information.

Reasons for this PR:
 - It is hard to determine the ironic version contained in an ironic-image during runtime.
 - Neither in CI nor in production can users easily verify that a specific ironic-image contains the corresponding ironic source code when ironic is installed from source. And by default ironic is installed from source.
 
 This will be followed up with change on the reusable image building workflow in project infra.