### PR TITLE
🐛 Fix missing changelogUrl in Renovate PRs for git-refs deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,14 +43,16 @@
       ]
     },
     {
-      "description": "Ensure any digest-pinned, GitHub-sourced, dependencies creates a link to the diff between the two commits",
-      "matchSourceUrls": [
-        "https://github.com/**/*"
-      ],
-      "matchUpdateTypes": [
-        "digest"
-      ],
-      "changelogUrl": "{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}"
+      "description": "Add changelog compare link for openstack-ironic digest updates",
+      "matchDepNames": ["openstack-ironic"],
+      "matchUpdateTypes": ["digest"],
+      "changelogUrl": "https://github.com/openstack/ironic/compare/{{currentDigest}}..{{newDigest}}"
+    },
+    {
+      "description": "Add changelog compare link for networking-generic-switch digest updates",
+      "matchDepNames": ["networking-generic-switch"],
+      "matchUpdateTypes": ["digest"],
+      "changelogUrl": "https://github.com/openstack/networking-generic-switch/compare/{{currentDigest}}..{{newDigest}}"
     },
     {
       "matchDepNames": [


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR, and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: 
Replace the broken generic rule with harcoded rules that match by depName and hardcode the GitHub compare URL. The variables currentDigest and newDigest are used by Renovate to produce a compare link.

This is a inelegant solution but I think it should work. Can only be tested by merging though.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes https://github.com/metal3-io/ironic-image/issues/810

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
