### PR TITLE
✨ Enable IPA pci-devices collector and accelerators inspection hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ functionality:
 - `GATEWAY_IP` - gateway IP address to use for ironic dnsmasq(dhcpd)
 - `DNS_IP` - DNS IP address to use for ironic dnsmasq(dhcpd)
 - `IRONIC_IPA_COLLECTORS` - Use a custom set of collectors to be run on
-   inspection. (default `default,logs`)
+   inspection. (default `default,logs,pci-devices`)
 - `HTTPD_ENABLE_SENDFILE` - Whether to activate the EnableSendfile apache
    directive for httpd `(default, false)`
 - `IRONIC_CONDUCTOR_HOST` - Host name of the current conductor (only makes

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -172,7 +172,7 @@ power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
 # Also keep in mind that only parameters unique for inspection go here.
 # No need to duplicate pxe_append_params/kernel_append_params.
 extra_kernel_params = ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} ipa-enable-vlan-interfaces={{ env.IRONIC_ENABLE_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp={{ env.IRONIC_IPA_COLLECT_LLDP | default('1') }}
-hooks = $default_hooks{% if env.IRONIC_IPA_COLLECT_LLDP | default('1') == '1' %},parse-lldp{% if env.IRONIC_NETWORKING_ENABLED | lower == "true" %},local-link-connection{% endif %}{% endif %}
+hooks = $default_hooks,accelerators{% if env.IRONIC_IPA_COLLECT_LLDP | default('1') == '1' %},parse-lldp{% if env.IRONIC_NETWORKING_ENABLED | lower == "true" %},local-link-connection{% endif %}{% endif %}
 add_ports = all
 keep_ports = present
 force_dhcp = {{ env.IRONIC_FORCE_DHCP }}

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -46,7 +46,7 @@ export IRONIC_AUTOMATED_CLEAN=${IRONIC_AUTOMATED_CLEAN:-true}
 export SEND_SENSOR_DATA=${SEND_SENSOR_DATA:-false}
 
 # Set of collectors that should be used with IPA inspection
-export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
+export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs,pci-devices}
 
 wait_for_interface_or_ip
 

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -19,7 +19,7 @@ export HTTPD_SERVE_NODE_IMAGES="${HTTPD_SERVE_NODE_IMAGES:-true}"
 HTTPD_ENABLE_SENDFILE="${HTTPD_ENABLE_SENDFILE:-false}"
 
 # Set of collectors that should be used with IPA inspection
-export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs}
+export IRONIC_IPA_COLLECTORS=${IRONIC_IPA_COLLECTORS:-default,logs,pci-devices}
 
 wait_for_interface_or_ip
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable the pci-devices collector on the IPA ramdisk and the accelerators processing hook on the inspector side so that discoveredc PCI accelerator devices (example GPUs) are populated into node.properties["accelerators"] during inspection.

This is required for BMO to expose accelerator inventory in hardwareData & BMH. xref: metal3-io/baremetal-operator#3601

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Integration tests have been added, if necessary.
