### PR TITLE
:warning: [release-38.0] update CI workflows and bump ironic hash

### DIFF
--- a/.github/workflows/bmo-e2e.yml
+++ b/.github/workflows/bmo-e2e.yml
@@ -16,7 +16,7 @@ jobs:
       IRONIC_CUSTOM_IMAGE: localhost/ironic:bmo-e2e
       # NOTE(dtantsur): change this on stable branches to make sure the correct
       # logic is used in IrSO.
-      IRONIC_CUSTOM_VERSION: latest
+      IRONIC_CUSTOM_VERSION: "38.0"
       # Use BMO from the main branch to immediately benefit from new tests.
       # Once branched, consider pinning to the next BMO version. Keep in mind
       # that BMO pins IrSO, which must be compatible with IRONIC_CUSTOM_VERSION.

--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -20,7 +20,7 @@ jobs:
       IRONIC_CUSTOM_IMAGE: localhost/ironic:test
       # NOTE(dtantsur): change this on stable branches to make sure the correct
       # logic is used in IrSO, and also that the tests are skipped properly.
-      IRONIC_CUSTOM_VERSION: latest
+      IRONIC_CUSTOM_VERSION: "38.0"
     steps:
     - name: Check docker version
       run: docker --version
@@ -31,6 +31,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: metal3-io/ironic-standalone-operator
+        ref: release-0.11
         path: ironic-standalone-operator
         persist-credentials: false
     - name: Calculate go version

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN IRONIC_PKG_LIST=/tmp/ironic-deps-list /bin/build-wheels.sh
 FROM python-build-base AS ironic-wheel-builder
 
 ARG UPPER_CONSTRAINTS_FILE=upper-constraints.txt
-ARG IRONIC_SOURCE=13d751e94e5e3ab9da7e69464db45fae0269a3f1 # bugfix/38.0
+ARG IRONIC_SOURCE=438596c876d3fbf5e89340e88b3b1835a0a07e0d # bugfix/38.0
 ARG SUSHY_SOURCE
 ARG NGS_SOURCE=dd883aacfc0bfe2d56666b9f0b548fa7557a0870 # master
 ARG INSTALL_NGS=true


### PR DESCRIPTION
We need to bump the ironic hash to include latest fix for
fast inspection.