### PR TITLE
✨ Add no-inspect and idrac-redfish to inspect interfaces

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -21,7 +21,7 @@ enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
 enabled_hardware_types = ipmi,idrac,fake-hardware,redfish,manual-management
-enabled_inspect_interfaces = agent,fake,redfish
+enabled_inspect_interfaces = no-inspect,agent,fake,redfish
 enabled_management_interfaces = ipmitool,fake,redfish,idrac-redfish,noop
 {%- if env.IRONIC_NETWORKING_ENABLED | lower == "true" %}
 enabled_network_interfaces = ironic-networking,noop

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -21,7 +21,7 @@ enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
 enabled_hardware_types = ipmi,idrac,fake-hardware,redfish,manual-management
-enabled_inspect_interfaces = no-inspect,agent,fake,redfish
+enabled_inspect_interfaces = no-inspect,agent,fake,redfish,idrac-redfish
 enabled_management_interfaces = ipmitool,fake,redfish,idrac-redfish,noop
 {%- if env.IRONIC_NETWORKING_ENABLED | lower == "true" %}
 enabled_network_interfaces = ironic-networking,noop


### PR DESCRIPTION
The no-inspect interface makes it clear that the node does not support inspection.
It will be eventually used for hosts that have inspection disabled to
avoid the hidden dependency on agent inspection.

The idrac-redfish interface is an enhanced version of redfish for Dell machines.

Required for: metal3-io/baremetal-operator#3283
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
