### PR TITLE
🌱 Add spec.images instead of patching spec.images/ironic

### DIFF
--- a/hack/prepare-bmo-tests.sh
+++ b/hack/prepare-bmo-tests.sh
@@ -33,9 +33,10 @@ patches:
 - target:
     kind: Ironic
   patch: |-
-    - op: replace
-      path: /spec/images/ironic
-      value: '${IRONIC_CUSTOM_IMAGE}'
+    - op: add
+      path: /spec/images
+      value:
+        ironic: '${IRONIC_CUSTOM_IMAGE}'
     - op: replace
       path: /spec/version
       value: '${IRONIC_CUSTOM_VERSION}'


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: BMO removed spec.images from its e2e Ironic overlay, so the old path no longer exists.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes https://github.com/metal3-io/ironic-image/issues/1135

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
