### PR TITLE
:warning:  Fail entrypoint waits with a timeout instead of hanging forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ functionality:
    `PROVISIONING_MACS` is provided)
 - `PROVISIONING_IP` - the specific IP to use (instead of calculating it based on
   the `PROVISIONING_INTERFACE`)
+- `IRONIC_IP_WAIT_TIMEOUT` - maximum time in seconds to wait for the
+  provisioning IP or interface to become available before failing the entry
+  point (default `1200`). Set to `0` (or a negative value) to wait
+  indefinitely, restoring the previous behaviour.
+- `IRONIC_IP_WAIT_INTERVAL` - polling interval in seconds while waiting for the
+  provisioning IP or interface (default `1`)
 - `DNSMASQ_EXCEPT_INTERFACE` - interfaces to exclude when providing DHCP address
   (default `lo`)
 - `HTTP_PORT` - port used by http server (default `80`)
@@ -225,6 +231,13 @@ MariaDB configuration:
 - `MARIADB_PASSWORD` - The database password.
    Deprecated. Instead, mount a secret with `password` (optionally with a
    `username`) under `/auth/mariadb` mount point.
+- `IRONIC_DBSYNC_TIMEOUT` - maximum time in seconds to wait for `ironic-dbsync`
+  to succeed (for example while MariaDB is starting up) before failing the
+  entry point (default `600`). Only applies when `IRONIC_USE_MARIADB` is
+  `true`. Set to `0` (or a negative value) to retry indefinitely, restoring the
+  previous behaviour.
+- `IRONIC_DBSYNC_INTERVAL` - interval in seconds between `ironic-dbsync`
+  retries (default `1`)
 
 The ironic configuration can be overridden by various environment variables.
 The following can serve as an example:

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -48,6 +48,32 @@ export IRONIC_FORCE_DHCP="${IRONIC_FORCE_DHCP:-false}"
 
 export IRONIC_FAST_TRACK="${IRONIC_FAST_TRACK:-true}"
 
+# Bounds for the loops that wait on an external condition (a provisioning
+# IP/interface to appear, or MariaDB to accept a dbsync). These used to loop
+# forever, which meant a misconfiguration or a permanently unavailable
+# dependency would hang the entrypoint silently and defeat "set -e". They now
+# give up after a timeout and exit non-zero. Set a timeout to 0 (or negative)
+# to restore the legacy behaviour of waiting forever.
+export IRONIC_IP_WAIT_TIMEOUT="${IRONIC_IP_WAIT_TIMEOUT:-1200}"
+export IRONIC_IP_WAIT_INTERVAL="${IRONIC_IP_WAIT_INTERVAL:-1}"
+export IRONIC_DBSYNC_TIMEOUT="${IRONIC_DBSYNC_TIMEOUT:-600}"
+export IRONIC_DBSYNC_INTERVAL="${IRONIC_DBSYNC_INTERVAL:-1}"
+
+# Exit non-zero once ${deadline} (a snapshot of the bash SECONDS counter taken
+# when the wait started) has been reached. This turns the unbounded
+# "wait for a condition" loops into bounded ones so that "set -e" can
+# act on them. A non-positive ${timeout} disables the check, preserving the
+# legacy behaviour of waiting forever.
+fail_if_timed_out()
+{
+    local deadline="$1" timeout="$2" message="$3"
+
+    if (( timeout > 0 )) && (( SECONDS >= deadline )); then
+        echo "ERROR: timed out after ${timeout}s ${message}" >&2
+        exit 1
+    fi
+}
+
 # Copy iPXE firmware binaries from a source directory into a destination
 # directory. The EFI binary basename is taken from ${SNP_BASENAME} so the served
 # name (dnsmasq.conf.j2) and the on-disk name always agree; downstreams whose
@@ -153,10 +179,13 @@ wait_for_interface_or_ip()
         fi
 
         local IFACE_OF_IP=""
+        local deadline=$(( SECONDS + IRONIC_IP_WAIT_TIMEOUT ))
         until [[ -n "${IFACE_OF_IP}" ]]; do
+            fail_if_timed_out "${deadline}" "${IRONIC_IP_WAIT_TIMEOUT}" \
+                "waiting for ${PROVISIONING_IP} to be configured on an interface"
             echo "Waiting for ${PROVISIONING_IP} to be configured on an interface..."
             IFACE_OF_IP="$(get_interface_of_ip "${PARSED_IP}")"
-            sleep 1
+            sleep "${IRONIC_IP_WAIT_INTERVAL}"
         done
 
         echo "Found ${PROVISIONING_IP} on interface \"${IFACE_OF_IP}\"!"
@@ -164,11 +193,14 @@ wait_for_interface_or_ip()
         export PROVISIONING_INTERFACE="${IFACE_OF_IP}"
         export IRONIC_IP="${PARSED_IP}"
     elif [[ -n "${PROVISIONING_INTERFACE}" ]]; then
+        local deadline=$(( SECONDS + IRONIC_IP_WAIT_TIMEOUT ))
         until [[ -n "$IRONIC_IP" ]]; do
+            fail_if_timed_out "${deadline}" "${IRONIC_IP_WAIT_TIMEOUT}" \
+                "waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
             IRONIC_IP="$(ip -br addr show scope global up dev "${PROVISIONING_INTERFACE}" | awk '{print $3}' | sed -e 's%/.*%%' | head -n 1)"
             export IRONIC_IP
-            sleep 1
+            sleep "${IRONIC_IP_WAIT_INTERVAL}"
         done
     else
         echo "ERROR: cannot determine an interface or an IP for binding and creating URLs"
@@ -209,9 +241,12 @@ run_ironic_dbsync()
     if [[ "${IRONIC_USE_MARIADB}" == "true" ]]; then
         # It's possible for the dbsync to fail if mariadb is not up yet, so
         # retry until success
+        local deadline=$(( SECONDS + IRONIC_DBSYNC_TIMEOUT ))
         until ironic-dbsync --config-file "${IRONIC_CONF_DIR}/ironic.conf" upgrade; do
+            fail_if_timed_out "${deadline}" "${IRONIC_DBSYNC_TIMEOUT}" \
+                "waiting for ironic-dbsync to succeed (is MariaDB reachable?)"
             echo "WARNING: ironic-dbsync failed, retrying"
-            sleep 1
+            sleep "${IRONIC_DBSYNC_INTERVAL}"
         done
     else
         # SQLite does not support some statements. Fortunately, we can just


### PR DESCRIPTION
The wait loops in ironic-common.sh:

- `wait_for_interface_or_ip`
- `run_ironic_dbsync`

looped indefinitely on their conditions, so set -euo pipefail could never act on them and a stuck dependency would hang the entrypoint silently.

Bound each loop with configurable timeout and exit non-zero when it elapses. Setting the timeout to 0 (or negative) restores the previous wait-forever behaviour.

New env vars documented in README.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
