### PR TITLE
🐛 Add signal handling to runlogwatch.sh for graceful shutdown

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -24,10 +24,18 @@ process_log_file() {
 # Export the function so watchmedo can use it
 export -f process_log_file
 
-# Use watchmedo to monitor for file close events
+# Use watchmedo to monitor for file close events.
+# NOTE: watchmedo (Python) never installs its own SIGTERM handler.
+# Instead, keep this script (bash) as PID 1, run watchmedo as a child,
+# and explicitly forward SIGTERM/SIGINT to it so the container stops
+# promptly.
+trap 'kill -TERM "${child_pid}" 2>/dev/null' TERM INT
+
 # shellcheck disable=SC2016
 watchmedo shell-command \
     --patterns="*" \
     --ignore-directories \
     --command='if [[ "${watch_event_type}" == "closed" ]]; then process_log_file "${watch_src_path}"; fi' \
-    "${LOG_DIR}"
+    "${LOG_DIR}" &
+child_pid=$!
+wait "${child_pid}"


### PR DESCRIPTION
**What this PR does / why we need it**:

watchmedo (Python) doesn't install its own SIGTERM handler, so we keep the bash script as PID 1, run watchmedo as a child process, and explicitly forward SIGTERM/SIGINT signals to it for prompt container termination.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #1163

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.

We could consider this as a feature (:sparkles:) also.