### PR TITLE
🌱 e2e: unpin BMO

### DIFF
--- a/.github/workflows/bmo-e2e.yml
+++ b/.github/workflows/bmo-e2e.yml
@@ -17,8 +17,10 @@ jobs:
       # NOTE(dtantsur): change this on stable branches to make sure the correct
       # logic is used in IrSO.
       IRONIC_CUSTOM_VERSION: latest
-      # Use latest stable BMO release - update this when new releases are available
-      BMO_VERSION: v0.13.2
+      # Use BMO from the main branch to immediately benefit from new tests.
+      # Once branched, consider pinning to the next BMO version. Keep in mind
+      # that BMO pins IrSO, which must be compatible with IRONIC_CUSTOM_VERSION.
+      BMO_VERSION: main
     steps:
     - name: Check docker version
       run: docker --version


### PR DESCRIPTION
Pinning BMO proved to be problematic. Not only do we not benefit from
new tests, but also cannot update IRONIC_CUSTOM_VERSION because BMO
tests pin IrSO to an older version.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
