### PR TITLE
:seedling: Work around re-usable workflow limitation

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -28,7 +28,7 @@ jobs:
       pushImage: true
       image-build-args: >-
         IRONIC_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ironic-version }}
-        NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
+        --build-arg NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
       generate-sbom: true
       sign-image: true
     secrets:
@@ -48,8 +48,8 @@ jobs:
       pushImage: true
       image-build-args: >-
         IRONIC_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ironic-version }}
-        NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
-        BASE_IMAGE=quay.io/centos/centos:stream10-minimal
+        --build-arg NGS_VERSION_LABEL=${{ needs.generate-core-component-source-versions.outputs.ngs-version }}
+        --build-arg BASE_IMAGE=quay.io/centos/centos:stream10-minimal
       generate-sbom: true
       sign-image: true
     secrets:


### PR DESCRIPTION
This commit:
  - Adds explicit "--build-arg" option for every build argument after the first in the merge build workflow.

Reason:
 - The workflow inherited from metal3-io/project-infra "re-defines" the build-args parameter of the original mr-smithers-excellent/docker-build-push from list to string. Because of the "type conversion" the original action only appends one "--build-args" not one per key=value pair as it supposed to.
 - Given the situation, this seems to be the fix with the lowest footprint.
