### PR TITLE
🐛 Bracket IPv6 IRONIC_EXTERNAL_IP when composing external URLs

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -54,11 +54,23 @@ wait_for_interface_or_ip
 export IRONIC_CONDUCTOR_HOST=${IRONIC_CONDUCTOR_HOST:-${IRONIC_URL_HOST}}
 
 if [[ -n "$IRONIC_EXTERNAL_IP" ]]; then
-    export IRONIC_EXTERNAL_CALLBACK_URL=${IRONIC_EXTERNAL_CALLBACK_URL:-"${IRONIC_SCHEME}://${IRONIC_EXTERNAL_IP}:${IRONIC_ACCESS_PORT}"}
-    if [[ "$IRONIC_VMEDIA_TLS_SETUP" == "true" ]]; then
-        export IRONIC_EXTERNAL_HTTP_URL=${IRONIC_EXTERNAL_HTTP_URL:-"https://${IRONIC_EXTERNAL_IP}:${VMEDIA_TLS_PORT}"}
+    # An IPv6 literal has to be bracketed before a port is appended, the same
+    # way IRONIC_URL_HOST is built in ironic-common.sh. Without it the URL is
+    # composed as http://2001:db8::139:6385, where host and port are
+    # ambiguous, and Ironic refuses to start while validating
+    # external_callback_url with "host was required but missing".
+    # An already bracketed value is left alone so it is not double wrapped.
+    if [[ "$IRONIC_EXTERNAL_IP" =~ .*:.* ]] && [[ "$IRONIC_EXTERNAL_IP" != \[*\] ]]; then
+        IRONIC_EXTERNAL_URL_HOST="[$IRONIC_EXTERNAL_IP]"
     else
-        export IRONIC_EXTERNAL_HTTP_URL=${IRONIC_EXTERNAL_HTTP_URL:-"http://${IRONIC_EXTERNAL_IP}:${HTTP_PORT}"}
+        IRONIC_EXTERNAL_URL_HOST="$IRONIC_EXTERNAL_IP"
+    fi
+
+    export IRONIC_EXTERNAL_CALLBACK_URL=${IRONIC_EXTERNAL_CALLBACK_URL:-"${IRONIC_SCHEME}://${IRONIC_EXTERNAL_URL_HOST}:${IRONIC_ACCESS_PORT}"}
+    if [[ "$IRONIC_VMEDIA_TLS_SETUP" == "true" ]]; then
+        export IRONIC_EXTERNAL_HTTP_URL=${IRONIC_EXTERNAL_HTTP_URL:-"https://${IRONIC_EXTERNAL_URL_HOST}:${VMEDIA_TLS_PORT}"}
+    else
+        export IRONIC_EXTERNAL_HTTP_URL=${IRONIC_EXTERNAL_HTTP_URL:-"http://${IRONIC_EXTERNAL_URL_HOST}:${HTTP_PORT}"}
     fi
 fi
 


### PR DESCRIPTION
## What this fixes

`IRONIC_EXTERNAL_IP` was concatenated straight onto the port when composing the
external URLs, so an IPv6 address produced `http://2001:db8::139:6385`. That is
ambiguous, and Ironic refuses to start while validating it:

```
CRITICAL ironic Unhandled error: oslo_config.cfg.ConfigFileValueError: Value for
option external_callback_url ... is not valid: ('host was required but missing',
URIReference(scheme='http', authority='2001:db8::139:6385', ...), ['host'])
```

The address needs bracketing first. `ironic-common.sh` already does exactly this
when it builds `IRONIC_URL_HOST`, so this follows the same pattern rather than
introducing a new one.

## Behaviour

| `IRONIC_EXTERNAL_IP` | callback URL | http URL (TLS off) |
|---|---|---|
| `192.168.0.10` | `http://192.168.0.10:6385` | `http://192.168.0.10:6180` |
| `2001:db8::139` | `http://[2001:db8::139]:6385` | `http://[2001:db8::139]:6180` |
| `[2001:db8::139]` | `http://[2001:db8::139]:6385` | `http://[2001:db8::139]:6180` |

IPv4 output is unchanged, and an already bracketed value is passed through so it
is not wrapped twice. Only the auto-composed defaults are affected — setting
`IRONIC_EXTERNAL_CALLBACK_URL` or `IRONIC_EXTERNAL_HTTP_URL` explicitly still
overrides them, which is the workaround people use today.

Bracketing has to happen here rather than upstream: IrSO forwards only the bare
IP as `IRONIC_EXTERNAL_IP`, and its webhook rejects a bracketed value.

## Testing

- `./hack/shellcheck.sh` clean.
- Replayed the block against IPv4, IPv6, already-bracketed and link-local input
  and confirmed the composed URLs match the table above.
- Confirmed the old form is what breaks parsing and the new one is not:
  `urlparse("http://2001:db8::139:6385")` raises
  `Port could not be cast to integer value as 'db8::1'`, while
  `urlparse("http://[2001:db8::139]:6385")` gives host `2001:db8::139`, port `6385`.

Fixes #1058