### PR TITLE
:sparkles: Add Redfish connect_timeout to ironic.conf template

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ MariaDB configuration:
    Deprecated. Instead, mount a secret with `password` (optionally with a
    `username`) under `/auth/mariadb` mount point.
 
+Redfish BMC connection configuration:
+
+- `REDFISH_CONNECT_TIMEOUT` - TCP connection timeout in seconds for Redfish BMC
+  connections (default `30`).
+  This controls how long Ironic waits for the initial TCP connection to a BMC
+  to be established.
+  A lower value allows faster failure when a BMC is unreachable, while the read
+  timeout (60s by default) is preserved for slow but responsive BMCs.
+  Can also be overridden at runtime via `OS_REDFISH__CONNECT_TIMEOUT`.
+
 The ironic configuration can be overridden by various environment variables.
 The following can serve as an example:
 

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -259,6 +259,7 @@ ipxe_config_template = {{ env.IRONIC_CONF_DIR }}/ipxe_config.template
 [redfish]
 use_swift = false
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure={{ env.IRONIC_IPA_INSECURE | default('1') }} {% if env.ENABLE_FIPS_IPA %}fips={{ env.ENABLE_FIPS_IPA|trim }}{% endif %} {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} systemd.journald.forward_to_console={{ env.IPA_FORWARD_CONSOLE | default('yes') }}
+connect_timeout = {{ env.REDFISH_CONNECT_TIMEOUT | default('30') }}
 {% if env.BMC_TLS_ENABLED == "true" %}
 # idrac uses the same options as the redfish driver
 verify_ca = {{ env.BMC_CACERT_FILE }}


### PR DESCRIPTION
When a BMC is unreachable, sushy waits up to 60 seconds per connection attempt using a single timeout for both TCP connect and HTTP read. This can cause significant delays when managing nodes with invalid or unreachable BMC addresses.

Add a connect_timeout option under [redfish] in the ironic.conf.j2 template, defaulting to 30 seconds. This separates the TCP connection timeout from the read timeout, allowing faster failure for unreachable BMCs while preserving the 60-second read timeout for slow but responsive ones.

The value is configurable via the REDFISH_CONNECT_TIMEOUT environment variable or the OS_REDFISH__CONNECT_TIMEOUT oslo.config override.

