### PR TITLE
:bug: Fix minor startup bugs in ironic-common.sh and httpd template

### DIFF
--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -44,8 +44,8 @@ Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
     SetEnv APACHE_RUN_GROUP ironic
 
     ErrorLog /dev/stderr
-    {% if env.IRONIC_HTTPD_LOGLEVEL is defined %}
-    LogLevel {{ env.IRONIC_HTTPD_LOGLEVEL }}
+    {% if env.IRONIC_HTTPD_LOGLEVEL is defined and env.IRONIC_HTTPD_LOGLEVEL | trim %}
+    LogLevel {{ env.IRONIC_HTTPD_LOGLEVEL | trim }}
     {% else %}
     LogLevel debug
     {% endif %}

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -91,8 +91,9 @@ copy_ipxe_firmware()
         fi
     done
 
-    # Validate that at least one legacy bios and one efi iPXE binary was successfully copied
-    if ! ls "${dst_dir}/"*.{kpxe,efi} &>/dev/null; then
+    # Validate that at least one usable iPXE binary was successfully copied
+    if ! ls "${dst_dir}/"*.kpxe &>/dev/null && \
+       ! ls "${dst_dir}/"*.efi &>/dev/null; then
         echo "ERROR: No iPXE firmware files found in ${dst_dir} after copying from ${src_dir}!"
         exit 1
     fi
@@ -162,7 +163,7 @@ wait_for_interface_or_ip()
         local PARSED_IP
         PARSED_IP="$(parse_ip_address "${IRONIC_IP}")"
         if [[ -z "${PARSED_IP}" ]]; then
-            echo "ERROR: PROVISIONING_IP contains an invalid IP address, failed to start ironic"
+            echo "ERROR: IRONIC_IP contains an invalid IP address, failed to start ironic"
             exit 1
         fi
 


### PR DESCRIPTION
- Fix error message in wait_for_interface_or_ip referencing PROVISIONING_IP instead of IRONIC_IP in the IRONIC_IP branch.
- Fix iPXE firmware validation using brace expansion that false-fails when only one firmware type (.kpxe or .efi) is present; test each glob independently so a valid partial set is accepted.
- Guard IRONIC_HTTPD_LOGLEVEL against exported empty values that would render a bare LogLevel directive and prevent Apache from starting.
