### PR TITLE
✨ Add TLS and IPv6 iPXE build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 ARG BASE_IMAGE=quay.io/centos/centos:stream9-minimal
-ARG IPXE_BINARIES_IMAGE=quay.io/metal3-io/ipxe-binaries@sha256:fec222a615ab03227a598ec9392c174af300762911896ecf1da9a5615f194032 # iPXE commit d0ea2b1bb8f78b219f74424d435b92ff8aa0ea8d
+ARG IPXE_BINARIES_IMAGE=quay.io/metal3-io/ipxe-binaries@sha256:155a410dbafc9537fe75c42f55c93843dfc6bba9e4f0676ac05f872f8a9e674d # iPXE commit d0ea2b1bb8f78b219f74424d435b92ff8aa0ea8d
+# iPXE binary source: "prebuilt" (default, uses the pinned IPXE_BINARIES_IMAGE)
+# or "source" (builds iPXE in-image using build-ipxe.sh with the options below).
+ARG IPXE_SOURCE=prebuilt
+# Only used when IPXE_SOURCE=source:
+ARG IPXE_COMMIT_HASH=d0ea2b1bb8f78b219f74424d435b92ff8aa0ea8d
+ARG IPXE_ENABLE_IPV6=false
+ARG IPXE_ENABLE_TLS=false
+ARG IPXE_CERT_FILE=/certs/ipxe/tls.crt
+ARG IPXE_KEY_FILE=/certs/ipxe/tls.key
+
 
 # Python tooling versions - update these regularly
 ARG PIP_VERSION=26.1.2
@@ -21,7 +31,28 @@ printf "[main]\ngpgcheck=1\ninstall_weak_deps=0\ntsflags=nodocs\nkeepcache=1\n" 
 prepare-efi.sh centos
 EORUN
 
-FROM $IPXE_BINARIES_IMAGE AS ipxe-binaries
+FROM $IPXE_BINARIES_IMAGE AS ipxe-prebuilt
+
+FROM $BASE_IMAGE AS ipxe-source
+WORKDIR /tmp
+ARG TARGETARCH
+ARG IPXE_COMMIT_HASH
+ARG IPXE_ENABLE_IPV6
+ARG IPXE_ENABLE_TLS
+ENV TARGETARCH=${TARGETARCH} \
+    IPXE_COMMIT_HASH=${IPXE_COMMIT_HASH} \
+    IPXE_ENABLE_IPV6=${IPXE_ENABLE_IPV6} \
+    IPXE_ENABLE_TLS=${IPXE_ENABLE_TLS}
+COPY prepare-ipxe.sh build-ipxe.sh /bin/
+RUN --mount=type=secret,id=ipxe_cert,target=/certs/ipxe/tls.crt \
+    --mount=type=secret,id=ipxe_key,target=/certs/ipxe/tls.key \
+    prepare-ipxe.sh && build-ipxe.sh && \
+    mkdir -p /ipxe && \
+    cp /tmp/ipxe/out/undionly.kpxe \
+        /tmp/ipxe/out/snponly-x86_64.efi \
+        /tmp/ipxe/out/snponly-arm64.efi /ipxe/
+
+FROM ipxe-${IPXE_SOURCE} AS ipxe-binaries
 
 ## Shared Python build toolchain for wheel builders
 FROM $BASE_IMAGE AS python-build-base

--- a/README.md
+++ b/README.md
@@ -438,3 +438,44 @@ where:
   projects.
 - **git_host** (optional) is the git host from which the project will be cloned.
   If unset, `https://opendev.org` is used.
+
+## Building custom iPXE binaries (TLS and IPv6)
+
+By default the image uses prebuilt iPXE binaries from the pinned
+**IPXE_BINARIES_IMAGE**. To build iPXE from source at image build time, for
+example to enable HTTPS (TLS) downloads or IPv6, set `IPXE_SOURCE=source`
+along with the relevant build arguments:
+
+- **IPXE_SOURCE** - `prebuilt` (default) uses the pinned binaries image;
+  `source` builds iPXE in-image using `build-ipxe.sh`.
+- **IPXE_COMMIT_HASH** - iPXE commit to build when `IPXE_SOURCE=source`
+  (defaults to the same commit as the prebuilt image).
+- **IPXE_ENABLE_IPV6** - build the firmware with IPv6 support (default `false`).
+- **IPXE_ENABLE_TLS** - build the firmware with HTTPS download support
+  (default `false`). Requires a certificate (see below).
+
+When `IPXE_ENABLE_TLS=true`, the certificate and key are supplied as build
+secrets rather than build arguments, so the secret files themselves are not
+copied into the image as standalone layers. Note that iPXE embeds the trust
+anchor into the firmware binary, and if `ipxe_key` is provided for mutual TLS
+the private key is embedded into that binary too, and the built firmware ships
+in the final image. Only provide `ipxe_key` if distributing that key inside the
+image is acceptable.
+
+- `ipxe_cert` (required) - certificate embedded as the TLS trust anchor, so
+  iPXE can validate a server presenting a certificate signed by it.
+- `ipxe_key` (optional) - private key; when present, the certificate is also
+  embedded as a client certificate for mutual TLS.
+
+```bash
+podman build -t ironic-image -f Dockerfile \
+  --build-arg IPXE_SOURCE=source \
+  --build-arg IPXE_ENABLE_TLS=true \
+  --secret id=ipxe_cert,src=./tls.crt \
+  --secret id=ipxe_key,src=./tls.key
+```
+
+**NOTE**: TLS and IPv6 are enabled only for the EFI binaries
+(`snponly-x86_64.efi`, `snponly-arm64.efi`). The legacy BIOS binary
+(`undionly.kpxe`) remains HTTP/IPv4 only, as upstream iPXE disables
+these protocols on BIOS builds.

--- a/build-ipxe.sh
+++ b/build-ipxe.sh
@@ -2,19 +2,46 @@
 
 set -euxo pipefail
 
+IPXE_ENABLE_IPV6="${IPXE_ENABLE_IPV6:-false}"
+IPXE_ENABLE_TLS="${IPXE_ENABLE_TLS:-false}"
+
 git clone https://github.com/ipxe/ipxe.git
 cd ipxe
 mkdir out
 git reset --hard "$IPXE_COMMIT_HASH"
 cd src
 
+# Common make options for every arch build.
+declare -a IPXE_MAKE_OPTS=("NO_WERROR=1")
+
+# IPv6: config/general.h ships NET_PROTO_IPV6 commented out, uncomment it.
+if [[ "${IPXE_ENABLE_IPV6}" == "true" ]]; then
+    sed -i 's|^//#define\s*NET_PROTO_IPV6|#define NET_PROTO_IPV6|' config/general.h
+fi
+
+# TLS: enable HTTPS download proto and embed the cert(s).
+if [[ "${IPXE_ENABLE_TLS}" == "true" ]]; then
+    if [[ ! -r "${IPXE_CERT_FILE}" ]]; then
+        echo "ERROR: TLS enabled but cert missing/unreadable: ${IPXE_CERT_FILE}" >&2
+        exit 1
+    fi
+    # DOWNLOAD_PROTO_HTTPS ships as #undef, turn it on. HTTP left enabled.
+    sed -i 's|^#undef\s*DOWNLOAD_PROTO_HTTPS|#define DOWNLOAD_PROTO_HTTPS|' config/general.h
+    # Trust anchor for server verification.
+    IPXE_MAKE_OPTS+=("TRUST=${IPXE_CERT_FILE}")
+    # If a key is also present, embed a client cert for mutual TLS.
+    if [[ -r "${IPXE_KEY_FILE}" ]]; then
+        IPXE_MAKE_OPTS+=("CERT=${IPXE_CERT_FILE}" "PRIVKEY=${IPXE_KEY_FILE}")
+    fi
+fi
+
 # Build iPXE binaries based on architecture
 if [[ "$TARGETARCH" == "amd64" ]]; then
-    NO_WERROR=1 make bin/undionly.kpxe bin-x86_64-efi/snponly.efi
-    NO_WERROR=1 make CROSS=aarch64-linux-gnu- bin-arm64-efi/snponly.efi
+    make "${IPXE_MAKE_OPTS[@]}" bin/undionly.kpxe bin-x86_64-efi/snponly.efi
+    make "${IPXE_MAKE_OPTS[@]}" CROSS=aarch64-linux-gnu- bin-arm64-efi/snponly.efi
 elif [[ "$TARGETARCH" == "arm64" ]]; then
-    NO_WERROR=1 make bin-arm64-efi/snponly.efi
-    NO_WERROR=1 make CROSS=x86_64-linux-gnu- bin/undionly.kpxe bin-x86_64-efi/snponly.efi
+    make "${IPXE_MAKE_OPTS[@]}" bin-arm64-efi/snponly.efi
+    make "${IPXE_MAKE_OPTS[@]}" CROSS=x86_64-linux-gnu- bin/undionly.kpxe bin-x86_64-efi/snponly.efi
 else
     echo "ERROR: Unsupported build architecture: $TARGETARCH"
     exit 1

--- a/prepare-ipxe.sh
+++ b/prepare-ipxe.sh
@@ -11,7 +11,7 @@ echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
 echo "keepcache=1" >> /etc/dnf/dnf.conf && \
 dnf install -y epel-release && \
 dnf config-manager --set-disabled epel && \
-dnf install -y git-core make perl xz-devel
+dnf install -y git-core make perl xz-devel openssl
 
 # Install appropriate gcc binaries based on build architecture
 if [[ "$TARGETARCH" == "amd64" ]]; then


### PR DESCRIPTION
Adds build support for compiling iPXE with TLS and IPv6 into the ironic-image build.

- `build-ipxe.sh`: edits iPXE's `config/general.h` to enable `DOWNLOAD_PROTO_HTTPS` (TLS) and `NET_PROTO_IPV6` (IPv6), and enables the certificate as a trust anchor (`TRUST=`), plus a client cert for mutual TLS when a key is provided (`CERT=`/`PRIVKEY=`).
- `prepare-ipxe.sh`: installs `openssl`, required for cert embedding.
- `Dockerfile`: new `IPXE_SOURCE` build arg. Default `prebuilt` keeps using the pinned `IPXE_BINARIES:IMAGE`; `source` builds iPXE in-image with `IPXE_ENABLE_IPV6` / `IPXE_ENABLE_TLS`. Cert and key are passed as build secrets so they key is never written to a layer.
- README: documents the new build args and the secret-based cert delivery.

**NOTE**:

- All the new behavior is disable by default and must be explicitly enabled, the default (prebuilt) build is unchanged.
- TLS and IPv6 apply to the EFI binaries (`snponly-*.efi`) only. The legacy BIOS `undionly.kpxe` stays HTTP/IPv4, as upstream iPXE disables these on `pcbios` builds.

**Testing**:

- Default build (`IPXE_SOURCE=prebuilt`): unchanged, ipxe-source stage skipped.
- Source build, and source + iPV6, and course + TLS (self-signed cert via `--secret`): all build successfully.
- Verified the `config/general.h` edits apply at the pinned iPXE commit.
