### PR TITLE
🌱 Sync checkout action to v7

### DIFF
--- a/.github/workflows/bmo-e2e.yml
+++ b/.github/workflows/bmo-e2e.yml
@@ -26,13 +26,13 @@ jobs:
       run: docker --version
 
     - name: Checkout ironic-image
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         path: ironic-image
         persist-credentials: false
 
     - name: Checkout BMO at release version
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: metal3-io/baremetal-operator
         ref: ${{ env.BMO_VERSION }}

--- a/.github/workflows/generate-core-component-source-versions.yml
+++ b/.github/workflows/generate-core-component-source-versions.yml
@@ -21,7 +21,7 @@ jobs:
       ngs-version: ${{ steps.compute.outputs.networking-generic-switch-version }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Generate ironic-image core component versions based on git metadata

--- a/.github/workflows/ironic-image-build-pr.yml
+++ b/.github/workflows/ironic-image-build-pr.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Docker Buildx

--- a/.github/workflows/irso-functional.yml
+++ b/.github/workflows/irso-functional.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
     - name: Check docker version
       run: docker --version
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         path: ironic-image
         persist-credentials: false
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: metal3-io/ironic-standalone-operator
         path: ironic-standalone-operator

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'metal3-io/ironic-image'
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Get changed files
@@ -93,7 +93,7 @@ jobs:
       env:
         RELEASE_TAG: ${{needs.push_release_tags.outputs.release_tag}}
     - name: checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         ref: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.12"]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/validate-security-insights.yml
+++ b/.github/workflows/validate-security-insights.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     # Upload SARIF to Security tab on push to main

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -7,3 +7,8 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+
+  # persist-credentials needed later in the workflow
+  artipacked:
+    ignore:
+    - release.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Sync all checkout versions to the same and bump to major v7.
Also use zizmor config file to get rid of inline ignore comment. This was confusing dependabot.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
