### PR TITLE
:seedling: Fix image building during merge

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       image-name: 'ironic'
       pushImage: true
-      image-build-args: |
+      image-build-args: >-
         IRONIC_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ironic-version }}
         NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
       generate-sbom: true
@@ -46,7 +46,7 @@ jobs:
     with:
       image-name: 'ironic_cs10'
       pushImage: true
-      image-build-args: |
+      image-build-args: >-
         IRONIC_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ironic-version }}
         NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
         BASE_IMAGE=quay.io/centos/centos:stream10-minimal


### PR DESCRIPTION
This PR:
 - Makes the ironic and "networking generic switch" custom label generation compatible with the container image build workflow triggered during the merging process.
 
 Reason:
 - During review, tests didn't catch the argument handling issue with the
   merge workflow.
 - Argument handling in merge workflow differs from PR workflow.
