### PR TITLE
:seedling: Harden renovate-validator script

### DIFF
--- a/hack/renovate-validator.sh
+++ b/hack/renovate-validator.sh
@@ -11,6 +11,14 @@ WORKDIR="${WORKDIR:-/workdir}"
 if [ "${IS_CONTAINER}" != "false" ]; then
     npx --yes -p renovate renovate-config-validator
 else
+	# Check if workdir contains :, it would break the volume mount syntax.
+	case "${WORKDIR}" in
+		*:*)
+			echo "FAIL (renovate-validator.sh): WORKDIR variable cannot contain ':', aborting"
+			exit 1
+			;;
+	esac
+
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --volume "${PWD}:${WORKDIR}:ro,z" \


### PR DESCRIPTION
Add check for WORKDIR variable containing a colon. A colon in the variable would break volume mount syntax.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This PR adds a check for WORKDIR variable which is used in volume mount. Theoretically the variable could contain a colon, which would cause the container runtime to consider everything after the colon as options. It can lead to undefined behavior. Forbidding colon from the directory name solves the problem and forces the volume to mount always as read only, because the script adds the read only option to the volume mount.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Integration tests have been added, if necessary.
