### PR TITLE
:book: Document why runhttpd does not fall back to built-in iPXE firmware

### DIFF
--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -68,6 +68,9 @@ if [[ "$IPXE_TLS_SETUP" == "true" ]]; then
     mkdir -p "${HTTPS_IPXE_BOOT_DIR}"
     chmod 2775 "${HTTPS_IPXE_BOOT_DIR}"
     render_j2_config "/templates/httpd-ipxe.conf.j2" "${HTTPD_CONF_DIR_D}/ipxe.conf"
+    # No fallback to /tftpboot here: TLS iPXE requires custom firmware with
+    # baked-in certificates and an embedded script pointing to the HTTPS
+    # endpoint. Falling back to generic firmware would silently break TLS boot.
     copy_ipxe_firmware "${IPXE_CUSTOM_FIRMWARE_DIR}" "${HTTPS_IPXE_BOOT_DIR}"
 fi
 


### PR DESCRIPTION
Unlike rundnsmasq, the TLS iPXE setup in runhttpd intentionally
requires custom firmware via IPXE_CUSTOM_FIRMWARE_DIR. TLS boot
needs certificates and an HTTPS boot script baked into the
firmware; falling back to the generic /tftpboot binaries would
silently serve non-TLS-capable firmware.

