### PR TITLE
:seedling: Add Renovate rule to track ipxe-binaries image digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -110,6 +110,17 @@
       "packageNameTemplate": "https://github.com/openstack/networking-generic-switch.git",
       "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "ARG NGS_SOURCE={{#if newDigest}}{{{newDigest}}}{{else}}{{{newValue}}}{{/if}} # {{{currentValue}}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Dockerfile$/"
+      ],
+      "matchStrings": [
+        "ARG IPXE_BINARIES_IMAGE=(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)[^\\n]*"
+      ],
+      "currentValueTemplate": "latest",
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
This enables automatic digest updates for the IPXE_BINARIES_IMAGE ARG in the Dockerfile when a new image is pushed to quay.io/metal3-io/ipxe-binaries.

